### PR TITLE
Allow components to fire events on their ancestors?

### DIFF
--- a/src/Ractive/prototype/fire.js
+++ b/src/Ractive/prototype/fire.js
@@ -1,13 +1,37 @@
+var nameOnly = /^(?:\.?\.\/)*(.*)/;
+var parents = /^((?:\.\.\/)*).*/;
+
 export default function Ractive$fire ( eventName ) {
-	var args, i, len, subscribers = this._subs[ eventName ];
+	var args, i, len, subscribers, target, ev, upCount; 
 
-	if ( !subscribers ) {
-		return;
-	}
+	upCount = eventName.match(parents)[1].split('/').length - 1;
 
-	args = Array.prototype.slice.call( arguments, 1 );
+	if ( upCount > 0 ) {
+		target = this;
+		ev = eventName.match(nameOnly)[1];
 
-	for ( i=0, len=subscribers.length; i<len; i+=1 ) {
-		subscribers[i].apply( this, args );
+		for ( i=0; i<upCount; i+=1 ) {
+			if ( !!target ) target = target._parent;
+		}
+
+		if ( !!target && typeof target.fire === 'function' ) {
+			args = Array.prototype.slice.call(arguments, 1);
+			args[ 0 ].parent = target;
+			args[ 0 ].child = this;
+			args.unshift(ev); // make sure to pass along a non-ancestor event name
+			target.fire.apply( target, args );
+		}
+	} else {
+		subscribers = this._subs[ eventName ];
+
+		if ( !subscribers ) {
+			return;
+		}
+
+		args = Array.prototype.slice.call( arguments, 1 );
+
+		for ( i=0, len=subscribers.length; i<len; i+=1 ) {
+			subscribers[i].apply( this, args );
+		}
 	}
 }


### PR DESCRIPTION
This is more of a proposal for discussion than a pull request.

When deeply nesting components, it is possible to manually bubble events up the component stack by having a boilerplate event handler that fires an event. There is already a notation for referencing up-hierarchy for references, so does it make sense to do the same for events?

This is mostly useful for components that act as containers, and as such, have a content partial as part of their template.

Given the following component

``` javascript
var cmp = Ractive.extend({
  template: '<div>{{> content }}</div>'
});
```

this would allow you to turn

``` javascript
var ractive = new Ractive({
  components: { cmp: cmp },
  template: 'other stuff <cmp on-clicked="clicked"><button on-click="clicked">Click Me</button></cmp> more other stuff',
  el: '#main'
});

ractive.on('clicked', function(e) { console.log('clicked'); });
```

into the slightly more friendly

``` javascript
var ractive = new Ractive({
  components: { cmp: cmp },
  template: 'other stuff <cmp><button on-click="../clicked">Click Me</button></cmp> more other stuff',
  el: '#main'
});

ractive.on('clicked', function(e) { console.log('clicked'); });
```

Granted, this short example doesn't show off the benefit very well, but when you get three or four levels deep with multiple events, it really starts to clear some fog. I suppose it may improve performance slightly as well since it skips intermediate events, but that wasn't really an avenue I was trying to explore.
