### PR TITLE
Component parameter bindings fix

### DIFF
--- a/src/shared/createComponentBinding.js
+++ b/src/shared/createComponentBinding.js
@@ -18,7 +18,7 @@ var Binding = function ( ractive, keypath, otherInstance, otherKeypath, priority
 Binding.prototype = {
 	setValue: function ( value ) {
 		// Only *you* can prevent infinite loops
-		if ( this.updating || this.counterpart && this.counterpart.updating ) {
+		if ( this.updating ) {
 			return;
 		}
 
@@ -33,8 +33,13 @@ Binding.prototype = {
 
 			// TODO maybe the case that `value === this.value` - should that result
 			// in an update rather than a set?
-			runloop.addInstance( this.otherInstance );
-			this.otherInstance.viewmodel.set( this.otherKeypath, value );
+
+			// Only *you* can prevent infinite loops... again
+			if ( !( this.counterpart && this.counterpart.updating ) ) { 
+				runloop.addInstance( this.otherInstance );
+				this.otherInstance.viewmodel.set( this.otherKeypath, value );
+			}
+
 			this.value = value;
 
 			// TODO will the counterpart update after this line, during

--- a/test/modules/components.js
+++ b/test/modules/components.js
@@ -1024,9 +1024,31 @@ define([ 'ractive' ], function ( Ractive ) {
 
 			ractive.set( 'but', 'maybe' );
 			t.htmlEqual( fixture.innerHTML, '<p>10</p><p>number: 42</p><p>I got 99 problems but type coercion ain\'t one</p><p>maybe</p>' );
-
 		});
 
+		// See issue #681
+		test( 'Inline component attributes update the value of bindings pointing to them even if they are old values', function ( t ) {
+			var Widget, ractive;
+
+			Widget = Ractive.extend({
+				template: '{{childdata}}'
+			});
+
+			ractive = new Ractive({
+				el: fixture,
+				template: '{{parentdata}} - <widget childdata="{{parentdata}}" />',
+				data: { parentdata: 'old' },
+				components: { widget: Widget }
+			});
+
+			t.htmlEqual( fixture.innerHTML, 'old - old' );
+
+			ractive.findComponent( 'widget' ).set( 'childdata', 'new' );
+			t.htmlEqual( fixture.innerHTML, 'new - new' );
+
+			ractive.set( 'parentdata', 'old' );
+			t.htmlEqual( fixture.innerHTML, 'old - old' );
+		});
 
 		asyncTest( 'Component render methods called in consistent order (gh #589)', function ( t ) {
 			var Simpson, ractive, order = { beforeInit: [], init: [], complete: [] },


### PR DESCRIPTION
This is an update to PR #682, and fixes issue #681. #682 didn't include the latest viewmodel changes. However, the included test still failed before the change, and passed after the change, so the issue is still relevant. I also cleaned up the whitespace. All other credit to @halfnelson.
