### PR TITLE
Don't discard dropped elements when using array methods

### DIFF
--- a/src/Ractive/prototype/shared/makeArrayMethod.js
+++ b/src/Ractive/prototype/shared/makeArrayMethod.js
@@ -7,7 +7,7 @@ var arrayProto = Array.prototype;
 
 export default function ( methodName ) {
 	return function ( keypath, ...args ) {
-		var array, spliceEquivalent, spliceSummary, promise;
+		var array, spliceEquivalent, spliceSummary, promise, change;
 
 		array = this.get( keypath );
 
@@ -18,7 +18,7 @@ export default function ( methodName ) {
 		spliceEquivalent = getSpliceEquivalent( array, methodName, args );
 		spliceSummary = summariseSpliceOperation( array, spliceEquivalent );
 
-		arrayProto[ methodName ].apply( array, args );
+		change = arrayProto[ methodName ].apply( array, args );
 
 		promise = runloop.start( this, true );
 		if ( spliceSummary ) {
@@ -27,6 +27,13 @@ export default function ( methodName ) {
 			this.viewmodel.mark( keypath );
 		}
 		runloop.end();
+
+		// resolve the promise with removals if applicable
+		if ( methodName === 'splice' || methodName === 'pop' || methodName === 'shift' ) {
+			promise = promise.then( function() {
+				return change;
+			} );
+		}
 
 		return promise;
 	};

--- a/test/modules/arrayMethods.js
+++ b/test/modules/arrayMethods.js
@@ -33,31 +33,39 @@ define([ 'ractive' ], function ( Ractive ) {
 				t.htmlEqual( fixture.innerHTML, '<ul><li>alice</li><li>bob</li><li>charles</li><li>dave</li></ul>' );
 			});
 
-			test( 'ractive.pop() (modifyArrays: ' + modifyArrays + ')', function ( t ) {
+			asyncTest( 'ractive.pop() (modifyArrays: ' + modifyArrays + ')', function ( t ) {
 				var items, ractive;
 
 				items = baseItems.slice();
+				expect(2);
 
 				ractive = new List({
 					el: fixture,
 					data: { items: items }
 				});
 
-				ractive.pop( 'items' );
+				ractive.pop( 'items' ).then( function(v) {
+					t.equal( v, 'charles' );
+					QUnit.start();
+				} );
 				t.htmlEqual( fixture.innerHTML, '<ul><li>alice</li><li>bob</li></ul>' );
 			});
 
-			test( 'ractive.shift() (modifyArrays: ' + modifyArrays + ')', function ( t ) {
+			asyncTest( 'ractive.shift() (modifyArrays: ' + modifyArrays + ')', function ( t ) {
 				var items, ractive;
 
 				items = baseItems.slice();
+				expect(2);
 
 				ractive = new List({
 					el: fixture,
 					data: { items: items }
 				});
 
-				ractive.shift( 'items' );
+				ractive.shift( 'items' ).then( function(v) {
+					t.equal( v, 'alice' );
+					QUnit.start();
+				} );
 				t.htmlEqual( fixture.innerHTML, '<ul><li>bob</li><li>charles</li></ul>' );
 			});
 
@@ -75,17 +83,22 @@ define([ 'ractive' ], function ( Ractive ) {
 				t.htmlEqual( fixture.innerHTML, '<ul><li>dave</li><li>alice</li><li>bob</li><li>charles</li></ul>' );
 			});
 
-			test( 'ractive.splice() (modifyArrays: ' + modifyArrays + ')', function ( t ) {
+			asyncTest( 'ractive.splice() (modifyArrays: ' + modifyArrays + ')', function ( t ) {
 				var items, ractive;
 
 				items = baseItems.slice();
+				expect(3);
 
 				ractive = new List({
 					el: fixture,
 					data: { items: items }
 				});
 
-				ractive.splice( 'items', 1, 1, 'dave', 'eric' );
+				ractive.splice( 'items', 1, 1, 'dave', 'eric' ).then( function(v) {
+					t.equal( v[0], 'bob' );
+					t.equal( v.length, 1 );
+					QUnit.start();
+				} );
 				t.htmlEqual( fixture.innerHTML, '<ul><li>alice</li><li>dave</li><li>eric</li><li>charles</li></ul>' );
 			});
 


### PR DESCRIPTION
I came across this while adding docs for array methods on ractive instances. It seems like the dropped elements should be returned for pop, shift, and slice as they are in their Array equivalents. This passes them along through the promise that is returned by the array methods.
