### PR TITLE
add file.name

### DIFF
--- a/wrapper/banner.js
+++ b/wrapper/banner.js
@@ -1,5 +1,5 @@
 /*
-	Ractive.js v<%= pkg.version %>
+	<%= file.name %> v<%= pkg.version %>
 	<%= grunt.template.today( 'yyyy-mm-dd' ) %> - commit <%= commitHash.substr( 0, 8 ) %>
 
 	http://ractivejs.org


### PR DESCRIPTION
Not sure if `file.name` is correct, but it is best if the filename is included in the header.  [jsDelivr CDN has a built-in concocting](https://github.com/jsdelivr/jsdelivr#url-structure) system, so filenames will be lost.
I even got confused when uploading; I hope I got filenames right.
