### PR TITLE
gh-801

### DIFF
--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -151,7 +151,7 @@ function flushChanges () {
 	while ( dirty ) {
 		dirty = false;
 
-		while ( thing = modelUpdates.pop() ) {
+		while ( thing = modelUpdates.shift() ) {
 			thing.update();
 			thing.dirty = false;
 		}

--- a/test/modules/misc.js
+++ b/test/modules/misc.js
@@ -1272,6 +1272,19 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.deepEqual( ractive.get( 'array.length' ), 3 );
 		});
 
+		test( 'Regression test for #801', function ( t ) {
+			var ractive = new Ractive({
+				el: document.createElement( 'div' ),
+				template: '<div>{{#(foo !== "bar")}}not bar{{#(foo !== "baz")}}not baz{{/()}}{{/()}}</div>',
+				data: {
+					foo: 'baz'
+				}
+			});
+
+			ractive.set( 'foo', 'bar' );
+			t.ok( true );
+		});
+
 
 		// These tests run fine in the browser but not in PhantomJS. WTF I don't even.
 		// Anyway I can't be bothered to figure it out right now so I'm just commenting


### PR DESCRIPTION
This PR fixes #801, albeit not at its fundamental level - the order in which indirect changes (i.e. evaluators) propagated was incorrect. The more thorough fix involves completing the work started with #804, which will hopefully make all this data-binding code easier to follow.
