### PR TITLE
Update getObserverFacade.js

### DIFF
--- a/src/Ractive/prototype/observe/getObserverFacade.js
+++ b/src/Ractive/prototype/observe/getObserverFacade.js
@@ -38,9 +38,9 @@ export default function getObserverFacade ( ractive, keypath, callback, options 
 
 				ractive.viewmodel.patternObservers.splice( index, 1 );
 				ractive.viewmodel.unregister( keypath, observer, 'patternObservers' );
+			} else {
+				ractive.viewmodel.unregister( keypath, observer, 'observers' );
 			}
-
-			ractive.viewmodel.unregister( keypath, observer, 'observers' );
 			cancelled = true;
 		}
 	};


### PR DESCRIPTION
Added a missing 'else'. Fixes a bug where cancelling a pattern observer would (additionally) throw an error.
