### PR TITLE
change operations should always update the DOM synchronously

### DIFF
--- a/test/modules/components.js
+++ b/test/modules/components.js
@@ -891,6 +891,43 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.equal( fixture.innerHTML, '<div class="map"></div>' );
 		});
 
+		test( 'Set operations inside an inline component\'s init() method update the DOM synchronously', function ( t ) {
+			var ListWidget, ractive, previousHeight = -1;
+
+			ListWidget = Ractive.extend({
+				template: '<ul>{{#visibleItems}}<li>{{this}}</li>{{/visibleItems}}</ul>',
+				init: function () {
+					var ul, lis, items, height, i;
+
+					console.group( 'initing' );
+
+					ul = this.find( 'ul' );
+					lis = this.findAll( 'li', { live: true });
+
+					items = this.get( 'items' );
+
+					for ( i = 0; i < items.length; i += 1 ) {
+						this.set( 'visibleItems', items.slice( 0, i ) );
+
+						t.equal( lis.length, i );
+
+						height = ul.offsetHeight;
+						t.ok( height > previousHeight );
+						previousHeight = height;
+					}
+
+					console.groupEnd();
+				}
+			});
+
+			ractive = new Ractive({
+				el: fixture,
+				template: '<list-widget items="{{items}}"/>',
+				data: { items: [ 'a', 'b', 'c', 'd' ]},
+				components: { 'list-widget': ListWidget }
+			});
+		});
+
 	};
 
 });


### PR DESCRIPTION
While working on a virtual scrolling component, I came across an unintended consequence of the new runloop behaviour - it's too conservative about when it flushes changes through the system. This means that changes inside (for example) an inline component's `init()` method don't result in synchronous DOM updates, which is problematic in certain cases.

The performance impact of this change _should_ be negligible, as it doesn't affect how transitions are handled (which was the main benefit of implementing a global runloop).

The `runloop.js` module has grown somewhat unwieldy and could use some refactoring, but that's a separate issue.
