### PR TITLE
Better event deprecation message for init

### DIFF
--- a/src/Ractive/prototype/shared/hooks/Hook.js
+++ b/src/Ractive/prototype/shared/hooks/Hook.js
@@ -1,17 +1,23 @@
 import log from 'utils/log';
 
-// TODO: depricate in future release
-var deprications = {
+// TODO: deprecate in future release
+var deprecations = {
 	construct: {
-		depricated: 'beforeInit',
+		deprecated: 'beforeInit',
 		replacement: 'onconstruct'
 	},
 	render: {
-		depricated: 'init',
-		replacement: 'onrender'
+		deprecated: 'init',
+		message: 'The "init" method has been deprecated ' +
+			'and will likely be removed in a future release. ' +
+			'You can either use the "oninit" method which will fire ' +
+			'only once prior to, and regardless of, any eventual ractive ' +
+			'instance being rendered, or if you need to access the ' +
+			'rendered DOM, use "onrender" instead. ' +
+			'See http://docs.ractivejs.org/latest/migrating for more information.'
 	},
 	complete: {
-		depricated: 'complete',
+		deprecated: 'complete',
 		replacement: 'oncomplete'
 	}
 };
@@ -19,7 +25,7 @@ var deprications = {
 function Hook ( event ) {
 	this.event = event;
 	this.method = 'on' + event;
-	this.depricate = deprications[ event ];
+	this.deprecate = deprecations[ event ];
 }
 
 Hook.prototype.fire = function ( ractive, arg ) {
@@ -33,11 +39,11 @@ Hook.prototype.fire = function ( ractive, arg ) {
 
 	call( this.method );
 
-	if ( this.depricate && call( this.depricate.depricated ) ) {
-		log.warn({
+	if ( this.deprecate && call( this.deprecate.deprecated ) ) {
+		log.warnAlways({
 			debug: ractive.debug,
-			message: 'methodDepricated',
-			args: this.depricate
+			message: this.deprecate.message || 'methodDeprecated',
+			args: this.deprecate
 		});
 	}
 

--- a/src/config/errors.js
+++ b/src/config/errors.js
@@ -38,6 +38,6 @@ export default {
 	noElementProxyEventWildcards:
 		'Only component proxy-events may contain "*" wildcards, <{element} on-{event}/> is not valid.',
 
-	methodDepricated:
-		'The method "{depricated}" has been depricated in favor of "{replacement}" and will likely be removed in a future release.'
+	methodDeprecated:
+		'The method "{deprecated}" has been deprecated in favor of "{replacement}" and will likely be removed in a future release. See http://docs.ractivejs.org/latest/migrating for more information.'
 };

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -4,6 +4,9 @@ import errors from 'config/errors';
 var log = {
 	warn: function ( options, passthru ) {
 		if ( !options.debug && !passthru ) { return; }
+		this.warnAlways( options );
+	},
+	warnAlways: function ( options ) {
 		this.logger( getMessage( options), options.allowDuplicates );
 	},
 	error: function ( options ) {

--- a/src/utils/warn.js
+++ b/src/utils/warn.js
@@ -11,7 +11,7 @@ if ( typeof console !== 'undefined' && typeof console.warn === 'function' && typ
 			warned[ message ] = true;
 		}
 
-		console.warn( message );
+		console.warn( '%cRactive.js: %c' + message, 'color: rgb(114, 157, 52);', 'color: rgb(85, 85, 85);' );
 	};
 } else {
 	warn = function () {};


### PR DESCRIPTION
See https://github.com/ractivejs/ractive/pull/1279#issuecomment-58096321

Also a trial of more naggy console warn for deprecations, no silence when debug is false.
