### PR TITLE
Amend tap's teardown function for pointer events

### DIFF
--- a/src/Ractive/Ractive.eventDefinitions/tap.js
+++ b/src/Ractive/Ractive.eventDefinitions/tap.js
@@ -139,6 +139,8 @@ eventDefinitions.tap = function ( node, fire ) {
 
 	return {
 		teardown: function () {
+			node.removeEventListener( 'pointerdown', mousedown, false );
+			node.removeEventListener( 'MSPointerDown', mousedown, false );
 			node.removeEventListener( 'mousedown', mousedown, false );
 			node.removeEventListener( 'touchstart', touchstart, false );
 		}


### PR DESCRIPTION
I unfortunately forgot that in pull request #136.
