### PR TITLE
small fix for a node.js edge case

### DIFF
--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -28,6 +28,8 @@ export default function initialiseRactiveInstance ( ractive, options = {} ) {
 		owner: ractive, // saves doing `if ( this.parent ) { /*...*/ }` later on
 	});
 
+	ractive.viewmodel.applyChanges();
+
 	// render automatically ( if `el` is specified )
 	tryRender( ractive );
 }

--- a/src/virtualdom/items/Element/prototype/toString.js
+++ b/src/virtualdom/items/Element/prototype/toString.js
@@ -48,7 +48,7 @@ function optionIsSelected ( element ) {
 		return true;
 	}
 
-	if ( element.select.attributes.multiple && isArray( selectValue ) ) {
+	if ( element.select.getAttribute( 'multiple' ) && isArray( selectValue ) ) {
 		i = selectValue.length;
 		while ( i-- ) {
 			if ( selectValue[i] == optionValue ) {

--- a/src/virtualdom/items/shared/Resolvers/ReferenceExpressionResolver.js
+++ b/src/virtualdom/items/shared/Resolvers/ReferenceExpressionResolver.js
@@ -81,7 +81,7 @@ ReferenceExpressionResolver.prototype = {
 	},
 
 	rebind: function ( indexRef, newIndex, oldKeypath, newKeypath ) {
-		var changed, i, member;
+		var changed;
 
 		if ( indexRef && this.indexRefMembers.length ) {
 			this.indexRefMembers.forEach( member => {


### PR DESCRIPTION
A Ractive instance's viewmodel should be 'applied' on initialisation, not just on render, so that `ractive.toHTML()` works correctly.

~~There's [one more test](https://github.com/ractivejs/ractive/blob/dev/test/samples/render.js#L447-L452) that's failing in node.js...~~ _fixed with 13f772f938fabe5612a5a01e0ccda8f86c2d0d53_
