### PR TITLE
Better handling of whitespace in templates

### DIFF
--- a/src/parse/utils/trimWhitespace.js
+++ b/src/parse/utils/trimWhitespace.js
@@ -1,28 +1,32 @@
 var leadingWhitespace = /^[ \t\f\r\n]+/,
 	trailingWhitespace = /[ \t\f\r\n]+$/;
 
-export default function ( items ) {
+export default function ( items, leading, trailing ) {
 	var item;
 
-	item = items[0];
-	if ( typeof item === 'string' ) {
-		item = item.replace( leadingWhitespace, '' );
+	if ( leading ) {
+		item = items[0];
+		if ( typeof item === 'string' ) {
+			item = item.replace( leadingWhitespace, '' );
 
-		if ( !item ) {
-			items.shift();
-		} else {
-			items[0] = item;
+			if ( !item ) {
+				items.shift();
+			} else {
+				items[0] = item;
+			}
 		}
 	}
 
-	item = items[ items.length - 1 ];
-	if ( typeof item === 'string' ) {
-		item = item.replace( trailingWhitespace, '' );
+	if ( trailing ) {
+		item = items[ items.length - 1 ];
+		if ( typeof item === 'string' ) {
+			item = item.replace( trailingWhitespace, '' );
 
-		if ( !item ) {
-			items.pop();
-		} else {
-			items[ items.length - 1 ] = item;
+			if ( !item ) {
+				items.pop();
+			} else {
+				items[ items.length - 1 ] = item;
+			}
 		}
 	}
 }

--- a/test/samples/parse.js
+++ b/test/samples/parse.js
@@ -563,16 +563,16 @@ var parseTests = [
 				t: 4,
 				n: 50,
 				r: 'foo',
-				f: [ ' foo ',
-					{ t: 4, n: 50, r: 'foo2', f: [' foo2 '] },
-					{ t: 4, n: 51, r: 'foo2', f: [' not foo2 '] }
+				f: [ 'foo ',
+					{ t: 4, n: 50, r: 'foo2', f: ['foo2'] },
+					{ t: 4, n: 51, r: 'foo2', f: ['not foo2'] }
 				],
 			},
 			{
 				t: 4,
 				n: 51,
 				r: 'foo',
-				f: [' bar']
+				f: ['bar']
 			}
 		]
 	},
@@ -710,8 +710,8 @@ var parseTests = [
 							 { t: 2,
 							   p: [ 4, 13 ],
 							   r: 'grand' },
-							 '?' ] },
-						' ' ] } ] } ]
+							 '?' ] }
+						] } ] } ]
 	},
 	{
 		name: "Mixture of HTML-able and non-HTML-able elements in template with Traces",


### PR DESCRIPTION
Before, whitespace would be stripped from the start and end of templates, and from the start and end of element fragments (since `<p>foo</p>` is identical to `<p>  foo  </p>` to browsers, except in the rare cases where `p` elements have `white-space: pre`, for which we use the `preserveWhitespace` flag when parsing). Contiguous whitespace would be collapsed to a single character. But whitespace at the start and end of _sections_ was preserved:

``` html
   {{#foo}}
      <p>   bar </p>
  {{/foo}}
```

...becomes...

``` js
[{"t": 4,"r": "foo","f": [" ",{"t": 7,"e": "p","f": ["bar"]}," "]}]
```

Note the `" "` strings either side of the `p` object.

Now, the parser is smarter about ditching unnecessary whitespace. The same template will now parse to

``` js
[{"t": 4,"r": "foo","f": [{"t": 7,"e": "p","f": ["bar"]}]}]
```

Aside from being more compact, this will be quicker to render, because a) we don't need to create useless text nodes, and b) when stamping out the `foo` fragment, we don't need to create a document fragment to temporarily store multiple nodes (text node, `<p>`, text node) before appending them to the DOM, because there's only one node.
