### PR TITLE
Test and fix for .findComponent does not work through {{>content}} (but .findAllComponents does)

### DIFF
--- a/src/render/DomFragment/Component/_Component.js
+++ b/src/render/DomFragment/Component/_Component.js
@@ -56,6 +56,10 @@ define([
 				return this.instance;
 			}
 
+			if ( this.instance.fragment ) {
+				return this.instance.fragment.findComponent( selector );
+			}
+						
 			return null;
 		},
 

--- a/test/modules/components.js
+++ b/test/modules/components.js
@@ -619,6 +619,30 @@ define([ 'Ractive' ], function ( Ractive ) {
 			t.htmlEqual( fixture.innerHTML, 'bar-bar' );
 		});
 
+
+		test( 'findComponent and findAllComponents work through {{>content}}', function ( t ) {
+
+		    Ractive.components.wrapper = Ractive.extend({
+		        template: '<p>{{>content}}</p>'    
+		    });
+		    Ractive.components.component = Ractive.extend({});
+		                                                     
+		    var ractive = new Ractive({
+		        el: fixture,
+		        template: '<component/>'
+		    });
+		    
+		    var r = new Ractive({
+		        template: '<wrapper><component/></wrapper>'
+		    });
+		    
+		    var find = r.findComponent('component'),
+		        findAll = r.findAllComponents('component');
+		    
+		    t.ok( find, 'component found' );
+		    t.equal( findAll.length, 1);
+		});
+
 	};
 
 });


### PR DESCRIPTION
Given `template: '<wrapper><component/></wrapper>'`

```
r.findAllComponents('component')  //works
r.findComponent('component') //returns null
```
