### PR TITLE
fix nameless partial expression exception if there is no matching partial

### DIFF
--- a/src/config/options/template/parser.js
+++ b/src/config/options/template/parser.js
@@ -58,7 +58,7 @@ function fromId ( id, options ) {
 }
 
 function isHashedId ( id ) {
-	return ( id.charAt( 0 ) === '#' ); // TODO what about `id[0]`, does that work everywhere?
+	return ( id && id.charAt( 0 ) === '#' ); // TODO what about `id[0]`, does that work everywhere?
 }
 
 function isParsed ( template) {

--- a/src/virtualdom/items/Partial/_Partial.js
+++ b/src/virtualdom/items/Partial/_Partial.js
@@ -104,7 +104,7 @@ Partial.prototype = {
 		// we may be here if we have a partial like `{{>foo}}` and `foo` is the
 		// name of both a data property (whose value ISN'T the name of a partial)
 		// and a partial. In those cases, this becomes a named partial
-		if ( !template && ( template = getPartialTemplate( this.root, this.name ) ) ) {
+		if ( !template && this.name && ( template = getPartialTemplate( this.root, this.name ) ) ) {
 			unbind.call( this );
 			this.isNamed = true;
 		}

--- a/test/modules/partials.js
+++ b/test/modules/partials.js
@@ -349,6 +349,15 @@ define([ 'ractive', 'legacy' ], function ( Ractive, legacy ) {
 
 			t.htmlEqual( ractive.toHTML(), 'number123texthello' );
 		});
+
+		test( 'Nameless expressions with no matching partial don\'t throw', ( t ) => {
+			var ractive = new Ractive({
+				el: fixture,
+				template: "{{> 'miss' + 'ing' }}"
+			});
+
+			t.htmlEqual( ractive.toHTML(), '' );
+		});
 	};
 
 });


### PR DESCRIPTION
`{{> 'some' + 'missing' + 'partial' }}` doesn't match a partial and doesn't have a name, so it throws an exception in `isHashedId`. This skips looking up a partial by name if there is no name.

It also, guards against falsey values in `isHashedId` for posterity.
