### PR TITLE
Make sure yielder fragment has the same parent element as the yield

### DIFF
--- a/src/virtualdom/items/Yielder.js
+++ b/src/virtualdom/items/Yielder.js
@@ -22,7 +22,8 @@ var Yielder = function ( options ) {
 	this.fragment = new Fragment({
 		owner: this,
 		root: componentInstance.yield.instance,
-		template: componentInstance.yield.template
+		template: componentInstance.yield.template,
+		pElement: this.surrogateParent.pElement
 	});
 
 	component.yielder = this;

--- a/test/modules/yield.js
+++ b/test/modules/yield.js
@@ -157,6 +157,30 @@ define([ 'ractive' ], function ( Ractive ) {
 
 			t.htmlEqual( fixture.innerHTML, 'cayield' );
 		});
+
+		test( 'A component {{yield}} should be parented by the fragment holding the yield and not the fragment holding the component', t => {
+			let template, widget;
+
+			template = `<widget foo='{{foo}}'>
+				{{#if foo}}foo!{{/if}}
+				{{#if foo}}foo!{{/if}}
+			</widget>`;
+
+			widget = Ractive.extend({
+				template: '<div>{{yield}}</div>',
+				data: {
+					foo: true
+				}
+			});
+
+			new Ractive({
+				el: fixture,
+				template: template,
+				components: { widget }
+			});
+
+			t.htmlEqual( fixture.innerHTML, '<div>foo! foo!</div>' );
+		});
 	};
 
 });


### PR DESCRIPTION
This should address #1206.

@Rich-Harris I don't foresee a scenario in which surrogateParent is missing, but just to be sure, should there be one?
