### PR TITLE
Allow { target, anchor } initialisation option for el (gh #625)

### DIFF
--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -90,6 +90,7 @@ define([
 	}
 
 	function validate ( ractive, options ) {
+		var anchor;
 
 		if ( ractive.magic && !magicAdaptor ) {
 			throw new Error( 'Getters and setters (magic mode) are not supported in this browser' );
@@ -99,6 +100,9 @@ define([
 			ractive.el = getElement( options.el );
 			if ( !ractive.el && ractive.debug ) {
 				throw new Error( 'Could not find container element' );
+			}
+			if ( anchor = getElement( options.el.anchor ) ) {
+				ractive.anchor = anchor;
 			}
 		}
 	}

--- a/src/Ractive/initialise/renderInstance.js
+++ b/src/Ractive/initialise/renderInstance.js
@@ -22,13 +22,13 @@ define([
 		}
 
 		// If the target contains content, and `append` is falsy, clear it
-		else if ( ractive.el && !options.append ) {
+		else if ( ractive.el && !options.append && !ractive.anchor ) {
 			ractive.el.innerHTML = '';
 		}
 
 		promise = new Promise( function ( fulfil ) { fulfilPromise = fulfil; });
 
-		ractive.render( ractive.el, fulfilPromise );
+		ractive.render( ractive.el, ractive.anchor, fulfilPromise );
 
 		if ( options.complete ) {
 			promise = promise.then( options.complete.bind( ractive ) );

--- a/src/Ractive/prototype/render.js
+++ b/src/Ractive/prototype/render.js
@@ -10,7 +10,7 @@ define([
 
 	'use strict';
 
-	return function Ractive_prototype_render ( target, callback ) {
+	return function Ractive_prototype_render ( target, anchor, callback ) {
 
 		this._rendering = true;
 		runloop.start( this, callback );
@@ -37,7 +37,11 @@ define([
 		});
 
 		if ( target ) {
-			target.appendChild( this.fragment.docFrag );
+			if ( anchor ) {
+				target.insertBefore( this.fragment.docFrag, anchor );
+			} else {
+				target.appendChild( this.fragment.docFrag );
+			}
 		}
 
 		// If this is *isn't* a child of a component that's in the process of rendering,

--- a/src/utils/getElement.js
+++ b/src/utils/getElement.js
@@ -2,11 +2,17 @@ define( function () {
 
 	'use strict';
 
-	return function ( input ) {
+	return function getElement( input ) {
 		var output;
+
+		if ( !input ) { return; }
 
 		if ( typeof window === 'undefined' || !document || !input ) {
 			return null;
+		}
+
+		if( input.target ) {
+			return getElement( input.target );
 		}
 
 		// We already have a DOM node - no work to do. (Duck typing alert!)

--- a/test/modules/initialisation.js
+++ b/test/modules/initialisation.js
@@ -354,6 +354,69 @@ define([ 'ractive' ], function ( Ractive ) {
 
 		});
 
+		test( 'Append true option inserts in correct location', function ( t ) {
+			var ractive, 
+				target = document.createElement('div'), 
+				child = document.createElement('div');
+
+			child.innerHTML = 'foo';
+			target.id = 'target';
+			target.appendChild( child );
+			fixture.appendChild( target );
+
+			t.equal( fixture.innerHTML, '<div id="target"><div>foo</div></div>' );
+
+			ractive = new Ractive({
+				el: target,
+				template: '<div>bar</div>',
+				append: true
+			});
+
+			t.equal( fixture.innerHTML, '<div id="target"><div>foo</div><div>bar</div></div>' );
+		});
+
+		test( 'Append false option inserts in correct location', function ( t ) {
+			var ractive, 
+				target = document.createElement('div'), 
+				child = document.createElement('div');
+
+			child.innerHTML = 'bar';
+			target.id = 'target';
+			target.appendChild( child );
+			fixture.appendChild( target );
+
+			t.equal( fixture.innerHTML, '<div id="target"><div>bar</div></div>' );
+
+			ractive = new Ractive({
+				el: target,
+				template: '<div>bar</div>',
+				append: false
+			});
+
+			t.equal( fixture.innerHTML, '<div id="target"><div>bar</div></div>' );
+		});
+
+
+		test( 'Insert element at { target, anchor } option inserts in correct location', function ( t ) {
+			var ractive, 
+				target = document.createElement('div'), 
+				anchor = document.createElement('div');
+
+			anchor.innerHTML = 'bar';
+			target.appendChild( anchor );
+			fixture.appendChild( target );
+
+			t.equal( fixture.innerHTML, '<div><div>bar</div></div>' );
+
+			ractive = new Ractive({
+				el: { target: target, anchor: anchor },
+				template: '<div>foo</div>'
+			});
+
+			t.equal( fixture.innerHTML, '<div><div>foo</div><div>bar</div></div>' );
+
+			
+		});
 
 
 	};

--- a/test/modules/reset.js
+++ b/test/modules/reset.js
@@ -151,6 +151,30 @@ define([ 'ractive' ], function ( Ractive ) {
 
 		});
 
+		test( 'Reset inserts { target, anchor } el option correctly', function ( t ) {
+			var ractive, 
+				target = document.createElement('div'), 
+				anchor = document.createElement('div');
+
+			anchor.innerHTML = 'bar';
+			target.id = 'target';
+			target.appendChild( anchor );
+			fixture.appendChild( target );
+
+			t.equal( fixture.innerHTML, '<div id="target"><div>bar</div></div>' );
+
+			ractive = new Ractive({
+				el: { target: target, anchor: anchor },
+				template: '<div>{{what}}</div>',
+				data: { what: 'fizz' }
+			});
+
+			t.equal( fixture.innerHTML, '<div id="target"><div>fizz</div><div>bar</div></div>' );
+			ractive.reset( { what: 'foo' } );
+			t.equal( fixture.innerHTML, '<div id="target"><div>foo</div><div>bar</div></div>' );
+
+			
+		});
 	};
 
 });


### PR DESCRIPTION
You can now use this for el:

``` js
var ractive, 
    target = document.createElement('div'), 
    anchor = document.createElement('div');

anchor.innerHTML = 'bar';
target.appendChild( anchor );
fixture.appendChild( target );

t.equal( fixture.innerHTML, '<div><div>bar</div></div>' );

ractive = new Ractive({
    el: { target: target, anchor: anchor },
    template: '<div>foo</div>'
});

t.equal( fixture.innerHTML, '<div><div>foo</div><div>bar</div></div>' );

```

Closes #625 
