### PR TITLE
make sure data is non-primitive at init

### DIFF
--- a/src/config/options/data.js
+++ b/src/config/options/data.js
@@ -13,6 +13,10 @@ function combine( Parent, target, options ) {
 
 	var value = options.data || {},
 		parentValue = getAddedKeys( Parent.prototype.data );
+	
+	if ( typeof value !== 'object' && typeof value !== 'function') {
+		throw new TypeError( 'data option must be an object or a function, "' + value + '" is not valid' );
+	}
 
 	return dispatch( parentValue, value );
 }
@@ -31,11 +35,6 @@ function init ( Parent, ractive, options ) {
 	if ( typeof result === 'function' ) {
 
 		result = result.call( ractive, value ) || value;
-	}
-
-	// make sure things that can't have properties slip through
-	if ( typeof result !== 'object' && typeof result !== 'function' ) {
-		result = {};
 	}
 
 	return ractive.data = result || {};

--- a/test/modules/initialisation/initialisation.js
+++ b/test/modules/initialisation/initialisation.js
@@ -217,18 +217,18 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.equal( fixture.innerHTML, 'barbizz' );
 		});
 
-		test( 'initing data with a primitive uses a fresh empty object instead', t => {
-			var ractive = new Ractive({
-				el: fixture,
-				template: '{{ test }}',
-				data: 1
-			});
+		test( 'initing data with a primitive results in an error', t => {
+			expect( 1 );
 
-			t.equal( fixture.innerHTML, '' );
-
-			ractive.set( 'test', 'foo' );
-
-			t.equal( fixture.innerHTML, 'foo' );
+			try {
+				var ractive = new Ractive({
+					el: fixture,
+					template: '{{ test }}',
+					data: 1
+				});
+			} catch ( ex ) {
+				t.equal( ex.message, 'data option must be an object or a function, "1" is not valid' );
+			}
 		});
 
 		test( 'Instantiated .extend() with data uses existing data instance', t => {


### PR DESCRIPTION
@martypdx Better than an error message for #1208?

I had a change that added a check and better error message for when data is a primitive, but I figured it was a little more friendly to fix the problem at init in the same way that falsey data is. This still won't handle the case that the ractive.data gets set to a primitive after init. Though I'm of the opinion that if you mess with ractive.data directly after init, you should probably expect zalgo to sally forth.
