### PR TITLE
Uncaught TypeError: Cannot call method 'teardown' of null" JavaScript error

### DIFF
--- a/release/0.3.6/Ractive.js
+++ b/release/0.3.6/Ractive.js
@@ -2009,8 +2009,12 @@ resolveMustache = function ( keypath ) {
 		// remove any fragments that should no longer exist
 		for ( id in fragmentsById ) {
 			if ( value[ id ] === undefined ) {
-				fragmentsById[ id ].teardown( true );
-				fragmentsById[ id ] = null;
+                if(fragmentsById[ id ])
+                {
+                    fragmentsById[ id ].teardown( true );
+                }
+
+                fragmentsById[ id ] = null;
 			}
 		}
 
@@ -6228,8 +6232,11 @@ DomSection.prototype = {
 
 		if ( this.fragmentsById ) {
 			for ( id in this.fragmentsById ) {
-				this.fragmentsById[ id ].teardown();
-				this.fragmentsById[ id ] = null;
+                if(this.fragmentsById[ id ])
+                {
+                    this.fragmentsById[ id ].teardown();
+                    this.fragmentsById[ id ] = null;
+                }
 			}
 		}
 	},


### PR DESCRIPTION
In my app sometimes I get "Uncaught TypeError: Cannot call method 'teardown' of null" JavaScript error.
I'm not sure why is it happening. Probably it tries to teardown some unexisting node?
The above code eliminates the error, I don't know if it fixes the problem. 
I don't know how Ractive internals work but maybe it will help you to figure out what causing the bug. Tell me if you need more info.
Sorry for updating the release file.
