### PR TITLE
Handle emulated events on 'window' (Fixes #535)

### DIFF
--- a/src/virtualdom/items/Element/EventHandler/prototype/render.js
+++ b/src/virtualdom/items/Element/EventHandler/prototype/render.js
@@ -11,7 +11,7 @@ export default function EventHandler$render () {
 		this.custom = definition( this.node, getCustomHandler( name ) );
 	} else {
 		// Looks like we're dealing with a standard DOM event... but let's check
-		if ( !( 'on' + name in this.node ) ) {
+		if ( !( 'on' + name in this.node ) && !( window && 'on' + eventName in window ) ) {
 			if ( !alreadyWarned[ name ] ) {
 				warn( 'Missing "' + this.name + '" event. You may need to download a plugin via http://docs.ractivejs.org/latest/plugins#events' );
 				alreadyWarned[ name ] = true;


### PR DESCRIPTION
Take two for #738, pulling on the `dev` branch this time.

Checks for events on `window` if they cannot be found on the node itself. This is only known to happen when Chrome emulates touchscreen mode - Events like `"ontouchstart"` work with `addEventListener` in that mode but do not appear as properties on the nodes themselves, only on `window`.
