### PR TITLE
make sure ./ notation in references survives parsing

### DIFF
--- a/src/parse/Parser/expressions/primary/reference.js
+++ b/src/parse/Parser/expressions/primary/reference.js
@@ -42,7 +42,7 @@ export default function ( parser ) {
 
 	if ( !ancestor ) {
 		// we might have an implicit iterator or a restricted reference
-		dot = parser.matchString( '.' ) || '';
+		dot = parser.matchString( './' ) || parser.matchString( '.' ) || '';
 	}
 
 	name = parser.matchPattern( /^@(?:index|key)/ ) || parser.matchPattern( patterns.name ) || '';

--- a/test/samples/render.js
+++ b/test/samples/render.js
@@ -333,6 +333,12 @@ var renderTests = [
 		result: '<p>baz</p><p>bar</p><p>foo</p>'
 	},
 	{
+		name: 'Restricted references',
+		template: '<pre>{{#foo}}{{bar}} {{.bar}} {{./bar}} {{baz}} {{.baz}} {{./baz}}{{/foo}}</pre>',
+		data: { bar: 'bartop', baz: 'baztop', foo: { bar: 'barfoo' } },
+		result: '<pre>barfoo barfoo barfoo baztop  </pre>'
+	},
+	{
 		name: 'Conditional expression with unresolved condition',
 		template: '{{ foobar ? "YES" : "NO"}}',
 		data: {},


### PR DESCRIPTION
This matches the `./` before the `.` case in a restricted reference so that the `/` doesn't get turned into an operator. See #1175 
