### PR TITLE
fire a an event called [transition-name]:end when a transition completes

### DIFF
--- a/src/render/DomFragment/Element/shared/executeTransition/Transition.js
+++ b/src/render/DomFragment/Element/shared/executeTransition/Transition.js
@@ -238,6 +238,8 @@ define([
 						// still transitioning...
 						return;
 					}
+					
+					t.root.fire(t.name + ':end');
 
 					t.node.removeEventListener( TRANSITIONEND, transitionEndHandler, false );
 


### PR DESCRIPTION
Inspired by the following gist : https://gist.github.com/Rich-Harris/c5033b380e0c2e4e0749

This should allow users to do stuff like:

```
ractive.on('fly:end', function() {
  console.log('the fly transition has ended');
})
```

Instead of the more generic:

```
ractive = new Ractive({
  ...
  complete: function () {
    alert( 'All initial intro transitions have completed' );
  }
});
```
