### PR TITLE
make style elements work in ie8

### DIFF
--- a/src/legacy.js
+++ b/src/legacy.js
@@ -261,6 +261,9 @@ if ( typeof window === 'undefined' ) {
 		((function(win, doc) {
 			var Event, addEventListener, removeEventListener, head, style, origCreateElement;
 
+			// because sometimes inquiring minds want to know
+			win.appearsToBeIELessEqual8 = true;
+
 			Event = function ( e, element ) {
 				var property, instance = this;
 

--- a/src/virtualdom/items/Element/prototype/render.js
+++ b/src/virtualdom/items/Element/prototype/render.js
@@ -15,6 +15,11 @@ var updateCss, updateScript;
 updateCss = function () {
 	var node = this.node, content = this.fragment.toString( false );
 
+	// IE8 has no styleSheet unless there's a type text/css
+	if ( window && window.appearsToBeIELessEqual8 ) {
+		node.type = 'text/css';
+	}
+
 	if ( node.styleSheet ) {
 		node.styleSheet.cssText = content;
 	} else {


### PR DESCRIPTION
@gkindel reported a few more issues on the end of #745, including a bug with style elements on ie8. Unfortunately, I'm stuck supporting ie8... _\_single tear**

This fixes the issue, but adding the type to all style elements breaks some tests. So I did the quick-and-ugly thing and added a flag on window from legacy.js to make it easy to target our old busted friend. Maybe one day we'll hit him. Also the usual caveat of "I don't actually have ie8, so this is ie11 in ie8 mode" applies.

Is this acceptable?
