### PR TITLE
Fix keypath resolution-originated teardown causing resolution failure

### DIFF
--- a/src/Ractive.prototype/helpers/attemptKeypathResolution.js
+++ b/src/Ractive.prototype/helpers/attemptKeypathResolution.js
@@ -1,20 +1,20 @@
 var attemptKeypathResolution = function ( root ) {
-	var i, unresolved, keypath;
+	var unresolved, keypath, leftover;
+
+	leftover = [];
 
 	// See if we can resolve any of the unresolved keypaths (if such there be)
-	i = root._pendingResolution.length;
-	while ( i-- ) { // Work backwards, so we don't go in circles!
-		unresolved = root._pendingResolution.splice( i, 1 )[0];
-
+	while ( unresolved = root._pendingResolution.splice( 0, 1 )[0] ) {
 		keypath = resolveRef( root, unresolved.ref, unresolved.contextStack );
 		if ( keypath !== undefined ) {
 			// If we've resolved the keypath, we can initialise this item
 			unresolved.resolve( keypath );
 
 		} else {
-			// If we can't resolve the reference, add to the back of
-			// the queue (this is why we're working backwards)
-			root._pendingResolution[ root._pendingResolution.length ] = unresolved;
+			// If we can't resolve the reference, try again next time.
+			leftover.push( unresolved );
 		}
 	}
+
+	Array.prototype.push.apply( root._pendingResolution, leftover );
 };


### PR DESCRIPTION
This fixes the keypath resolution issue, by clearly separating items for next time and items for this time, having the effect of not letting changes to `_pendingResolution` trip us up mid-loop.
