### PR TITLE
Prevent setting computed props with no setter across component bindings (#1357)

### DIFF
--- a/test/modules/computations.js
+++ b/test/modules/computations.js
@@ -421,6 +421,33 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.deepEqual( count, { foo: 3, bar: 2, baz: 3, qux: 1 });
 		});
 
+		test( 'Computations don\'t mistakenly set when used in components (#1357)', function ( t ) {
+			var ractive, Component;
+
+			Component = Ractive.extend({
+				template: "{{ a }}:{{ b }}",
+			    computed: {
+			        b: function() {
+			            var a = this.get("a");
+			            return a + "bar";
+			        }
+			    }
+			});
+
+			ractive = new Ractive({
+			    el: fixture,
+			    template: '{{ a }}:{{ b }}-<component a="{{ a }}" b="{{ b }}" />',
+				components: {
+			        component: Component
+			    },
+			    data: {
+			        a: "foo"
+			    }
+			});
+
+			t.equal( fixture.innerHTML, 'foo:foobar-foo:foobar' );
+		})
+
 	};
 
 });


### PR DESCRIPTION
Avoid setting a computed property that doesn't have a setter that's involved in a component binding.

This seems rather odd, but I think it's the right thing to do, as it will fail otherwise. See #1357 
