### PR TITLE
bind option functions to ractive instance, warn on debug no fn return

### DIFF
--- a/src/config/errors.js
+++ b/src/config/errors.js
@@ -24,5 +24,8 @@ export default {
 		'Missing "{name}" {plugin} plugin. You may need to download a {plugin} via http://docs.ractivejs.org/latest/plugins#{plugin}s',
 
 	badRadioInputBinding:
-		'A radio input can have two-way binding on its name attribute, or its checked attribute - not both'
+		'A radio input can have two-way binding on its name attribute, or its checked attribute - not both',
+
+	noRegistryFunctionReturn:
+		'A function was specified for "{name}" {registry}, but no {registry} was returned'
 };

--- a/src/virtualdom/items/Component/getComponent.js
+++ b/src/virtualdom/items/Component/getComponent.js
@@ -1,4 +1,5 @@
 import config from 'config/config';
+import log from 'utils/log';
 import circular from 'circular';
 
 var Ractive;
@@ -17,14 +18,25 @@ export default function getComponent ( ractive, name ) {
 
 		// best test we have for not Ractive.extend
 		if ( !component._parent ) {
-			// function option. execute and store for reset
-			let fn = component;
+			// function option, execute and store for reset
+			let fn = component.bind( instance );
 			fn.isOwner = instance.components.hasOwnProperty( name );
 			component = fn( instance.data );
+
+			if ( !component ) {
+				log.warn({
+					debug: ractive.debug,
+					message: 'noRegistryFunctionReturn',
+					args: { registry: 'component', name: name }
+				});
+				return;
+			}
+
 			if ( typeof component === 'string' ) {
 				//allow string lookup
 				component = getComponent ( ractive, component );
 			}
+
 			component._fn = fn;
 			instance.components[ name ] = component;
 		}

--- a/src/virtualdom/items/Partial/getPartialDescriptor.js
+++ b/src/virtualdom/items/Partial/getPartialDescriptor.js
@@ -50,10 +50,20 @@ function getPartialFromRegistry ( ractive, name ) {
 
 	// partial is a function?
 	if ( typeof partial === 'function' ) {
-		fn = partial;
+		fn = partial.bind( instance );
 		fn.isOwner = instance.partials.hasOwnProperty(name);
-		partial = partial( instance.data );
+		partial = fn( instance.data );
 	}
+
+	if ( !partial ) {
+		log.warn({
+			debug: ractive.debug,
+			message: 'noRegistryFunctionReturn',
+			args: { registry: 'partial', name: name }
+		});
+		return;
+	}
+
 	// If this was added manually to the registry,
 	// but hasn't been parsed, parse it now
 	if ( !parser.isParsed( partial ) ) {

--- a/test/modules/components.js
+++ b/test/modules/components.js
@@ -1284,6 +1284,64 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.htmlEqual( fixture.innerHTML, 'foo' );
 		});
 
+		if ( console && console.warn ) {
+
+			test( 'no return of component warns in debug', function ( t ) {
+
+				var ractive, warn = console.warn;
+
+				expect( 1 );
+
+				console.warn = function( msg ) {
+					t.ok( msg );
+				}
+
+				ractive = new Ractive({
+					el: fixture,
+					template: '<widget/>',
+					debug: true,
+					components: {
+						widget: function( data ) {
+							// where's my component?
+						}
+					}
+				});
+
+				console.warn = warn;
+
+			});
+		}
+
+		test( '`this` in function refers to ractive instance', function ( t ) {
+
+			var thisForFoo, thisForBar, ractive, Component;
+
+			Component = Ractive.extend({})
+
+			ractive = new Ractive({
+				el: fixture,
+				template: '<foo/><widget/>',
+				data: { foo: true },
+				components: {
+					widget: Ractive.extend({
+						template: '<bar/>'
+					}),
+					foo: function ( ) {
+						thisForFoo = this;
+						return Component;
+					},
+					bar: function ( ) {
+						thisForBar = this;
+						return Component;
+					}
+				}
+			});
+
+			t.equal( thisForFoo, ractive );
+			t.equal( thisForBar, ractive );
+
+		});
+
 	};
 
 });

--- a/test/modules/partials.js
+++ b/test/modules/partials.js
@@ -29,6 +29,68 @@ define([ 'ractive', 'legacy' ], function ( Ractive, legacy ) {
 
 		});
 
+		if ( console && console.warn ) {
+
+			test( 'no return of partial warns in debug', function ( t ) {
+
+				var ractive, warn = console.warn;
+
+				expect( 2 ); //throws counts as an assertion
+
+				console.warn = function( msg ) {
+					t.ok( msg );
+				}
+
+				// will throw on no-partial found
+				throws( () => {
+					ractive = new Ractive({
+						el: fixture,
+						template: '{{>foo}}',
+						data: { foo: true },
+						debug: true,
+						partials: {
+							foo: function ( data ) {
+								// where's my partial?
+							}
+						}
+					});
+				});
+
+				console.warn = warn;
+
+			});
+		}
+
+		test( '`this` in function refers to ractive instance', function ( t ) {
+
+			var thisForFoo, thisForBar, ractive;
+
+			ractive = new Ractive({
+				el: fixture,
+				template: '{{>foo}}<widget/>',
+				data: { foo: true },
+				components: {
+					widget: Ractive.extend({
+						template: '{{>bar}}'
+					})
+				},
+				partials: {
+					foo: function ( ) {
+						thisForFoo = this;
+						return 'foo';
+					},
+					bar: function ( ) {
+						thisForBar = this;
+						return 'bar';
+					}
+				}
+			});
+
+			t.equal( thisForFoo, ractive );
+			t.equal( thisForBar, ractive );
+
+		});
+
 		test( 'partial functions belong to instance, not Component', function ( t ) {
 
 			var Component, ractive1, ractive2;


### PR DESCRIPTION
Woke up and realized option functions for partials and components need to have `this` bound to ractive instance.

Writing those tests, realized need to warn if debug and no function return.
