### PR TITLE
Small change to parser behaviour

### DIFF
--- a/src/parse/converters/element.js
+++ b/src/parse/converters/element.js
@@ -10,7 +10,7 @@ import processDirective from 'parse/converters/element/processDirective';
 var tagNamePattern = /^[a-zA-Z]{1,}:?[a-zA-Z0-9\-]*/,
 	validTagNameFollower = /^[\s\n\/>]/,
 	onPattern = /^on/,
-	proxyEventPattern = /^on-([a-zA-Z$_][a-zA-Z$_0-9\-]+)/,
+	proxyEventPattern = /^on-([a-zA-Z$_][a-zA-Z$_0-9\-]+)$/,
 	reservedEventNames = /^(?:change|reset|teardown|update)$/,
 	directives = { 'intro-outro': 't0', intro: 't1', outro: 't2', decorator: 'o' },
 	exclude = { exclude: true },
@@ -80,7 +80,7 @@ function getElement ( parser ) {
 		parser.error( 'Illegal tag name' );
 	}
 
-	addProxyEvent = function ( name ) {
+	addProxyEvent = function ( name, directive ) {
 		var directiveName = directive.n || directive;
 
 		if ( reservedEventNames.test( directiveName ) ) {
@@ -102,7 +102,7 @@ function getElement ( parser ) {
 		else if ( match = proxyEventPattern.exec( attribute.name ) ) {
 			if ( !element.v ) element.v = {};
 			directive = processDirective( attribute.value );
-			match[1].split( '-' ).forEach( addProxyEvent );
+			addProxyEvent( match[1], directive );
 		}
 
 		else {

--- a/test/modules/events.js
+++ b/test/modules/events.js
@@ -392,6 +392,25 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.htmlEqual( ractive.find( '.result' ).innerHTML, '0' );
 		});
 
+		test( 'Multiple events can share the same directive', function ( t ) {
+			var ractive, count = 0;
+
+			ractive = new Ractive({
+				el: fixture,
+				template: '<div on-click-mouseover="foo"></div>'
+			});
+
+			ractive.on( 'foo', function () {
+				count += 1;
+			});
+
+			simulant.fire( ractive.find( 'div' ), 'click' );
+			t.equal( count, 1 );
+
+			simulant.fire( ractive.find( 'div' ), 'mouseover' );
+			t.equal( count, 2 );
+		});
+
 	};
 
 });

--- a/test/samples/parse.js
+++ b/test/samples/parse.js
@@ -744,6 +744,11 @@ var parseTests = [
 		name: 'Reserved event names can be part of proxy event names',
 		template: '<div on-foo="thiswillchange"></div>',
 		parsed: [{t:7,e:'div',v:{foo:'thiswillchange'}}]
+	},
+	{
+		name: 'Multiple proxy event names joined by "-"',
+		template: '<div on-foo-bar="baz"></div>',
+		parsed: [{t:7,e:'div',v:{'foo-bar':'baz'}}]
 	}
 ];
 


### PR DESCRIPTION
This changes how proxy events are represented in parsed templates, from

``` js
Ractive.parse( '<div on-foo-bar="baz:qux"></div>' );
// -> [{"t":7,"e":"div","v":{"foo":{"n":"baz","a":"qux"},"bar":{"n":"baz","a":"qux"}}}]
```

to

``` js
Ractive.parse( '<div on-foo-bar="baz:qux"></div>' );
// -> [{"t":7,"e":"div","v":{"foo-bar":{"n":"baz","a":"qux"}}}]
```

As well as being more efficient this works around a downstream bug with template optimisation.
