### PR TITLE
Enable computed properties to "see" parent data on init (#1278)

### DIFF
--- a/src/Ractive/prototype/get.js
+++ b/src/Ractive/prototype/get.js
@@ -10,7 +10,7 @@ export default function Ractive$get ( keypath ) {
 	value = this.viewmodel.get( keypath, options );
 
 	// Create inter-component binding, if necessary
-	if ( value === undefined && this._parent && !this.isolated && this.fragment ) {
+	if ( value === undefined && this._parent && !this.isolated ) {
 		if ( resolveRef( this, keypath, this.fragment ) ) { // creates binding as side-effect, if appropriate
 			value = this.viewmodel.get( keypath );
 		}

--- a/src/shared/resolveRef.js
+++ b/src/shared/resolveRef.js
@@ -36,6 +36,9 @@ export default function resolveRef ( ractive, ref, fragment, isParentLookup ) {
 	// ...otherwise we need to find the keypath
 	key = ref.split( '.' )[0];
 
+	// get() in viewmodel creation means no fragment (yet)
+	fragment = fragment || {};
+
 	do {
 		context = fragment.context;
 

--- a/test/modules/computations.js
+++ b/test/modules/computations.js
@@ -292,6 +292,37 @@ define([ 'ractive' ], function ( Ractive ) {
 
 		});
 
+		test( 'Unresolved computations resolve when parent component data exists', function ( t ) {
+			var ractive, Component;
+
+			Component = Ractive.extend({
+			    template: '{{FOO}} {{BAR}}',
+			    computed: {
+			        FOO: '${foo}.toUpperCase()',
+			        BAR: function () {
+			            return this.get( 'bar' ).toUpperCase();
+			        }
+			    }
+			});
+
+			ractive = new Ractive({
+			    el: fixture,
+			    template: '<component/>',
+			    data: {
+			        foo: 'fee fi',
+			        bar: 'fo fum'
+			    },
+			    components: {
+			    	component: Component
+			    }
+			});
+
+			t.equal( fixture.innerHTML, 'FEE FI FO FUM' );
+
+		});
+
+
+
 	};
 
 });


### PR DESCRIPTION
Well, this was deceptively simply. Rather than guarding `resolveRef` call in `ractive.get()`, just allow it to proceed with no fragment adn guard in `resolveRef`.
