### PR TITLE
Speed up build

### DIFF
--- a/grunt/config/concurrent.js
+++ b/grunt/config/concurrent.js
@@ -1,0 +1,5 @@
+module.exports = {
+	test: [ 'nodeunit', 'qunit:all' ],
+	uglify: [ 'uglify:0', 'uglify:1', 'uglify:2', 'uglify:3' ],
+	requirejs: [ 'requirejs:full', 'requirejs:legacy', 'requirejs:runtime', 'requirejs:runtime_legacy' ]
+};

--- a/grunt/config/uglify.js
+++ b/grunt/config/uglify.js
@@ -1,6 +1,6 @@
 module.exports = [
-		{ dest: '<%= tmpDir %>/ractive.min.js', src: '<%= tmpDir %>/ractive.js' },
-		{ dest: '<%= tmpDir %>/ractive-legacy.min.js', src: '<%= tmpDir %>/ractive-legacy.js' },
-		{ dest: '<%= tmpDir %>/ractive.runtime.min.js', src: '<%= tmpDir %>/ractive.runtime.js' },
-		{ dest: '<%= tmpDir %>/ractive-legacy.runtime.min.js', src: '<%= tmpDir %>/ractive-legacy.runtime.js' }
-	];
+	{ dest: '<%= tmpDir %>/ractive.min.js', src: '<%= tmpDir %>/ractive.js' },
+	{ dest: '<%= tmpDir %>/ractive-legacy.min.js', src: '<%= tmpDir %>/ractive-legacy.js' },
+	{ dest: '<%= tmpDir %>/ractive.runtime.min.js', src: '<%= tmpDir %>/ractive.runtime.js' },
+	{ dest: '<%= tmpDir %>/ractive-legacy.runtime.min.js', src: '<%= tmpDir %>/ractive-legacy.runtime.js' }
+];

--- a/grunt/tasks/build.js
+++ b/grunt/tasks/build.js
@@ -7,7 +7,7 @@ module.exports = function ( grunt ) {
 		'clean:tmpDir',
 		'buildTests',
 		'broccoli:toTmpDir:build',
-		'requirejs',
+		'concurrent:requirejs',
 		'concat:closure',
 		'revision',
 		'jsbeautifier'

--- a/grunt/tasks/default.js
+++ b/grunt/tasks/default.js
@@ -4,8 +4,8 @@ module.exports = function ( grunt ) {
 
 	grunt.registerTask( 'default', [
 		'build',
-		'runTests',
-		'uglify',
+		'concurrent:test',
+		'concurrent:uglify',
 		'concat:banner'
 	]);
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "broccoli-cli": "0.0.1",
     "broccoli-es6-transpiler": "~0.1.0",
     "grunt-broccoli": "~0.2.2",
-    "broccoli-env": "0.0.1"
+    "broccoli-env": "0.0.1",
+    "grunt-concurrent": "~0.5.0"
   },
   "testling": {
     "html": "test/testling.html",


### PR DESCRIPTION
Which I'd discovered this sooner. [grunt-concurrent](https://github.com/sindresorhus/grunt-concurrent) allows you to run tasks in parallel using multiple cores - for example optimising all requirejs targets and uglifying all four builds simultaneously. Shaves a few seconds off each build.
