### PR TITLE
Add support for bubbling events

### DIFF
--- a/src/Ractive/prototype/fire.js
+++ b/src/Ractive/prototype/fire.js
@@ -1,17 +1,58 @@
-export default function Ractive$fire ( eventName, event ) {
-	var args, i, len, originalEvent, stopEvent = false, subscribers = this._subs[ eventName ];
+var sigils, doNothing;
 
-	if ( !subscribers ) {
-		return;
+sigils = /^(\**)(.*)/;
+doNothing = function () {};
+
+export default function Ractive$fire ( eventName, event ) {
+	var args, i, len, name, originalEvent, match, cmp, target, stopBubble = false, bubbleMode, stopEvent = false, subscribers;
+
+	match = sigils.exec(eventName);
+	bubbleMode = match[ 1 ].length;
+	name = match[ 2 ];
+
+	// find all of the relevant subscribers for this event
+	if ( bubbleMode === 0 ) { // no bubble
+		subscribers = [ { cmp: this, subs: this._subs[ name ] } ];
+
+		if ( !subscribers[ 0 ].subs ) {
+			return;
+		}
+	} else { // bubble
+		target = this;
+		subscribers = [];
+
+		while ( !!target ) {
+			if ( !!target._subs[ name ] ) {
+				subscribers.push( { cmp: target, subs: target._subs[ name ] } );
+				if ( bubbleMode === 1 ) target = null;
+				else target = target._parent;
+			} else {
+				target = target._parent;
+			}
+		}
+
+		if ( !subscribers ) return;
+
+		if ( !!event ) {
+			event.cancelBubble = ( bubbleMode === 1 ? doNothing : function () { stopBubble = true; });
+		}
 	}
 
 	args = Array.prototype.slice.call( arguments, 1 );
 
-	for ( i=0, len=subscribers.length; i<len; i+=1 ) {
-		if ( subscribers[ i ].apply( this, args ) === false ) {
-			stopEvent = true;
+	// fire this event on the appropriate component(s)
+	for ( cmp of subscribers ) {
+		if ( cmp.cmp !== this ) event.component = this;
+
+		for ( i=0, len=cmp.subs.length; i<len; i+=1 ) {
+			if ( cmp.subs[ i ].apply( cmp.cmp, args ) === false ) {
+				stopEvent = true;
+			}
 		}
+
+		if ( stopBubble ) break;
 	}
+
 	if ( stopEvent && ( originalEvent = event.original ) ) {
 		originalEvent.preventDefault && originalEvent.preventDefault();
 		originalEvent.stopPropagation && originalEvent.stopPropagation();


### PR DESCRIPTION
Allow the template to specify that an event should bubble to the first available handler up the component hierarchy (`*` - bubbled) or all the way to the root (`**` - double bubbled). Double bubbled events get a `cancelBubble` function added to them to stop the bubbling. I tried adding a cancelBubble to all events, but it failed a magic change test where the data is passed instead of an event.

Since ancestor events using `../` couple the publishers and subscribers, and namespaced events seem to have some other complexity issues surrounding them (how to subscribe form a template, how to change the namespace, etc) bubbling seems like the next logical attempt to cut down on event proxy boilerplate in nested component templates. It would also allow components designed to be nested to fire events up-tree by default if they so desire, and it keeps the event context available to the appropriate callbacks.

See the tests for contrived examples. Is this closer to generally useful?
