### PR TITLE
Fix tests for 1019

### DIFF
--- a/test/modules/misc.js
+++ b/test/modules/misc.js
@@ -1309,7 +1309,7 @@ define([ 'ractive' ], function ( Ractive ) {
 		});
 
 		asyncTest( 'Regression test for #1019', function ( t ) {
-			var ractive, img;
+			var ractive, img, int, i;
 
 			ractive = new Ractive({
 				el: fixture,
@@ -1318,16 +1318,18 @@ define([ 'ractive' ], function ( Ractive ) {
 
 			img = ractive.find( 'img' );
 
-			img.addEventListener( 'load', function () {
-				setTimeout( function () {
+			i = 0;
+			int = setInterval( function () {
+				if ( img.complete || i++ === 20 ) {
+					clearInterval( int );
 					t.equal( img.width, 350 );
 					QUnit.start();
-				});
-			});
+				}
+			}, 100);
 		});
 
 		asyncTest( 'Another regression test for #1019', function ( t ) {
-			var ractive, img;
+			var ractive, img, int, i;
 
 			ractive = new Ractive({
 				el: fixture,
@@ -1336,12 +1338,14 @@ define([ 'ractive' ], function ( Ractive ) {
 
 			img = ractive.find( 'img' );
 
-			img.addEventListener( 'load', function () {
-				setTimeout( function () {
+			i = 0;
+			int = setInterval( function () {
+				if ( img.complete || i++ === 20 ) {
+					clearInterval( int );
 					t.equal( img.width, 350 );
 					QUnit.start();
-				});
-			});
+				}
+			}, 100);
 		});
 
 		test( 'Regression test for #1003', function ( t ) {


### PR DESCRIPTION
> In some versions of IE, if the image is in the browser cache, the load event will be fired immediately when the .src value is set. If your load handler is not already in place, you will miss that event.

http://stackoverflow.com/questions/12000016/image-load-not-working-with-ie-8-or-lower
