### PR TITLE
Using `this` for restricted references

### DIFF
--- a/src/parse/Parser/expressions/primary/reference.js
+++ b/src/parse/Parser/expressions/primary/reference.js
@@ -45,12 +45,6 @@ export default function ( parser ) {
 		};
 	}
 
-	// allow the use of `this`
-	if ( name === 'this' && !ancestor && !dot ) {
-		name = '.';
-		startPos += 3; // horrible hack to allow method invocations with `this` by ensuring combo.length is right!
-	}
-
 	combo = ( ancestor || dot ) + name;
 
 	if ( !combo ) {
@@ -77,6 +71,6 @@ export default function ( parser ) {
 
 	return {
 		t: types.REFERENCE,
-		n: combo
+		n: combo.replace( /^this\./, './' ).replace( /^this$/, '.' )
 	};
 }

--- a/src/shared/resolveRef.js
+++ b/src/shared/resolveRef.js
@@ -86,10 +86,10 @@ function resolveAncestorReference ( baseContext, ref ) {
 		return contextKeys.join( '.' );
 	}
 
-	// not an ancestor reference - must be a restricted reference (prepended with ".")
+	// not an ancestor reference - must be a restricted reference (prepended with "." or "./")
 	if ( !baseContext ) {
-		return ref.substring( 1 );
+		return ref.replace( /^\.\/?/, '' );
 	}
 
-	return baseContext + ref;
+	return baseContext + ref.replace( /^\.\//, '.' );
 }

--- a/test/samples/parse.js
+++ b/test/samples/parse.js
@@ -806,6 +806,18 @@ var parseTests = [
 		name: 'Illegal bracketed expression (missing closing paren)',
 		template: '{{(foo}}',
 		error: 'Expected closing paren at line 1 character 7:\n{{(foo}}\n      ^----'
+	},
+
+	// `this`
+	{
+		name: '`this` becomes `.`',
+		template: '{{this}}',
+		parsed: [{t:2,r:'.'}]
+	},
+	{
+		name: '`this.foo` becomes `./foo`',
+		template: '{{this.foo}}',
+		parsed: [{t:2,r:'./foo'}]
 	}
 ];
 

--- a/test/samples/render.js
+++ b/test/samples/render.js
@@ -634,6 +634,14 @@ var renderTests = [
 		result: '<p>a</p><p>b</p><p>c</p>',
 		new_data: { items: null },
 		new_result: '<p>no items!</p>'
+	},
+	{
+		name: 'Restricting references with `this`',
+		template: '{{#foo}}{{this.bar}}{{/foo}}',
+		data: { foo: {}, bar: 'fail' },
+		result: '',
+		new_data: { foo: { bar: 'success' }, bar: 'fail' },
+		new_result: 'success'
 	}
 ];
 


### PR DESCRIPTION
This PR changes the behaviour of `this` in templates. `{{this}}` translates to `{{.}}`, as before, but `{{this.foo}}` now means the same as `{{.foo}}` - in other words, it restricts the search for `foo` to the current context.

While I was at it, I added support for `{{./foo}}` notation. This means the same as `{{.foo}}`, but better matches the filesystem metaphor used for _ancestor references_ (i.e. `{{../foo}}`), so may suit some developers' tastes better.
