### PR TITLE
Allow contenteditable attributes to be bindable

### DIFF
--- a/src/virtualdom/items/Element/prototype/init/createTwowayBinding.js
+++ b/src/virtualdom/items/Element/prototype/init/createTwowayBinding.js
@@ -21,7 +21,12 @@ export default function createTwowayBinding ( element ) {
 	}
 
 	// contenteditable
-	if ( element.getAttribute( 'contenteditable' ) && isBindable( attributes.value ) ) {
+	if (
+		// if the contenteditable attribute is true or is bindable and may thus become true
+		( element.getAttribute( 'contenteditable' ) || ( !!attributes.contenteditable && isBindable( attributes.contenteditable ) ) )
+		// and this element also has a value attribute to bind
+		&& isBindable( attributes.value )
+	) {
 		Binding = ContentEditableBinding;
 	}
 

--- a/test/modules/twoway.js
+++ b/test/modules/twoway.js
@@ -140,6 +140,21 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.htmlEqual( fixture.innerHTML, '<div contenteditable="true"><p>some different content</p></div>' );
 		});
 
+		test( 'Contenteditable elements can be bound with a bindable contenteditable attribute.', ( t ) => {
+			var div, ractive = new Ractive({
+				el: fixture,
+				template: '<div contenteditable="{{editable}}" value="{{content}}"><strong>some content</strong></div>',
+				data: { editable: false }
+			});
+
+			div = ractive.find( 'div' );
+			div.innerHTML = 'foo';
+			simulant.fire( div, 'change' );
+
+			t.equal( div.innerHTML, ractive.get( 'content' ) );
+			t.equal( ractive.get( 'content' ), 'foo' );
+		});
+
 		test( 'Existing model data overrides contents of contenteditable elements', function ( t ) {
 			var ractive = new Ractive({
 				el: fixture,


### PR DESCRIPTION
This should address #1365

Is this `if` ok? I didn't see any immediate examples of coding convention for long conditionals that could bear explanation inline.
