### PR TITLE
Using components in Node.js fails due to no DOM

### DIFF
--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -56,6 +56,14 @@ define([
 
 		var key, template, templateEl, parsedTemplate;
 
+		if(options.window && typeof window == 'undefined') {
+			window = options.window;
+		}
+
+		if(options.document && typeof document == 'undefined') {
+			document = options.document;
+		}			
+
 		// Options
 		// -------
 		for ( key in defaultOptions ) {

--- a/wrapper/intro.js
+++ b/wrapper/intro.js
@@ -1,3 +1,6 @@
 (function ( global ) {
 
 'use strict';
+
+var window = window;
+var document = document;


### PR DESCRIPTION
I believe I've found a work-around. I've modified the Ractive init function to accept 'window' and 'document' variables, which it then sets to the scope of the Ractive module (in the cases that document and window are both undefined).

Fixes issues experienced in #448 
