### PR TITLE
Apply function naming conventions to Ractive.prototype methods...

### DIFF
--- a/src/Ractive/prototype.js
+++ b/src/Ractive/prototype.js
@@ -1,5 +1,5 @@
 import add from 'Ractive/prototype/add';
-import animate from 'Ractive/prototype/animate/_animate';
+import animate from 'Ractive/prototype/animate';
 import detach from 'Ractive/prototype/detach';
 import find from 'Ractive/prototype/find';
 import findAll from 'Ractive/prototype/findAll';
@@ -8,12 +8,11 @@ import findComponent from 'Ractive/prototype/findComponent';
 import fire from 'Ractive/prototype/fire';
 import get from 'Ractive/prototype/get';
 import insert from 'Ractive/prototype/insert';
-import merge from 'Ractive/prototype/merge/_merge';
+import merge from 'Ractive/prototype/merge';
 import observe from 'Ractive/prototype/observe';
 import off from 'Ractive/prototype/off';
 import on from 'Ractive/prototype/on';
 import render from 'Ractive/prototype/render';
-import renderHTML from 'Ractive/prototype/renderHTML';
 import reset from 'Ractive/prototype/reset';
 import resetTemplate from 'Ractive/prototype/resetTemplate';
 import set from 'Ractive/prototype/set';
