### PR TITLE
Ref closing sections with indexRef function correctly

### DIFF
--- a/src/parse/Parser/getMustache/SectionStub.js
+++ b/src/parse/Parser/getMustache/SectionStub.js
@@ -15,7 +15,7 @@ define([
 	'use strict';
 
 	var SectionStub = function ( firstToken, parser ) {
-		var next, compare;
+		var next;
 
 		this.ref = firstToken.ref;
 		this.indexRef = firstToken.indexRef;
@@ -37,14 +37,7 @@ define([
 
 		while ( next ) {
 			if ( next.mustacheType === types.CLOSING ) {
-				if ( this.ref ) {
-					compare = normaliseKeypath( next.ref.trim() );
-					if ( compare && compare !== this.ref ) {
-						throw new Error( 'Could not parse template: Illegal closing section {{/' 
-							+ compare + '}}. Expected {{/' + this.ref + '}}.' );
-					}
-				}
-
+				validateClosing(this, next);
 				parser.pos += 1;
 				break;
 			}
@@ -52,8 +45,25 @@ define([
 			this.items.push( parser.getStub() );
 			next = parser.next();
 		}
+
 	};
 
+	function validateClosing(stub, token){
+		var opening = stub.ref, 
+			closing = normaliseKeypath( token.ref.trim() );
+
+		if ( !opening || !closing ) { return; }
+
+		if( stub.indexRef ) { opening += ':' + stub.indexRef; }
+
+		if ( opening.substr( 0, closing.length) !== closing ) {
+
+			throw new Error( 'Could not parse template: Illegal closing section {{/' 
+				+ closing + '}}. Expected {{/' + stub.ref + '}}.' );
+
+		}
+	}
+						
 	SectionStub.prototype = {
 		toJSON: function ( noStringify ) {
 			var json;

--- a/test/modules/parse.js
+++ b/test/modules/parse.js
@@ -29,6 +29,13 @@ define([ 'ractive', 'samples/parse' ], function ( Ractive, tests ) {
 			/(?=.*foo)(?=.*bar)/)
 		});
 
+		test('Illegal closing section: closing must be contained in openning', function(t){
+			throws( function(){
+				Ractive.parse( '{{#foo}}{{/foo:i}}' );
+			},
+			/(?=.*foo)(?=.*foo:i)/)
+		});
+
 	};
 
 });

--- a/test/samples/parse.js
+++ b/test/samples/parse.js
@@ -353,6 +353,21 @@ var parseTests = [
 		name: 'Keypath expression section',
 		template: '{{#foo[bar]}}{{.}}{{/}}',
 		parsed: [{"t":4,"kx":{"r":"foo","m":[{"t":30,"n":"bar"}]},"f":[{"t":2,"r":"."}]}]
+	},
+	{
+		name: 'List section with index ref and full closing',
+		template: '{{#foo:i}}{{.}}{{/foo:i}}',
+		parsed: [{"t":4,"r":"foo","i":"i","f":[{"t":2,"r":"."}]}] 
+	},
+	{
+		name: 'List section with index ref and ref only closing',
+		template: '{{#foo:i}}{{.}}{{/foo}}',
+		parsed: [{"t":4,"r":"foo","i":"i","f":[{"t":2,"r":"."}]}] 
+	},
+	{
+		name: 'List section with index ref and empty closing',
+		template: '{{#foo:i}}{{.}}{{/}}',
+		parsed: [{"t":4,"r":"foo","i":"i","f":[{"t":2,"r":"."}]}] 
 	}
 ];
 


### PR DESCRIPTION
All three are now valid:

```
{{#foo:i}}{{.}}{{/foo:i}}
{{#foo:i}}{{.}}{{/foo}}
{{#foo:i}}{{.}}{{/}}
```

Throws if opening does not begin with closing:
`{{#foo}}{{/foo:i}}`
