### PR TITLE
Fix single select attribute update

### DIFF
--- a/src/virtualdom/items/Element/Attribute/prototype/update.js
+++ b/src/virtualdom/items/Element/Attribute/prototype/update.js
@@ -32,7 +32,7 @@ export default function Attribute$update () {
 	else if ( name === 'value' ) {
 		// special case - selects
 		if ( element.name === 'select' && name === 'value' ) {
-			updateMethod = element.getAttribute( 'multiple' ) !== null ? updateMultipleSelectValue : updateSelectValue;
+			updateMethod = element.getAttribute( 'multiple' ) ? updateMultipleSelectValue : updateSelectValue;
 		}
 
 		else if ( element.name === 'textarea' ) {


### PR DESCRIPTION
Commit a99c938 broke the single select update logic a bit, 
because `element.getAttribute( 'multiple' )` returns `undefined` instead of null, 
so single select also used `updateMultipleSelectValue`.

I couldn't update select with numeric values, tweaked the test to show that.
