### PR TITLE
Fix inputfile twoway

### DIFF
--- a/src/virtualdom/items/Element/prototype/init/createTwowayBinding.js
+++ b/src/virtualdom/items/Element/prototype/init/createTwowayBinding.js
@@ -37,7 +37,7 @@ export default function createTwowayBinding ( element ) {
 			}
 		}
 
-		else if ( type === 'file' ) {
+		else if ( type === 'file' && isBindable( attributes.value ) ) {
 			Binding = FileListBinding;
 		}
 

--- a/test/modules/twoway.js
+++ b/test/modules/twoway.js
@@ -108,6 +108,16 @@ define([ 'ractive' ], function ( Ractive ) {
 			}
 		});
 
+		test( 'Two-way data binding is not attempted on elements with no mustache binding', function ( t ) {
+			expect(0);
+
+			// This will throw an error if the binding is attempted (Issue #750)
+			var ractive = new Ractive({
+				el: fixture,
+				template: '<input type="radio"><input type="checkbox"><input type="file"><select></select><textarea></textarea><div contenteditable="true"></div>'
+			});
+		});
+
 	};
 
 });


### PR DESCRIPTION
Fixes #750.

Adds an `isBindable()` check to the <input type="file"> path in the Two-way Binding code that probably should have always been there. Added regression test for that and all other two-way bindings. Also checked from the front that this doesn't break <input type="file"> two-way binding when a `value="{{ mustache}}"` is added, but no test for that, it's covered.
