### PR TITLE
BREAKING CHANGE {{else}} is not treated as a regular reference inside {{#foo}}...{{/foo}}

### DIFF
--- a/src/parse/converters/mustache.js
+++ b/src/parse/converters/mustache.js
@@ -109,6 +109,7 @@ function getMustacheOfType ( parser, delimiterType ) {
 
 					default:
 						currentChildren = elseChildren = [];
+						continue;
 				}
 			}
 

--- a/test/samples/parse.js
+++ b/test/samples/parse.js
@@ -571,30 +571,6 @@ var parseTests = [
 			'{{else}} not allowed in {{#with}} at line 1 character 31:\n{{#with foo}}with foo {{else}}no foo?{{/with}}\n                              ^----'
 	},
 	{
-		name: 'Else is just a regular interpolator in {{#}}',
-		template: '{{#foo}}with foo {{else}}no foo?{{/foo}}',
-		parsed:
-			[ { t: 4,
-			    r: 'foo',
-			    f:
-			     [ 'with foo ',
-			       { t: 2, r: 'else' },
-			       'no foo?' ] } ]
-
-	},
-	{
-		name: 'Else is just a regular interpolator in {{^}}',
-		template: '{{^foo}}not foo {{else}}no foo?{{/foo}}',
-		parsed:
-			[ { t: 4,
-				r: 'foo',
-				n: 51,
-				f:
-				 [ 'not foo ',
-				   { t: 2, r: 'else' },
-				   'no foo?' ] } ]
-	},
-	{
 		name: 'Mixed Handlebars-style and regular syntax',
 		template: '{{#foo}}normal{{/foo}}{{#if foo}}handlebars{{/if}}',
 		parsed: [{t:4,r:'foo',f:['normal']},{t:4,r:'foo',n:50,f:['handlebars']}]


### PR DESCRIPTION
Follow up to #891, implements #668. In order for this to work, `{{else}}` can't be treated as a normal reference inside sections. I'd argue that's a good thing, and that in future we should probably prevent keywords from being used as references altogether
