### PR TITLE
Allow to have _super in complete

### DIFF
--- a/src/extend/_extend.js
+++ b/src/extend/_extend.js
@@ -73,7 +73,7 @@ define([
 	inheritable = [ 'el', 'template', 'complete', 'modifyArrays', 'twoway', 'lazy', 'append', 'preserveWhitespace', 'sanitize', 'noIntro', 'transitionsEnabled' ];
 	
 	blacklist = {};
-	extendable.concat( inheritable ).forEach( function ( prop ) {
+	extendable.forEach( function ( prop ) {
 		blacklist[ prop ] = true;
 	});
 

--- a/src/shared/render.js
+++ b/src/shared/render.js
@@ -23,7 +23,7 @@ define([
 			el.innerHTML = '';
 		}
 
-		ractive._transitionManager = transitionManager = makeTransitionManager( ractive, options.complete );
+		ractive._transitionManager = transitionManager = makeTransitionManager( ractive, ractive.complete || options.complete );
 
 		// Render our *root fragment*
 		ractive.fragment = new DomFragment({


### PR DESCRIPTION
Example:
http://jsfiddle.net/rj7c3/

```
var e = Ractive.extend({
    init: function() {
      console.log('parent init2');  
    },
    complete: function() {
     console.log('parent2');   
    }
})

var ex = e.extend({
    init: function() {
        this._super();
      console.log('parent init');  
    },
    complete: function() {
        this._super();
     console.log('parent');   
    }
})

var ractive = ex.extend({
            el: 'container',
            template: '#myTemplate',
            data: { greeting: 'Hello', recipient: 'world' },
    complete: function() {
        this._super();
     console.log('child');   
    }
        });

a = new ractive();
```

Output:

```
parent2
parent
child
parent init2
parent init 
```

Please review before accepting pull request. It might break other things.
