### PR TITLE
Make float call compatible with our minifier.

### DIFF
--- a/src/legacy.js
+++ b/src/legacy.js
@@ -434,7 +434,7 @@ if ( !win.getComputedStyle ) {
 						style[ property ] = getPixelSize(element, currentStyle, property, fontSize) + 'px';
 					}
 				} else if (property === 'styleFloat') {
-					style.float = currentStyle[property];
+					style['float'] = currentStyle[property];
 				} else {
 					style[property] = currentStyle[property];
 				}


### PR DESCRIPTION
We really enjoy using ractive, thanks so much for this great tool. 

This is a nit to pick, but every time I update our build chain with the latest ractive, we need to fix this so our hyper-careful JS compressor doesn't complain.
