### PR TITLE
Allow running 'npm test'

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "type": "git",
     "url": "https://github.com/ractivejs/ractive.git"
   },
+  "scripts": {
+    "test": "grunt test"
+  },
   "github": "https://github.com/ractivejs/ractive",
   "devDependencies": {
     "grunt": "~0.4.4",


### PR DESCRIPTION
This allows anyone to run `npm test` to invoke grunt tests, following npm conventions.

Btw, you may consider want to adding in something like `"prepublish": "grunt"`. this will simplify the development setup instructions to merely "do a git clone, then do `npm i`" since the prepublish hooks will be ran on install.
