### PR TITLE
Add a 'come' transition to the generic transitions of Ractive (from right to left)

### DIFF
--- a/src/Ractive/Ractive.transitions/generic.js
+++ b/src/Ractive/Ractive.transitions/generic.js
@@ -164,6 +164,10 @@
 		transitions.fly = makeTransition([ 'opacity', 'left', 'position' ], {
 			duration: 400, easing: 'easeOut'
 		}, { position: 'relative', left: '-500px' }, { position: 'relative', left: 0 });
+
+		transitions.come = makeTransition([ 'opacity', 'right', 'position' ], {
+			duration: 400, easing: 'easeOut'
+		}, { position: 'relative', right: '-500px' }, { position: 'relative', right: 0 });
 	}
 
 	


### PR DESCRIPTION
The goal of this pull request is to add a 'come' transition into the generic transitions of Ractive (from right to left, the inverse of 'fly').
I use this transition intensively in my web apps, that's why i propose to include it by default into Ractive.
Hope it won't disturb you.
