### PR TITLE
Allow Ractive.debug to be set after extend

### DIFF
--- a/src/config/options/debug.js
+++ b/src/config/options/debug.js
@@ -1,5 +1,11 @@
 import optionConfig from 'config/options/option';
+import circular from 'circular';
 
+var Ractive;
+
+circular.push( function () {
+	Ractive = circular.Ractive;
+});
 
 var config = optionConfig( 'debug' );
 
@@ -10,10 +16,15 @@ function copyFromConstructor( parent, target, options ) {
 	// if not explicitly set on options
 	if ( !( 'debug' in options ) ) {
 
-		// ok to use Parent.debug instead of Parent.defaults.debug
+		// ok to use Parent.defaults.debug
 		if ( 'debug' in parent ) {
 
 			options.debug = parent.debug;
+		}
+
+		// Ractive.defaults explicity set
+		else if ( Ractive && ( ( Ractive.defaults && Ractive.defaults.debug ) || Ractive.debug ) ) {
+			options.debug = true;
 		}
 	}
 

--- a/test/modules/config/custom.js
+++ b/test/modules/config/custom.js
@@ -10,16 +10,20 @@ define([
 
 	return function () {
 
-		module( 'Debug' );
+		module( 'Debug', {
+			teardown: () => { Ractive.debug = false; }
+		});
 
 		test( 'can be set on Ractive', function ( t ) {
-			var ractive;
+			var ractive, old = Ractive.debug;
 
 			Ractive.debug = true;
 
 			ractive = new Ractive();
 
 			t.ok( ractive.debug );
+
+			Ractive.debug = old;
 
 		});
 
@@ -35,13 +39,28 @@ define([
 		});
 
 		test( 'can be set on Ractive after extend', function ( t ) {
-			var Component, ractive;
+			var Component, ractive, old = Ractive.defaults.debug;
 
 			Component = Ractive.extend();
 			Ractive.debug = true;
 			ractive = new Component();
 
 			t.ok( ractive.debug );
+
+			Ractive.debug = old;
+
+		});
+
+		test( 'can be set on Ractive,defaults after extend', function ( t ) {
+			var Component, ractive, old = Ractive.defaults.debug;
+
+			Component = Ractive.extend();
+			Ractive.defaults.debug = true;
+			ractive = new Component();
+
+			t.ok( ractive.debug );
+
+			Ractive.defaults.debug = old;
 
 		});
 


### PR DESCRIPTION
``` js
Component = Ractive.extend();
Ractive.debug = true;
ractive = new Component();

t.ok( ractive.debug );
```
