### PR TITLE
in encapsulated css, media queries should not be transformed

### DIFF
--- a/src/extend/utils/transformCss.js
+++ b/src/extend/utils/transformCss.js
@@ -51,7 +51,7 @@ define( function () {
 			var selectors, transformed;
 
 			// don't transform media queries!
-			if ( mediaQueryPattern.test( match ) ) return match;
+			if ( mediaQueryPattern.test( $1 ) ) return match;
 
 			selectors = $1.split( ',' ).map( trim );
 			transformed = selectors.map( addGuid ).join( ', ' ) + ' ';

--- a/test/modules/css.js
+++ b/test/modules/css.js
@@ -159,7 +159,7 @@ define([ 'ractive' ], function ( Ractive ) {
 
 			Widget = Ractive.extend({
 				template: '<p>red</p>',
-				css: '@media screen { p { color: red; } }'
+				css: 'p { color: blue } @media screen and (max-width: 99999px) { p { color: red; } }'
 			});
 
 			ractive = new Ractive({


### PR DESCRIPTION
This isn't ready for merge just yet - there are various other 'at-rules' besides media queries that are nuked by the transformCss.js module (reference: https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule).

Some of these may need different treatment. For example should an `@import`ed file itself be transformed? Should `@keyframes` be namespaced somehow to avoid pollution? These are tricky questions that will require a bit of thought - in the meantime I just needed to make this quick fix for my current project.
