### PR TITLE
fixes #1367

### DIFF
--- a/src/Ractive/prototype/render.js
+++ b/src/Ractive/prototype/render.js
@@ -1,16 +1,13 @@
 import css from 'global/css';
 import Hook from 'Ractive/prototype/shared/hooks/Hook';
-import HookQueue from 'Ractive/prototype/shared/hooks/HookQueue';
 import getElement from 'utils/getElement';
 import runloop from 'global/runloop';
 
-var renderHook = new HookQueue( 'render' ),
+var renderHook = new Hook( 'render' ),
 	completeHook = new Hook( 'complete' );
 
 export default function Ractive$render ( target, anchor ) {
 	var promise, instances, transitionsEnabled;
-
-	renderHook.begin( this );
 
 	// if `noIntro` is `true`, temporarily disable transitions
 	transitionsEnabled = this.transitionsEnabled;
@@ -19,6 +16,7 @@ export default function Ractive$render ( target, anchor ) {
 	}
 
 	promise = runloop.start( this, true );
+	runloop.scheduleTask( () => renderHook.fire( this ), true );
 
 	if ( this.fragment.rendered ) {
 		throw new Error( 'You cannot call ractive.render() on an already rendered instance! Call ractive.unrender() first' );
@@ -48,8 +46,6 @@ export default function Ractive$render ( target, anchor ) {
 			target.appendChild( this.fragment.render() );
 		}
 	}
-
-	renderHook.end( this );
 
 	runloop.end();
 

--- a/test/modules/init/hooks.js
+++ b/test/modules/init/hooks.js
@@ -304,6 +304,36 @@ define([ 'ractive' ], function ( Ractive ) {
 
 		});
 
+		test( 'render hooks are not fired until after DOM updates (#1367)', function ( t ) {
+			var ractive = new Ractive({
+				el: fixture,
+				template: '<one/>',
+				components: {
+					one: Ractive.extend({
+						template: `
+							{{#if bool}}
+								<p></p>
+							{{/if}}
+
+							{{#if bool}}
+								<two/>
+							{{/if}}`
+					}),
+					two: Ractive.extend({
+						onrender: function () {
+							this._parent.find( 'whatever' );
+						}
+					})
+				}
+			});
+
+			expect( 0 );
+
+			// If the `<one>` component is not rendered, the `<two>` component's
+			// render handler will cause an error
+			ractive.set( 'bool', true );
+		});
+
 		// Hold off on these until demand for them.
 		// also an issue is that reserve event checking
 		// currently happens at parse time, so that


### PR DESCRIPTION
This is my proposed fix for #1367. @martypdx could you take a look at this when you get a chance please? It affects lifecycle hooks, and I want to make sure I'm not doing something wrong here.

Rather than firing `render` hooks _before_ `runloop.end`, this schedules it for later, when all views have been updated - so any given component's `onrender` hook is guaranteed to only fire once the DOM is in sync with Ractive.