@@ -41,7 +40,6 @@ export default {
 	off: off,
 	on: on,
 	render: render,
-	renderHTML: renderHTML,
 	reset: reset,
 	resetTemplate: resetTemplate,
 	set: set,

--- a/src/Ractive/prototype/add.js
+++ b/src/Ractive/prototype/add.js
@@ -1,5 +1,5 @@
 import add from 'Ractive/prototype/shared/add';
 
-export default function ( keypath, d ) {
+export default function Ractive$add ( keypath, d ) {
 	return add( this, keypath, ( d === undefined ? 1 : +d ) );
 }

--- a/src/Ractive/prototype/animate.js
+++ b/src/Ractive/prototype/animate.js
@@ -9,7 +9,7 @@ var noop = function () {}, noAnimation = {
 	stop: noop
 };
 
-export default function ( keypath, to, options ) {
+export default function Ractive$animate ( keypath, to, options ) {
 
 	var promise,
 		fulfilPromise,

--- a/src/Ractive/prototype/detach.js
+++ b/src/Ractive/prototype/detach.js
@@ -1,6 +1,6 @@
 import removeFromArray from 'utils/removeFromArray';
 
-export default function () {
+export default function Ractive$detach () {
 	if ( this.el ) {
 		removeFromArray( this.el.__ractive_instances__, this );
 	}

--- a/src/Ractive/prototype/find.js
+++ b/src/Ractive/prototype/find.js
@@ -1,4 +1,4 @@
-export default function ( selector ) {
+export default function Ractive$find ( selector ) {
 	if ( !this.el ) {
 		return null;
 	}

--- a/src/Ractive/prototype/findAll.js
+++ b/src/Ractive/prototype/findAll.js
@@ -1,6 +1,6 @@
 import makeQuery from 'Ractive/prototype/shared/makeQuery/_makeQuery';
 
-export default function ( selector, options ) {
+export default function Ractive$findAll ( selector, options ) {
 	var liveQueries, query;
 
 	if ( !this.el ) {

--- a/src/Ractive/prototype/findAllComponents.js
+++ b/src/Ractive/prototype/findAllComponents.js
@@ -1,6 +1,6 @@
 import makeQuery from 'Ractive/prototype/shared/makeQuery/_makeQuery';
 
-export default function ( selector, options ) {
+export default function Ractive$findAllComponents ( selector, options ) {
 	var liveQueries, query;
 
 	options = options || {};

--- a/src/Ractive/prototype/findComponent.js
+++ b/src/Ractive/prototype/findComponent.js
@@ -1,3 +1,3 @@
-export default function ( selector ) {
+export default function Ractive$findComponent ( selector ) {
 	return this.fragment.findComponent( selector );
 }

--- a/src/Ractive/prototype/fire.js
+++ b/src/Ractive/prototype/fire.js
@@ -1,4 +1,4 @@
-export default function ( eventName ) {
+export default function Ractive$fire ( eventName ) {
 	var args, i, len, subscribers = this._subs[ eventName ];
 
 	if ( !subscribers ) {

--- a/src/Ractive/prototype/insert.js
+++ b/src/Ractive/prototype/insert.js
@@ -1,6 +1,6 @@
 import getElement from 'utils/getElement';
 
-export default function ( target, anchor ) {
+export default function Ractive$insert ( target, anchor ) {
 	if ( !this.rendered ) {
 		// TODO create, and link to, documentation explaining this
 		throw new Error( 'The API has changed - you must call `ractive.render(target[, anchor])` to render your Ractive instance. Once rendered you can use `ractive.insert()`.' );

--- a/src/Ractive/prototype/merge.js
+++ b/src/Ractive/prototype/merge.js
@@ -8,7 +8,7 @@ import propagateChanges from 'Ractive/prototype/merge/propagateChanges';
 
 var comparators = {};
 
-export default function merge ( keypath, array, options ) {
+export default function Ractive$merge ( keypath, array, options ) {
 
 	var currentArray,
 		oldArray,

--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -1,7 +1,7 @@
 import isObject from 'utils/isObject';
 import getObserverFacade from 'Ractive/prototype/observe/getObserverFacade';
 
-export default function observe ( keypath, callback, options ) {
+export default function Ractive$observe ( keypath, callback, options ) {
 
 	var observers, map, keypaths, i;
 

--- a/src/Ractive/prototype/observe/getPattern.js
+++ b/src/Ractive/prototype/observe/getPattern.js
@@ -1,6 +1,6 @@
 import isArray from 'utils/isArray';
 
-export default function ( ractive, pattern ) {
+export default function getPattern ( ractive, pattern ) {
 	var keys, key, values, matchingKeypaths;
 
 	keys = pattern.split( '.' );

--- a/src/Ractive/prototype/off.js
+++ b/src/Ractive/prototype/off.js
@@ -1,7 +1,7 @@
 import trim from 'Ractive/prototype/shared/trim';
 import notEmptyString from 'Ractive/prototype/shared/notEmptyString';
 
-export default function ( eventName, callback ) {
+export default function Ractive$off ( eventName, callback ) {
 	var eventNames;
 
 	// if no arguments specified, remove all callbacks

--- a/src/Ractive/prototype/on.js
+++ b/src/Ractive/prototype/on.js
@@ -1,7 +1,7 @@
 import trim from 'Ractive/prototype/shared/trim';
 import notEmptyString from 'Ractive/prototype/shared/notEmptyString';
 
-export default function ( eventName, callback ) {
+export default function Ractive$on ( eventName, callback ) {
 	var self = this, listeners, n, eventNames;
 
 	// allow mutliple listeners to be bound in one go

--- a/src/Ractive/prototype/renderHTML.js
+++ b/src/Ractive/prototype/renderHTML.js
@@ -1,7 +1,0 @@
-import warn from 'utils/warn';
-
-export default function () {
-	// TODO remove this method in a future version!
-	warn( 'renderHTML() has been deprecated and will be removed in a future version. Please use toHTML() instead' );
-	return this.toHTML();
-}

--- a/src/Ractive/prototype/reset.js
+++ b/src/Ractive/prototype/reset.js
@@ -7,7 +7,7 @@ import initialiseRegistries from 'Ractive/initialise/initialiseRegistries';
 
 var shouldRerender = [ 'template', 'partials', 'components', 'decorators', 'events' ].join();
 
-export default function ( data, callback ) {
+export default function Ractive$reset ( data, callback ) {
 	var self = this,
 		promise,
 		fulfilPromise,

--- a/src/Ractive/prototype/resetTemplate.js
+++ b/src/Ractive/prototype/resetTemplate.js
@@ -6,7 +6,7 @@ import Fragment from 'virtualdom/Fragment';
 // could be achieved with unrender-resetTemplate-render. Also, it should
 // conceptually be similar to resetPartial, which couldn't be async
 
-export default function ( template ) {
+export default function Ractive$resetTemplate ( template ) {
 	var transitionsEnabled,
 		changes,
 		options = {

--- a/src/Ractive/prototype/shared/add.js
+++ b/src/Ractive/prototype/shared/add.js
@@ -1,6 +1,6 @@
 import isNumeric from 'utils/isNumeric';
 
-export default function ( root, keypath, d ) {
+export default function add ( root, keypath, d ) {
 	var value;
 
 	if ( typeof keypath !== 'string' || !isNumeric( d ) ) {

--- a/src/Ractive/prototype/shared/makeQuery/_makeQuery.js
+++ b/src/Ractive/prototype/shared/makeQuery/_makeQuery.js
@@ -5,7 +5,7 @@ import sort from 'Ractive/prototype/shared/makeQuery/sort';
 import dirty from 'Ractive/prototype/shared/makeQuery/dirty';
 import remove from 'Ractive/prototype/shared/makeQuery/remove';
 
-export default function ( ractive, selector, live, isComponentQuery ) {
+export default function makeQuery ( ractive, selector, live, isComponentQuery ) {
 	var query = [];
 
 	defineProperties( query, {

--- a/src/Ractive/prototype/subtract.js
+++ b/src/Ractive/prototype/subtract.js
@@ -1,5 +1,5 @@
 import add from 'Ractive/prototype/shared/add';
 
-export default function ( keypath, d ) {
+export default function Ractive$subtract ( keypath, d ) {
 	return add( this, keypath, ( d === undefined ? -1 : -d ) );
 }

--- a/src/Ractive/prototype/teardown.js
+++ b/src/Ractive/prototype/teardown.js
@@ -4,7 +4,7 @@ import clearCache from 'shared/clearCache';
 // Teardown. This goes through the root fragment and all its children, removing observers
 // and generally cleaning up after itself
 
-export default function ( callback ) {
+export default function Ractive$teardown ( callback ) {
 	var keypath, promise, unresolvedImplicitDependency;
 
 	this.fire( 'teardown' );

--- a/src/Ractive/prototype/toHTML.js
+++ b/src/Ractive/prototype/toHTML.js
@@ -1,3 +1,3 @@
-export default function () {
+export default function Ractive$toHTML () {
 	return this.fragment.toString( true );
 }

--- a/src/Ractive/prototype/toggle.js
+++ b/src/Ractive/prototype/toggle.js
@@ -1,4 +1,4 @@
-export default function ( keypath, callback ) {
+export default function Ractive$toggle ( keypath, callback ) {
 	var value;
 
 	if ( typeof keypath !== 'string' ) {

--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -3,7 +3,7 @@ import Promise from 'utils/Promise';
 import clearCache from 'shared/clearCache';
 import notifyDependants from 'shared/notifyDependants';
 
-export default function ( keypath, callback ) {
+export default function Ractive$update ( keypath, callback ) {
 	var promise, fulfilPromise;
 
 	if ( typeof keypath === 'function' ) {


### PR DESCRIPTION
...for the sake of slightly easier debugging. Also, removes the (long since deprecated) `ractive.renderHTML()` method (which just called `ractive.toHTML()`)
