### PR TITLE
broccoli realtime transpile, testing and sandbox

### DIFF
--- a/broccoli/clean-transpiled.js
+++ b/broccoli/clean-transpiled.js
@@ -1,0 +1,53 @@
+'use strict';
+var Filter = require('broccoli-filter')
+
+// boilerplate broccoli filter, extract to own module...
+function CleanTranspileFilter(inputTree /*, options*/) {
+	if (!(this instanceof CleanTranspileFilter)) {
+		return new CleanTranspileFilter(inputTree /*, options*/);
+	}
+
+	this.inputTree = inputTree;
+	//this.options = options || {};
+}
+
+CleanTranspileFilter.prototype = Object.create(Filter.prototype);
+CleanTranspileFilter.prototype.constructor = CleanTranspileFilter;
+CleanTranspileFilter.prototype.extensions = ['js'];
+CleanTranspileFilter.prototype.targetExtension = 'js';
+
+CleanTranspileFilter.prototype.processString = function ( src ) {
+	var dependencies = {};
+
+	src = src
+
+		// anonymise the module
+		.replace( /^define\(".+?",\s+/, 'define(' )
+
+		// remove "exports" from dependency list
+		.replace( /,?"exports"/, '' )
+
+		// remove empty dependency lists
+		.replace( /^define\(\[\],\s+/, 'define(' )
+
+		// gather dependency names
+		.replace( /\svar (.+?) = __dependency(\d+)__\["default"\];\n/g, function ( match, name, num ) {
+			dependencies[ num ] = name;
+			return '';
+		})
+
+		// replace dependency names
+		.replace( /__dependency(\d+)__,/g, function ( match, num ) {
+			return ( dependencies[ num ] ? dependencies[ num ] + ',' : '' );
+		})
+
+		// remove __exports__
+		.replace( /,?\s*__exports__/, '' )
+
+		// `return` instead of `__exports__['default'] =`
+		.replace( /__exports__\["default"\] =/, 'return' );
+
+	return src;
+};
+
+module.exports = CleanTranspileFilter;

--- a/brocfile.js
+++ b/brocfile.js
@@ -1,0 +1,24 @@
+	// utilities
+var pick = require('broccoli-static-compiler'),
+	merge = require('broccoli-merge-trees'),
+	// filters
+	transpileES6 = require('broccoli-es6-module-transpiler'),
+	cleanTranspiled = require('./broccoli/clean-transpiled');
+
+function copy( path ) {
+	return pick( path, { srcDir: '/', destDir: '/' + path } );
+}
+
+var src = pick('src', {
+		srcDir: '/',
+		files: [ '**/*.js' ],
+		destDir: '/.amd'
+	}),
+	transpiled = transpileES6( src, {
+		moduleName: function(filePath) {
+			return filePath.replace(/.js$/, '');
+  		}
+	}),
+	amd = cleanTranspiled( transpiled );
+
+module.exports = merge( [ amd, copy( 'test' ), copy( 'sandbox' ) ] );

--- a/package.json
+++ b/package.json
@@ -77,7 +77,13 @@
     "promises-aplus-tests": "*",
     "grunt-jsbeautifier": "~0.2.7",
     "grunt-contrib-requirejs": "~0.4.3",
-    "grunt-es6-module-transpiler": "~0.6.0"
+    "grunt-es6-module-transpiler": "~0.6.0",
+    "broccoli": "~0.12.0",
+    "broccoli-static-compiler": "~0.1.4",
+    "broccoli-merge-trees": "~0.1.3",
+    "broccoli-es6-module-transpiler": "~0.1.0",
+    "broccoli-filter": "~0.1.6",
+    "broccoli-cli": "0.0.1"
   },
   "testling": {
     "html": "test/testling.html",


### PR DESCRIPTION
This turned out even better than I hoped.

Fetch latest dev, from your ractive dir install new dev-deps:

``` sh
$ npm install
```

From then on simply run:

``` sh
$ broccoli serve
```

Default server is `http://localhost:4200/`, so `localhost:4200/test/tests` runs all qunit.

I left the transpiled src at `.amd`. You can go to `localhost:4200/sandbox/whatever/` to run sandbox, just _make sure you change to the `.amd` directory_ in your sandbox pages.

Okay, here's the really cool part, with [chrome livereload plugin](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei) installed, turn on and **your pages will auto refresh on save from the IDE!**
