### PR TITLE
add support for . references to root

### DIFF
--- a/src/virtualdom/items/shared/Resolvers/ExpressionResolver.js
+++ b/src/virtualdom/items/shared/Resolvers/ExpressionResolver.js
@@ -45,6 +45,9 @@ var ExpressionResolver = function ( owner, parentFragment, expression, callback 
 		if ( keypath = resolveRef( ractive, reference, parentFragment ) ) {
 			args[i] = { keypath: keypath };
 			return;
+		} else if ( reference === '.' ) { // special case of context reference to root
+			args[i] = { '': '' };
+			return;
 		}
 
 		// Couldn't resolve yet

--- a/test/modules/misc.js
+++ b/test/modules/misc.js
@@ -1538,6 +1538,16 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.equal( two.getAttribute( 'spellchecker' ), 'false' );
 		});
 
+		test( '. reference without any implicit or explicit context should resolve to root', t => {
+			var ractive = new Ractive({
+				el: fixture,
+				template: '{{JSON.stringify(.)}}',
+				data: { foo: 'bar' }
+			});
+
+			t.equal( fixture.innerHTML, JSON.stringify( ractive.data ) );
+		});
+
 		// These tests run fine in the browser but not in PhantomJS. WTF I don't even.
 		// Anyway I can't be bothered to figure it out right now so I'm just commenting
 		// these out so it will build


### PR DESCRIPTION
Should resolve #1204

This was a fun trip through the plumbing of references and resolutions. I believe this is the best spot to fix this as a special case. Since `resolveRef` takes the ancestor path and there is no base context, it returns the falsey empty string. The viewmodel already handles resolving the empty string keypath in the desired way.

Does that sound right?
