### PR TITLE
Fix prototype issue with Android Browser

### DIFF
--- a/build/Ractive.js
+++ b/build/Ractive.js
@@ -9072,13 +9072,14 @@ var extend__extend = function (create, inheritFromParent, inheritFromChildProps,
             return Child;
         };
     }(utils_create, extend_inheritFromParent, extend_inheritFromChildProps, extend_extractInlinePartials, extend_conditionallyParseTemplate, extend_conditionallyParsePartials, extend_initChildInstance, circular);
-var Ractive__Ractive = function (svg, create, defineProperties, prototype, partialRegistry, adaptorRegistry, easingRegistry, Ractive_extend, parse, initialise, circular) {
+var Ractive__Ractive = function (svg, create, defineProperties, _prototype, partialRegistry, adaptorRegistry, easingRegistry, Ractive_extend, parse, initialise, circular) {
         
         var Ractive = function (options) {
             initialise(this, options);
         };
+        Ractive.prototype=_prototype;
         defineProperties(Ractive, {
-            prototype: { value: prototype },
+            //prototype: { value: prototype },
             partials: { value: partialRegistry },
             adaptors: { value: adaptorRegistry },
             easing: { value: easingRegistry },


### PR DESCRIPTION
Generating a new Ractive object fails on Android browser with an error message saying "render" is not defined. 
I found that none of the prototype functions actually got added to the object on Android.

Traced the problem to the way the prototype was added to the Ractive object. It used defineProperties with a line where the property name and the variable name was both "prototype". This threw the Android browser off.
I changed the variable name and did a direct value assignment. The changed code worked in Firefox 28, Chrome 31, Android 4.0 and Android 2.3.
