### PR TITLE
Keypath expressions are resolved when not rooted

### DIFF
--- a/test/modules/reassignFragments.js
+++ b/test/modules/reassignFragments.js
@@ -134,6 +134,27 @@ define([
 			t.htmlEqual( fixture.innerHTML, '1,11,6,8,');
 		})
 
+		test('Section updates child keypath expression', function(t){
+			var ractive = new Ractive({
+					el: fixture,
+					template: '{{#items:i}}{{foo[bar]}},{{/}}',
+					data: {
+						bar: 'name',
+						items: [
+							{ foo: { name: 'bob' } },
+							{ foo: { name: 'bill' } },
+							{ foo: { name: 'betty' } },
+						]
+					}
+				});
+
+			t.htmlEqual( fixture.innerHTML, 'bob,bill,betty,');
+
+			var items = ractive.get('items');
+			items.splice(1,2, { foo: { name: 'jill' } } );
+			t.htmlEqual( fixture.innerHTML, 'bob,jill,');
+		})
+
 		test('Section with nested sections and inner context does splice()', function(t){
 			var template = '{{#model:i}}{{#thing}}' +
 								'{{# .inner.length > 1}}' +

--- a/test/samples/render.js
+++ b/test/samples/render.js
@@ -494,6 +494,15 @@ var renderTests = [
 	},
 	{
 		nodeOnly: true,
+		name: 'Two-way select bindings inside list',
+		template: '<select value="{{selected}}">{{#items}}<option value="{{.}}">{{.}}</option>{{/items}}</select>',
+		data: { selected: 2, items: [1,2,3] },
+		result: '<select><option value="1">1</option><option value="2" selected>2</option><option value="3">3</option></select>',
+		new_data: { selected: 3 },
+		new_result: '<select><option value="1">1</option><option value="2">2</option><option value="3" selected>3</option></select>'
+	},
+	{
+		nodeOnly: true,
 		name: 'Two-way multiple select bindings',
 		template: '<select multiple value="{{foo}}"><option value="a">a</option><option value="b">b</option><option value="c">c</option></select>',
 		data: {},
@@ -509,6 +518,32 @@ var renderTests = [
 		result: '<input type="radio" name="{{foo}}" value="one" checked><input type="radio" name="{{foo}}" value="two">',
 		new_data: { foo: 'two' },
 		new_result: '<input type="radio" name="{{foo}}" value="one"><input type="radio" name="{{foo}}" value="two" checked>'
+	},
+
+	//unresolved expressions
+	{
+		name: 'Keypath expression with unresolved member resolves',
+		template: '{{foo[bar]}}',
+		data: { foo: { boo: 'bizz' } },
+		result: '',
+		new_data: { bar: 'boo' },
+		new_result: 'bizz'
+	},	
+	{
+		name: 'Keypath expression with top level unresolved',
+		template: '{{foo[bar]}}',
+		data: { bar: 'boo' },
+		result: '',
+		new_data: { foo: { boo: 'bizz' } },
+		new_result: 'bizz'
+	},	
+	{
+		name: 'Nested keypath expression with top level unresolved',
+		template: '{{#item}}{{foo[bar]}}{{/}}',
+		data: { bar: 'boo' },
+		result: '',
+		new_data: { item: { foo: { boo: 'bizz' } } },
+		new_result: 'bizz'
 	}
 ];
 


### PR DESCRIPTION
Fixes #571.

Example would be a template like `{{#item}}{{foo[bar]}}{{/}}`. `foo` is not at the root and would not resolve to being under `item`.

@Rich-Harris This changes the logic to be, as I understand, consistent with other ref resolution in Ractive.
