### PR TITLE
A test for specific event names (and possible fix).

### DIFF
--- a/src/utils/getPotentialWildcardMatches.js
+++ b/src/utils/getPotentialWildcardMatches.js
@@ -24,7 +24,7 @@ export function getPotentialWildcardMatches ( keypath ) {
 	while ( i-- ) {
 		wildcardKeypath = starMap[i].map( mapper ).join( '.' );
 
-		if ( !result[ wildcardKeypath ] ) {
+		if ( !result.hasOwnProperty( wildcardKeypath ) ) {
 			result.push( wildcardKeypath );
 			result[ wildcardKeypath ] = true;
 		}

--- a/test/modules/events.js
+++ b/test/modules/events.js
@@ -45,6 +45,25 @@ define([ 'ractive' ], function ( Ractive ) {
 			simulant.fire( node, 'click' );
 		});
 
+		test( 'sharing names with array mutator functions doesn\'t break events', t => {
+			var ractive,
+				eventNames = ['sort', 'reverse', 'push', 'pop', 'shift', 'unshift', 'fhtagn'], // the last one just tests the test
+				results = new Object(null);
+
+			expect(eventNames.length);
+
+			ractive = new Ractive({
+				el: fixture,
+				template: ''
+			});
+
+			eventNames.forEach(function(eventName) {
+				ractive.on( eventName, function () { results[eventName] = true; });
+				ractive.fire( eventName );
+				t.ok( typeof( results[eventName] ) != 'undefined', 'Event "'+eventName+'" did not fire.' );
+			});
+		});
+
 		test( 'custom event invoked and torndown', t => {
 			var ractive, custom, node;
 


### PR DESCRIPTION
As [Daslicht](http://stackoverflow.com/users/1527027/daslicht) observed over at [StackOverflow](http://stackoverflow.com/questions/25673742/ractivejs-stuck-at-tutorial-4-event-proxies) (in the comment, not in the main thingie), events named after array mutators won't fire.

Here's the [failing fiddle](http://jsfiddle.net/Writhe/qoqzve03/1/).

I tracked it down to a falsely positive check in getPotentialWildcardMatches(), patched it up, ran the tests.
It _seems_ to work.

Cheers!
