### PR TITLE
Support for XML Namespaces

### DIFF
--- a/release/0.3.6/Ractive.js
+++ b/release/0.3.6/Ractive.js
@@ -8676,7 +8676,7 @@ var getTag;
 		return tag;
 	};
 
-	getTagName = getRegexMatcher( /^[a-zA-Z][a-zA-Z0-9\-]*/ );
+	getTagName = getRegexMatcher( /^[a-zA-Z][a-zA-Z0-9\-:]*/ );
 
 	getAttributes = function ( tokenizer ) {
 		var start, attrs, attr;


### PR DESCRIPTION
I'm using Facebook XFBML namespaced tags in my app (e.g. fb:like) and Ractive fails to parse them.
http://developers.facebook.com/docs/reference/javascript/FB.XFBML.parse/

So I decided to add ':' as a valid match for such tags (it's still not exact validation, e.g. ':' should not be used at the end of the tag, but at least now parser doesn't fails).

http://www.w3.org/TR/REC-xml-names/#NT-NCName
It's not valid for HTML, but probably for XHTML it is.

You need to decide if you want to support namespaced tags in the Ractive parser.
