### PR TITLE
Closing Section fixes and changes

### DIFF
--- a/src/parse/Parser/getMustache/SectionStub.js
+++ b/src/parse/Parser/getMustache/SectionStub.js
@@ -15,7 +15,7 @@ define([
 	'use strict';
 
 	var SectionStub = function ( firstToken, parser ) {
-		var next;
+		var next, compare;
 
 		this.ref = firstToken.ref;
 		this.indexRef = firstToken.indexRef;
@@ -37,14 +37,16 @@ define([
 
 		while ( next ) {
 			if ( next.mustacheType === types.CLOSING ) {
-				if ( ( normaliseKeypath( next.ref.trim() ) === this.ref ) || this.expr ) {
-					parser.pos += 1;
-					break;
+				if ( this.ref ) {
+					compare = normaliseKeypath( next.ref.trim() );
+					if ( compare && compare !== this.ref ) {
+						throw new Error( 'Could not parse template: Illegal closing section {{/' 
+							+ compare + '}}. Expected {{/' + this.ref + '}}.' );
+					}
 				}
 
-				else {
-					throw new Error( 'Could not parse template: Illegal closing section' );
-				}
+				parser.pos += 1;
+				break;
 			}
 
 			this.items.push( parser.getStub() );
@@ -76,6 +78,10 @@ define([
 
 			if ( this.expr ) {
 				json.x = this.expr.toJSON();
+			}
+
+			if ( this.keypathExpr ) {
+				json.kx = this.keypathExpr.toJSON();
 			}
 
 			if ( this.items.length ) {

--- a/test/modules/parse.js
+++ b/test/modules/parse.js
@@ -21,6 +21,14 @@ define([ 'ractive', 'samples/parse' ], function ( Ractive, tests ) {
 			runTest( tests[i] );
 		}
 
+		//TODO: create structure like above to run parsing error tests
+		test('Illegal closing section: ref mismatch', function(t){
+			throws( function(){
+				Ractive.parse( '{{#foo}}{{/bar}}' );
+			},
+			/(?=.*foo)(?=.*bar)/)
+		});
+
 	};
 
 });

--- a/test/samples/parse.js
+++ b/test/samples/parse.js
@@ -343,6 +343,16 @@ var parseTests = [
 		name: 'Tag with newline before attributes',
 		template: '<img\nsrc="{{foo}}">',
 		parsed: [{t:7,e:'img',a:{src:[{t:2,r:'foo'}]}}]
+	},
+	{
+		name: 'Expression section',
+		template: '{{#[1,2,3]}}{{.}}{{/}}',
+		parsed: [{"t":4,"x":{"r":[],"s":"[1,2,3]"},"f":[{"t":2,"r":"."}]}]
+	},
+	{
+		name: 'Keypath expression section',
+		template: '{{#foo[bar]}}{{.}}{{/}}',
+		parsed: [{"t":4,"kx":{"r":"foo","m":[{"t":30,"n":"bar"}]},"f":[{"t":2,"r":"."}]}]
 	}
 ];
 


### PR DESCRIPTION
Fix keypath expression sections:

```
{{#foo[bar]}}{{.}}{{/}}
```

Allow empty ref closing sections:

```
{{#items}}{{.}}{{/}} //this now works
```

But, look for mismatches on reference closing sections. This:

```
{{#foo}}{{.}}{{/bar}}
```

now raises:

```
Could not parse template: Illegal closing section {{/bar}}. Expected {{/foo}}.
```
