### PR TITLE
Don't change the datatype of values bound to form elements

### DIFF
--- a/src/virtualdom/items/Element/Binding/GenericBinding.js
+++ b/src/virtualdom/items/Element/Binding/GenericBinding.js
@@ -25,12 +25,6 @@ GenericBinding = Binding.extend({
 
 	getValue: function () {
 		var value = this.element.node.value;
-
-		// if the value is numeric, treat it as a number. otherwise don't
-		if ( ( +value + '' === value ) && value.indexOf( 'e' ) === -1 ) {
-			value = +value;
-		}
-
 		return value;
 	},
 


### PR DESCRIPTION
See https://github.com/ractivejs/ractive/issues/488

@Rich-Harris says "so basically I think we should keep things as are for the moment, and revisit it once 0.4.0 is out the door." So I don't expect this to get merged immediately. I am providing this PR as a reminder that this issue needs to be revisited at some point.
