### PR TITLE
Correct legalReference regex

### DIFF
--- a/src/parse/converters/mustache/content.js
+++ b/src/parse/converters/mustache/content.js
@@ -7,7 +7,7 @@ var indexRefPattern = /^\s*:\s*([a-zA-Z_$][a-zA-Z_$0-9]*)/,
 	handlebarsBlockPattern = new RegExp( '^(' + Object.keys( handlebarsBlockCodes ).join( '|' ) + ')\\b' ),
 	legalReference;
 
-legalReference = /^[a-zA_Z$_0-9]+(?:(\.[a-zA_Z$_0-9]+)|(\[[a-zA_Z$_0-9]+\]))*$/;
+legalReference = /^[a-zA-Z$_0-9]+(?:(\.[a-zA-Z$_0-9]+)|(\[[a-zA-Z$_0-9]+\]))*$/;
 
 export default function ( parser, delimiterType ) {
 	var start, pos, mustache, type, block, expression, i, remaining, index, delimiters, referenceExpression;

--- a/test/samples/parse.js
+++ b/test/samples/parse.js
@@ -179,6 +179,11 @@ var parseTests = [
 		parsed: [{r:"todos.0.content",t:2}]
 	},
 	{
+		name: "Mustache references that aren't valid expressions can have uppercase",
+		template: "{{00.Content}}",
+		parsed: [{r:"00.Content",t:2}]
+	},
+	{
 		name: "Expression with keypath like foo.0.bar",
 		template: "{{( process( foo.0.bar ) )}}",
 		parsed: [{t:2,"x":{r:["process","foo.0.bar"],"s":"${0}(${1})"}}]


### PR DESCRIPTION
Fixes #850. Regression test added as well.
