### PR TITLE
Nested component content fix

### DIFF
--- a/src/render/DomFragment/Partial/_Partial.js
+++ b/src/render/DomFragment/Partial/_Partial.js
@@ -20,6 +20,7 @@ define([
 
 	DomPartial = function ( options, docFrag ) {
 		var parentFragment = this.parentFragment = options.parentFragment, descriptor;
+		var root = parentFragment.root;
 
 		this.type = types.PARTIAL;
 		this.name = options.descriptor.r;
@@ -32,9 +33,14 @@ define([
 
 		descriptor = getPartialDescriptor( parentFragment.root, options.descriptor.r );
 
+		//we want to use the content from the parent ractive (for any further content partials)
+		if (this.name == 'content') {
+			root = parentFragment.root._parent;
+		}
+
 		this.fragment = new DomFragment({
 			descriptor:   descriptor,
-			root:         parentFragment.root,
+			root:         root,
 			pNode:        parentFragment.pNode,
 			owner:        this
 		});


### PR DESCRIPTION
This is a go at resolving some of the problems with the current implementation of content partials for components as mentioned here: https://github.com/ractivejs/ractive/issues/287

It allows components with content partials to be nested more than 1 level deep and allows the content partial to be evaluated against its original root ractive instead of the component it is within.
