### PR TITLE
Removing unnecessary evaluator function calls

### DIFF
--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -92,9 +92,13 @@ runloop = {
 	},
 
 	// changes that may cause additional changes...
-	modelUpdate: function ( thing ) {
-		dirty = true;
-		modelUpdates.push( thing );
+	modelUpdate: function ( thing, remove ) {
+		if ( remove ) {
+			removeFromArray( modelUpdates, thing );
+		} else {
+			dirty = true;
+			modelUpdates.push( thing );
+		}
 	},
 
 	// TODO this is wrong - inputs should be grouped by instance

--- a/src/shared/registerDependant.js
+++ b/src/shared/registerDependant.js
@@ -1,5 +1,5 @@
 export default function registerDependant ( dependant ) {
-	var depsByKeypath, deps, ractive, keypath, priority;
+	var depsByKeypath, deps, ractive, keypath, priority, evaluator;
 
 	ractive = dependant.root;
 	keypath = dependant.keypath;
@@ -13,6 +13,14 @@ export default function registerDependant ( dependant ) {
 
 	if ( !keypath ) {
 		return;
+	}
+
+	if ( evaluator = ractive._evaluators[ keypath ] ) {
+		if ( !evaluator.dependants ) {
+			evaluator.wake();
+		}
+
+		evaluator.dependants += 1;
 	}
 
 	updateDependantsMap( ractive, keypath );

--- a/src/shared/unregisterDependant.js
+++ b/src/shared/unregisterDependant.js
@@ -1,5 +1,5 @@
 export default function unregisterDependant ( dependant ) {
-	var deps, index, ractive, keypath, priority;
+	var deps, index, ractive, keypath, priority, evaluator;
 
 	ractive = dependant.root;
 	keypath = dependant.keypath;
@@ -17,6 +17,14 @@ export default function unregisterDependant ( dependant ) {
 
 	if ( !keypath ) {
 		return;
+	}
+
+	if ( evaluator = ractive._evaluators[ keypath ] ) {
+		evaluator.dependants -= 1;
+
+		if ( !evaluator.dependants ) {
+			evaluator.sleep();
+		}
 	}
 
 	updateDependantsMap( ractive, keypath );

--- a/src/virtualdom/items/shared/Evaluator/_Evaluator.js
+++ b/src/virtualdom/items/shared/Evaluator/_Evaluator.js
@@ -21,6 +21,8 @@ Evaluator = function ( root, keypath, uniqueString, functionStr, args, priority 
 	evaluator.values = [];
 	evaluator.refs = [];
 
+	evaluator.dependants = 0;
+
 	args.forEach( function ( arg, i ) {
 		if ( !arg ) {
 			return;
@@ -38,8 +40,17 @@ Evaluator = function ( root, keypath, uniqueString, functionStr, args, priority 
 };
 
 Evaluator.prototype = {
+	wake: function () {
+		this.awake = true;
+	},
+
+	sleep: function () {
+		this.awake = false;
+		runloop.modelUpdate( this, true ); // cancel pending update, if there is one
+	},
+
 	bubble: function () {
-		if ( !this.dirty ) {
+		if ( !this.dirty && this.awake ) {
 			// Re-evaluate once all changes have propagated
 			this.dirty = true;
 			runloop.modelUpdate( this );

--- a/test/modules/misc.js
+++ b/test/modules/misc.js
@@ -1134,6 +1134,44 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.equal( ractive.find( 'p' ).namespaceURI, 'http://www.w3.org/1999/xhtml' );
 		});
 
+		test( 'Evaluators are not called if their expressions no longer exist (#716)', function ( t ) {
+			var ractive, doubled = 0, tripled = 0;
+
+			ractive = new Ractive({
+				el: fixture,
+				template: '<p>{{double(foo)}}</p>{{#bar}}<p>{{triple(foo)}}</p>{{/bar}}',
+				data: {
+					foo: 3,
+					double: function ( foo ) {
+						doubled += 1;
+						return foo * 2;
+					},
+					triple: function ( foo ) {
+						tripled += 1;
+						return foo * 3;
+					}
+				}
+			});
+
+			t.equal( doubled, 1 );
+			t.equal( tripled, 0 );
+
+			ractive.set({
+				foo: 4,
+				bar: true
+			});
+
+			t.equal( doubled, 2 );
+			t.equal( tripled, 1 );
+
+			ractive.set({
+				foo: 5,
+				bar: false
+			});
+			t.equal( doubled, 3 );
+			t.equal( tripled, 1 );
+		});
+
 
 		// These tests run fine in the browser but not in PhantomJS. WTF I don't even.
 		// Anyway I can't be bothered to figure it out right now so I'm just commenting


### PR DESCRIPTION
See #716. May see if it's possible to prevent evaluators being run twice when they get created at the same time as their arguments are being set; will hold off merging for the time being.
