### PR TITLE
Handle emulated events on 'window' (Fixes #535)

### DIFF
--- a/src/render/DomFragment/Element/initialise/addEventProxies/addEventProxy.js
+++ b/src/render/DomFragment/Element/initialise/addEventProxies/addEventProxy.js
@@ -36,7 +36,7 @@ define([ 'utils/warn', 'render/StringFragment/_StringFragment' ], function ( war
 			this.custom = definition( this.node, getCustomHandler( eventName ) );
 		} else {
 			// Looks like we're dealing with a standard DOM event... but let's check
-			if ( !( 'on' + eventName in this.node ) ) {
+			if ( !( 'on' + eventName in this.node ) && !( window && 'on' + eventName in window ) ) {
 				warn( 'Missing "' + this.name + '" event. You may need to download a plugin via http://docs.ractivejs.org/latest/plugins#events' );
 			}
 


### PR DESCRIPTION
Checks for events on `window` if they cannot be found on the node itself. This is only known to happen when Chrome emulates touchscreen mode - Events like `"ontouchstart"` work with `addEventListener` in that mode but do not appear as properties on the nodes themselves, only on `window`.
