### PR TITLE
Fixing swapped parameters

### DIFF
--- a/src/render/DomFragment/Partial/getPartialDescriptor.js
+++ b/src/render/DomFragment/Partial/getPartialDescriptor.js
@@ -7,8 +7,8 @@ define([
 	'parse/_parse'
 ], function (
 	errors,
-	warn,
 	isClient,
+	warn,
 	isObject,
 	partials,
 	parse


### PR DESCRIPTION
`isClient` and `warn` were swapped resulting in `TypeError: boolean is not a function` errors.
