### PR TITLE
Fix component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,5 +7,8 @@
   "dependencies": {},
   "development": {},
   "license": "MIT",
+  "scripts": [
+    "ractive.js"
+  ],
   "main": "ractive.js"
 }


### PR DESCRIPTION
According to this: https://github.com/component/spec/blob/master/component.json/specifications.md#main, you still need to add a `scripts` property which includes the `main` script.

The regression seems to have been introduced when bumping to version 0.4.0.
