### PR TITLE
Resolvable expression can be treated as Reference, solves #319

### DIFF
--- a/src/render/DomFragment/Attribute/bindAttribute.js
+++ b/src/render/DomFragment/Attribute/bindAttribute.js
@@ -112,6 +112,10 @@ define([
 		}
 
 		if ( item.descriptor.x ) {
+			if (item.root.get(item.keypath) !== undefined) {
+				return item;
+			}
+			
 			if ( attribute.root.debug ) {
 				throw new Error( 'You cannot set up two-way binding against an expression' );
 			}

--- a/src/render/shared/ExpressionResolver.js
+++ b/src/render/shared/ExpressionResolver.js
@@ -57,11 +57,23 @@ define([
 			if ( !this.ready ) {
 				return;
 			}
-			
-			this.keypath = getKeypath( this.str, this.args );
-			this.createEvaluator();
+			var self = this;
 
-			this.mustache.resolve( this.keypath );
+			// get string that is unique to this expression
+			var keypath = this.str.replace( /\$\{([0-9]+)\}/g, function ( match, $1 ) {
+				return self.args[ $1 ] ? self.args[ $1 ][1] : 'undefined';
+			});
+			
+			keypath = resolveRef( this.root, keypath, this.mustache.contextStack );
+			if ( keypath ) {
+				this.resolved = false;
+				this.mustache.resolve( keypath );
+			} else {
+				this.keypath = getKeypath(this.str, this.args);
+				
+				this.createEvaluator();
+				this.mustache.resolve(this.keypath);
+			}
 		},
 
 		teardown: function () {


### PR DESCRIPTION
Fix #319 
At render time, it first tries to normalize to a keypath and later at attribute binding checks if the keypath are able in `ractive.get()`
Here is example http://jsfiddle.net/7KfEe/2/ , we can see `items` do get updated when we type in inputfield. Atleast outside the items loop but not inside, so there is still something that is missing, but it works.
