### PR TITLE
Smarter reassignFragment on section changes

### DIFF
--- a/src/render/DomFragment/Section/reassignFragment.js
+++ b/src/render/DomFragment/Section/reassignFragment.js
@@ -19,12 +19,14 @@ define([
 			return;
 		}
 
-		if ( fragment.indexRefs && fragment.indexRefs[ indexRef ] !== undefined ) {
+		// assign new context keypath if needed
+		assignNewKeypath(fragment, 'context', oldKeypath, newKeypath);
+
+		if ( fragment.indexRefs 
+			&& fragment.indexRefs[ indexRef ] !== undefined 
+			&& fragment.indexRefs[ indexRef ] !== newIndex) {
 			fragment.indexRefs[ indexRef ] = newIndex;
 		}
-
-		// fix context stack
-		assignNewKeypath(fragment, 'context', oldKeypath, newKeypath);
 		
 		i = fragment.items.length;
 		while ( i-- ) {
@@ -56,9 +58,7 @@ define([
 	}
 
 	function assignNewKeypath ( target, property, oldKeypath, newKeypath ) {
-
 		if ( !target[property] || target[property] === newKeypath ) { return; }
-		
 		target[property] = getNewKeypath(target[property], oldKeypath, newKeypath);
 	}
 
@@ -92,6 +92,8 @@ define([
 		}
 
 		if ( storage = element.node._ractive ) {
+
+			//adjust keypath if needed
 			assignNewKeypath(storage, 'keypath', oldKeypath, newKeypath);
 
 			if ( indexRef != undefined ) {
@@ -169,7 +171,10 @@ define([
 		// normal keypath mustache?
 		if ( mustache.keypath ) {
 			updated =  getNewKeypath( mustache.keypath, oldKeypath, newKeypath );
+			
+			//was a new keypath created?
 			if(updated){
+				//resolve it
 				mustache.resolve( updated );
 			}
 		}

--- a/src/render/DomFragment/Section/reassignFragments.js
+++ b/src/render/DomFragment/Section/reassignFragments.js
@@ -7,6 +7,13 @@ define([
 	'use strict';
 
 	return function ( section, start, end, by ) {
+
+		//nothing to do if only end of array was modified...
+		//push
+		if( start + by === end ) { return; }
+		//pop
+		if( start === end ) { return; }
+
 		var i, fragment, indexRef, oldIndex, newIndex, oldKeypath, newKeypath;
 
 		indexRef = section.descriptor.i;

--- a/test/tests/index.html
+++ b/test/tests/index.html
@@ -30,7 +30,8 @@
 			'adaptors',
 			'reset',
 			'css',
-			'transitions'
+			'transitions',
+			'reassignFragments'
 		];
 	</script>
 

--- a/test/tests/reassignFragments.html
+++ b/test/tests/reassignFragments.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<title>DomFragment | Ractive Test Suite</title>
+	<title>Reassign Fragments | Ractive Test Suite</title>
 	<link rel='stylesheet' href='../vendor/qunit.css' type='text/css' media='screen' />
 </head>
 <body>
@@ -10,11 +10,10 @@
 
 	<script src='../vendor/qunit.js'></script>
 	<script src='../vendor/qunit-html.js'></script>
-	<script src='../vendor/simulant.js'></script>
 	<script src='../vendor/require.js'></script>
 
 	<script>
-		_modules = [ 'DomFragment' ];
+		_modules = [ 'reassignFragments' ];
 	</script>
 
 	<script src='runTests.js'></script>

--- a/test/tests/runTests.js
+++ b/test/tests/runTests.js
@@ -9,11 +9,12 @@
 		QUnit.config.autostart = false;
 
 		config = {
+			baseUrl: '../../src/',
 			paths: {
-				Ractive: '../../tmp/Ractive-legacy',
-				modules: '../modules',
-				samples: '../samples',
-				vendor: '../vendor'
+				Ractive: '../tmp/Ractive-legacy',
+				modules: '../test/modules',
+				samples: '../test/samples',
+				vendor: '../test/vendor'
 			}
 		};
 	} else {


### PR DESCRIPTION
Avoid unnecessary work on `push` and `pop` that only modify trailing end of array.

Additional tests including complex expressions that use `indexRef` and item value `.`.
