### PR TITLE
Add parsing error for no closing mustache (was throwing js error)

### DIFF
--- a/src/parse/Tokenizer/_Tokenizer.js
+++ b/src/parse/Tokenizer/_Tokenizer.js
@@ -78,9 +78,12 @@ define([
 			            this.getTag() ||
 			            this.getText();
 
-			token.getLinePos = function () {
-				return tokenizer.getLinePos(pos);
-			};
+			if(token) {
+				token.getLinePos = function () {
+					return tokenizer.getLinePos(pos);
+				};
+			}
+
 			return token;
 		},
 		getLinePos: function (pos) {

--- a/src/parse/Tokenizer/getMustache/_getMustache.js
+++ b/src/parse/Tokenizer/getMustache/_getMustache.js
@@ -56,7 +56,7 @@ define([
 
 		if ( !tokenizer.getStringMatch( delimiters[1] ) ) {
 			tokenizer.pos = start;
-			return null;
+			tokenizer.expected('closing delimiter "' + delimiters[1] + '" after reference');
 		}
 
 		return content;

--- a/test/samples/parse.js
+++ b/test/samples/parse.js
@@ -400,6 +400,14 @@ var parseTests = [
 			'           ^----'
 	},
 	{
+		name: 'Unclosed mustache',
+		template: '{{foo}',
+		error:
+			'Tokenizer failed: unexpected string \"{{foo}\" (expected closing delimiter \"}}\" after reference) on line 1:1:\n' +
+			'{{foo}\n' +
+			'^----'
+	},
+	{
 		name: 'Unclosed comment',
 		template: 'ok <!--',
 		error:


### PR DESCRIPTION
Was getting error on bad closing mustache. Guarded against !token and added message.

Message could be a little better and point to end of reference, but that would mean fiddling with getMustacheContent to return position instead of reseting, and I'm not up for yak shaving today.
