### PR TITLE
Convert arguments to array on reproxy

### DIFF
--- a/src/virtualdom/items/Component/initialise/propagateEvents.js
+++ b/src/virtualdom/items/Component/initialise/propagateEvents.js
@@ -34,22 +34,16 @@ function propagateEvent ( childInstance, parentInstance, eventName, proxyEventNa
 	}
 
 	childInstance.on( eventName, function () {
-		var options;
+		var event, args;
 
 		// semi-weak test, but what else? tag the event obj ._isEvent ?
 		if ( arguments[0].node ) {
-			options = {
-				event: Array.prototype.shift.call( arguments ),
-				args: arguments
-			};
-		}
-		else {
-			options = {
-				args: Array.prototype.slice.call( arguments )
-			};
+			event = Array.prototype.shift.call( arguments );
 		}
 
-		fireEvent( parentInstance, proxyEventName, options );
+		args = Array.prototype.slice.call( arguments );
+
+		fireEvent( parentInstance, proxyEventName, { event: event, args: args } );
 
 		// cancel bubbling
 		return false;

--- a/test/modules/events.js
+++ b/test/modules/events.js
@@ -1062,6 +1062,35 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.ok( true );
 		});
 
+		test( 'component "on-" handles arguments correctly', t => {
+			var Component, component, ractive;
+
+			expect( 3 );
+
+			Component = Ractive.extend({
+				template: '<span id="test" on-click="foo:\'foo\'">click me</span>'
+			});
+
+			ractive = new Ractive({
+				el: fixture,
+				template: '<component on-foo="foo-reproxy" on-bar="bar-reproxy"/>',
+				components: {
+					component: Component
+				}
+			});
+
+			ractive.on( 'foo-reproxy', ( e, arg ) => {
+				t.equal( e.original.type, 'click' );
+				t.equal( arg, 'foo' );
+			});
+			ractive.on( 'bar-reproxy', ( arg ) => {
+				t.equal( arg, 'bar' );
+			});
+
+			component = ractive.findComponent( 'component' );
+			simulant.fire( component.nodes.test, 'click' );
+			component.fire( 'bar', 'bar' );
+		});
 
 
 


### PR DESCRIPTION
Fixes error when re-proxying events on a component. Instead of individual arguments, javascript `arguments` object was getting passed.
