### PR TITLE
add console to supported globals, for easy logging

### DIFF
--- a/src/parse/Parser/expressions/primary/reference.js
+++ b/src/parse/Parser/expressions/primary/reference.js
@@ -17,7 +17,7 @@ getArrayRefinement = function ( parser ) {
 arrayMemberPattern = /^\[(0|[1-9][0-9]*)\]/;
 
 // if a reference is a browser global, we don't deference it later, so it needs special treatment
-globals = /^(?:Array|Date|RegExp|decodeURIComponent|decodeURI|encodeURIComponent|encodeURI|isFinite|isNaN|parseFloat|parseInt|JSON|Math|NaN|undefined|null)$/;
+globals = /^(?:Array|console|Date|RegExp|decodeURIComponent|decodeURI|encodeURIComponent|encodeURI|isFinite|isNaN|parseFloat|parseInt|JSON|Math|NaN|undefined|null)$/;
 
 // keywords are not valid references, with the exception of `this`
 keywords = /^(?:break|case|catch|continue|debugger|default|delete|do|else|finally|for|function|if|in|instanceof|new|return|switch|throw|try|typeof|var|void|while|with)$/;


### PR DESCRIPTION
This PR makes it possible to do this sort of thing:

``` js
ractive = new Ractive({
  el: 'body',
  template: '{{ console.log("the answer is " + (a+b) ) }}',
  data: { a: 40, b: 2 }
});
```

Makes it nice and easy to debug stuff. Can anyone think of a good reason _not_ to do this?
