### PR TITLE
For jam, need to have a consistent case strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     }
   ],
   "jam": {
+    "name": "Ractive",
     "main": "Ractive.js",
     "include": [
       "Ractive.js",


### PR DESCRIPTION
With the new plugin structure, jam automatically wires up based on case. This patch will make it consistent in the jam ecosystem. I am doing this to minimize impact in other package managers. I am not sure if you would want to go further and lower case all requirejs references, or uppercase the name of the project. 

I was curious to make sure jam publish could support case, and it seems to be fine with it. I will make you owner so you can publish uppercase Ractive in the future ;)
