### PR TITLE
Pull component parameter fix

### DIFF
--- a/src/shared/createComponentBinding.js
+++ b/src/shared/createComponentBinding.js
@@ -30,7 +30,7 @@ Binding.prototype = {
         var value;
 
         // Only *you* can prevent infinite loops
-        if ( this.updating || this.counterpart && this.counterpart.updating ) {
+			if ( this.updating ) {
             return;
         }
 
@@ -47,8 +47,13 @@ Binding.prototype = {
 
             // TODO maybe the case that `value === this.value` - should that result
             // in an update rather than a set?
-            runloop.addInstance( this.otherInstance );
-            set( this.otherInstance, this.otherKeypath, value );
+
+				//we have already done this, stop infinite loop
+				if (!(this.counterpart && this.counterpart.updating)) {
+					runloop.addInstance(this.otherInstance);
+					set(this.otherInstance, this.otherKeypath, value);
+				}
+				//this should be set for the binding even if the counterpart wasnt set. so that it lines up.
             this.value = value;
 
             // TODO will the counterpart update after this line, during

--- a/test/modules/components.js
+++ b/test/modules/components.js
@@ -1023,6 +1023,30 @@ define([ 'ractive' ], function ( Ractive ) {
 
 		});
 
+		test( 'Inline component attributes update the value of bindings pointing to them even if they are old values gh-#681', function ( t ) {
+			var Widget, ractive;
+
+			Widget = Ractive.extend({
+				template: '{{childdata}}'
+			});
+
+			ractive = new Ractive({
+				el: fixture,
+				template: '{{parentdata}} - <widget childdata="{{parentdata}}" />',
+				data: { parentdata: 'old' },
+				components: { widget: Widget }
+			});
+
+			t.htmlEqual( fixture.innerHTML, 'old - old' );
+			var widget = ractive.findComponent("widget");
+			widget.set("childdata","new");
+			t.htmlEqual( fixture.innerHTML, 'new - new' );
+
+			ractive.set( 'parentdata', 'old' );
+			t.htmlEqual( fixture.innerHTML, 'old - old' );
+		});
+
+
 
 		asyncTest( 'Component render methods called in consistent order (gh #589)', function ( t ) {
 			var Simpson, ractive, order = { beforeInit: [], init: [], complete: [] },


### PR DESCRIPTION
fix two way updating of component parameters so that setting the previous value on the parent still updates the child if the child was the one that set the new value.

See https://github.com/ractivejs/ractive/issues/681
