### PR TITLE
gh-533

### DIFF
--- a/src/parse/converters/element.js
+++ b/src/parse/converters/element.js
@@ -24,6 +24,7 @@ define([
 		validTagNameFollower = /^[\s\n\/>]/,
 		onPattern = /^on/,
 		proxyEventPattern = /^on-([a-zA-Z$_][a-zA-Z$_0-9\-]+)/,
+		reservedEventNames = /(?:change|reset|teardown|update)/,
 		directives = { 'intro-outro': 't0', intro: 't1', outro: 't2', decorator: 'o' },
 		exclude = { exclude: true },
 		converters;
@@ -93,6 +94,13 @@ define([
 		}
 
 		addProxyEvent = function ( name ) {
+			var directiveName = directive.n || directive;
+
+			if ( reservedEventNames.test( directiveName ) ) {
+				parser.pos -= directiveName.length;
+				parser.error( 'Cannot use reserved event names (change, reset, teardown, update)' );
+			}
+
 			element.v[ name ] = directive;
 		};
 

--- a/test/samples/parse.js
+++ b/test/samples/parse.js
@@ -733,6 +733,12 @@ var parseTests = [
 			          [ { t: 2,
 			              p: [ 1, 20 ],
 			              r: 'mustache' } ] } ] } ]
+	},
+	{
+		name: 'Reserved event names cannot be used for proxy events',
+		template: '<div on-foo="change"></div>',
+		error: 'Cannot use reserved event names (change, reset, teardown, update) at line 1 character 15:\n' +
+			'<div on-foo=\"change\"></div>\n              ^----'
 	}
 ];
 


### PR DESCRIPTION
This closes #533. Reserved event names in templates - currently 'change', 'reset', 'teardown', 'update', though this isn't set in stone forever - will cause the parser to throw an error:

``` html
<!-- cannot use 'change' as a proxy event name -->
<input on-input='change'>
```
