### PR TITLE
Remove proto restrictions on data config

### DIFF
--- a/src/config/options/data.js
+++ b/src/config/options/data.js
@@ -1,4 +1,3 @@
-import create from 'utils/create';
 import wrap from 'utils/wrapMethod';
 
 var dataConfig = {
@@ -92,14 +91,9 @@ function fromProperties ( child, parent ) {
 
 	child = child || {};
 
-	if ( parent && Object.keys( parent ).length ) {
+	if ( !parent ) { return child; }
 
-		// this is same as current ractive behavior
-		// would like to revisit...
-		parent = create( parent );
-		copy( child, parent );
-		child = parent;
-	}
+	copy( parent, child, true );
 
 	return child;
 }
@@ -115,19 +109,22 @@ function fromFn ( child, parentFn ) {
 
 			// Track the keys that our on the child,
 			// but not on the data. We'll need to apply these
-			// after the parent function returns
-			keys = Object.keys( child );
+			// after the parent function returns.
+			keys = [];
 
-			if ( data ) {
-
-				keys = keys.filter( key => !( key in data ) );
+			for ( let key in child ) {
+				if ( !data || !( key in data ) ) {
+					keys.push( key );
+				}
 			}
 		}
 
 		// call the parent fn, use data if no return value
 		data = parentFn.call( this, data ) || data;
 
-		// copy child keys back onto data
+		// Copy child keys back onto data. The child keys
+		// should take precedence over whatever the
+		// parent did with the data.
 		if ( keys && keys.length ) {
 
 			data = data || {};

--- a/src/utils/wrapMethod.js
+++ b/src/utils/wrapMethod.js
@@ -1,7 +1,6 @@
-export default function ( method, superMethod ) {
+export default function ( method, superMethod, force ) {
 
-
-	if ( superMethod && typeof superMethod === 'function' && /_super/.test( method ) ) {
+	if ( force || needsSuper( method, superMethod ) )  {
 
 		return function () {
 
@@ -22,4 +21,8 @@ export default function ( method, superMethod ) {
 	else {
 		return method;
 	}
+}
+
+function needsSuper ( method, superMethod ) {
+	return typeof superMethod === 'function' && /_super/.test( method );
 }

--- a/test/modules/components.js
+++ b/test/modules/components.js
@@ -308,8 +308,6 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.htmlEqual( fixture.innerHTML, '<ul><li>0: h</li><li>1: d</li></ul><p>h d</p>' );
 		});
 
-		// TODO: Is thie correct? Or should ractive.complete call this._super?
-		// Which is current requirement within the .extend chain
 		asyncTest( 'Component complete() methods are called', function ( t ) {
 			var ractive, Widget, counter, done;
 

--- a/test/modules/config/config.js
+++ b/test/modules/config/config.js
@@ -59,12 +59,6 @@ define([
 			}
 		} );
 
-		// test( 'extended', t => {
-
-		// 	testConfiguration( Child, Ractive );
-
-		// });
-
 		module( 'Configure Instance', {
 			setup: function () {
 				configureRactive();

--- a/test/modules/initialisation/initialisation.js
+++ b/test/modules/initialisation/initialisation.js
@@ -43,10 +43,36 @@ define([ 'ractive' ], function ( Ractive ) {
 
 		});
 
-		/* Not currently true. There are number of issues that need to resolved
-		   before we could make this happen */
-		/*
+		test( 'data is inherited from grand parent extend (gh-923)', t => {
+			var Child, Grandchild, child, grandchild;
+
+			Child = Ractive.extend({
+				append: true,
+			    template: 'title:{{format(title)}}',
+			    data: {
+			        format: function(title){
+			            return title.toUpperCase();
+			        }
+			    }
+			});
+
+			Grandchild = Child.extend();
+
+			child = new Child({
+			    el: fixture,
+			    data: { title: 'child' }
+			});
+
+			grandchild = new Grandchild({
+			el: fixture,
+			    data: { title: 'grandchild' }
+			});
+
+			t.equal( fixture.innerHTML, 'title:CHILDtitle:GRANDCHILD');
+		})
+
 		test( 'Ractive instance data is used as data object', t => {
+
 			var ractive, data = { foo: 'bar' } ;
 
 			Ractive.defaults.data = { bar: 'bizz' };
@@ -56,7 +82,6 @@ define([ 'ractive' ], function ( Ractive ) {
 
 			delete Ractive.defaults.data;
 		});
-		*/
 
 		test( 'Default data function with no return uses existing data instance', t => {
 			var ractive;


### PR DESCRIPTION
When we removed clone on `.hasOwnProperty` check on `ractive.set`, I forgot there was a task to update the data config accordingly.
