### PR TITLE
Make sure computation changes cascade

### DIFF
--- a/src/viewmodel/prototype/applyChanges.js
+++ b/src/viewmodel/prototype/applyChanges.js
@@ -53,6 +53,7 @@ export default function Viewmodel$applyChanges () {
 
 			keys = dependants.map( getKey );
 			keys.forEach( mark );
+			keys.forEach( cascade );
 		}
 	});
 

--- a/test/modules/computations.js
+++ b/test/modules/computations.js
@@ -448,6 +448,23 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.equal( fixture.innerHTML, 'foo:foobar-foo:foobar' );
 		})
 
+		test( 'Computations depending up computed values cascade while updating (#1383)', ( t ) => {
+			var ractive = new Ractive({
+				el: fixture,
+				template: '{{#if a < 10}}less{{else}}more{{/if}}',
+				data: {
+					b: { c: 0 }
+				},
+				computed: {
+					a: function() { return this.get('b').c; }
+				}
+			});
+
+			t.equal( fixture.innerHTML, 'less' );
+			ractive.set( 'b.c', 100 );
+			t.equal( fixture.innerHTML, 'more' );
+		});
+
 	};
 
 });


### PR DESCRIPTION
This fixes #1383. It adds a cascade round for dependencies of computations so that any computations referencing them will also be updated. I don't think this will cause issues, but I I'm not positive...
