### PR TITLE
Fix operator precedence in expression AST

### DIFF
--- a/src/parser/getToken/getMustacheOrTriple/getExpression/getExpression.js
+++ b/src/parser/getToken/getMustacheOrTriple/getExpression/getExpression.js
@@ -221,34 +221,43 @@ var getExpression;
 				return null;
 			}
 
-			start = tokenizer.pos;
+			// Loop to handle left-recursion in a case like `a * b * c` and produce
+			// left association, i.e. `(a * b) * c`.  The matcher can't call itself
+			// to parse `left` because that would be infinite regress.
+			while (true) {
+				start = tokenizer.pos;
 
-			allowWhitespace( tokenizer );
+				allowWhitespace( tokenizer );
 
-			if ( !getStringMatch( tokenizer, symbol ) ) {
-				tokenizer.pos = start;
-				return left;
+				if ( !getStringMatch( tokenizer, symbol ) ) {
+					tokenizer.pos = start;
+					return left;
+				}
+
+				// special case - in operator must not be followed by [a-zA-Z_$0-9]
+				if ( symbol === 'in' && /[a-zA-Z_$0-9]/.test( tokenizer.remaining().charAt( 0 ) ) ) {
+					tokenizer.pos = start;
+					return left;
+				}
+
+				allowWhitespace( tokenizer );
+
+				// right operand must also consist of only higher-precedence operators
+				right = fallthrough( tokenizer );
+				if ( !right ) {
+					tokenizer.pos = start;
+					return left;
+				}
+
+				left = {
+					t: INFIX_OPERATOR,
+					s: symbol,
+					o: [ left, right ]
+				};
+
+				// Loop back around.  If we don't see another occurrence of the symbol,
+				// we'll return left.
 			}
-
-			// special case - in operator must not be followed by [a-zA-Z_$0-9]
-			if ( symbol === 'in' && /[a-zA-Z_$0-9]/.test( tokenizer.remaining().charAt( 0 ) ) ) {
-				tokenizer.pos = start;
-				return left;
-			}
-
-			allowWhitespace( tokenizer );
-
-			right = getExpression( tokenizer );
-			if ( !right ) {
-				tokenizer.pos = start;
-				return left;
-			}
-
-			return {
-				t: INFIX_OPERATOR,
-				s: symbol,
-				o: [ left, right ]
-			};
 		};
 	};
 


### PR DESCRIPTION
Expression parsing had subtle bugs that prevented operator precedence rules (a.k.a. order of operations) from working as intended when creating the AST.  As far as I know, this wasn't detectable from using Ractive, since expressions are stringified in a way that assumes the structure of the AST already follows operator precedence and doesn't insert parentheses.  However, the mis-parsing is evident from looking at the result of `getExpression`.

It might be worth reviewing all code sites where the parser invokes the top-level `getExpression` to make sure it doesn't consume too big an expression as it did in these cases.
