### PR TITLE
Allow HTML inside attributes. Fixes #1322

### DIFF
--- a/src/parse/converters/element.js
+++ b/src/parse/converters/element.js
@@ -61,7 +61,7 @@ function getElement ( parser ) {
 
 	start = parser.pos;
 
-	if ( parser.inside ) {
+	if ( parser.inside || parser.inAttribute ) {
 		return null;
 	}
 

--- a/src/parse/converters/text.js
+++ b/src/parse/converters/text.js
@@ -11,7 +11,6 @@ export default function ( parser ) {
 		index = remaining.indexOf( barrier );
 	} else {
 		disallowed = [
-			barrier,
 			parser.delimiters[0],
 			parser.tripleDelimiters[0],
 			parser.staticDelimiters[0],
@@ -21,10 +20,12 @@ export default function ( parser ) {
 		// http://developers.whatwg.org/syntax.html#syntax-attributes
 		if ( parser.inAttribute === true ) {
 			// we're inside an unquoted attribute value
-			disallowed.push( '"', "'", '=', '>', '`' );
+			disallowed.push( '"', "'", '=', '<', '>', '`' );
 		} else if ( parser.inAttribute ) {
 			// quoted attribute value
 			disallowed.push( parser.inAttribute );
+		} else {
+			disallowed.push( barrier );
 		}
 
 		index = getLowestIndex( remaining, disallowed );

--- a/test/samples/parse.js
+++ b/test/samples/parse.js
@@ -695,6 +695,16 @@ var parseTests = [
 		name: '{{else}} block in attribute',
 		template: '<img src="{{#if mobile}}small{{else}}big{{/if}}.png">',
 		parsed: {v:1,t:[{t:7,e:'img',a:{src:[{t:4,r:'mobile',n:50,f:['small']},{t:4,r:'mobile',n:51,f:['big']},'.png']}}]}
+	},
+	{
+		name: 'Attributes can contain HTML (#1322)',
+		template: '<div data-attr="{{#each array}}<div>{{this}}</div>{{/each}}"></div>',
+		parsed: {v:1,t:[{t:7,e:'div',a:{'data-attr':[{t:4,n:52,r:'array',f:['<div>',{t:2,r:'.'},'</div>']}]}}]}
+	},
+	{
+		name: 'Attributes can contain HTML (#1322)',
+		template: '<div data-attr=\'{{#each array}}<div>{{this}}</div>{{/each}}\'></div>',
+		parsed: {v:1,t:[{t:7,e:'div',a:{'data-attr':[{t:4,n:52,r:'array',f:['<div>',{t:2,r:'.'},'</div>']}]}}]}
 	}
 ];
 


### PR DESCRIPTION
This includes a breaking change - since attributes were parsed using `element` converter first, it was possible to use characters that aren't allowed inside unquoted attributes, e.g. `<div data-attr=<p></p>></div>` would be parsed correctly. This is no longer the case as it was probably a bug too. @ractivejs/team-ractive let me know if you think we should keep on supporting that.
