### PR TITLE
Play binding ping-pong until the ball comes to rest

### DIFF
--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -43,9 +43,13 @@ runloop = {
 		if ( batch ) {
 			if ( batch.viewmodels.indexOf( viewmodel ) === -1 ) {
 				batch.viewmodels.push( viewmodel );
+				return true;
+			} else {
+				return false;
 			}
 		} else {
 			viewmodel.applyChanges();
+			return false;
 		}
 	},
 

--- a/src/shared/createComponentBinding.js
+++ b/src/shared/createComponentBinding.js
@@ -48,7 +48,10 @@ Binding.prototype = {
 			// TODO maybe the case that `value === this.value` - should that result
 			// in an update rather than a set?
 
-			runloop.addViewmodel( other = this.otherInstance.viewmodel );
+			// if the other viewmodel is already locked up, need to do a deferred update
+			if ( !runloop.addViewmodel( other = this.otherInstance.viewmodel ) && this.counterpart.value !== value ) {
+				runloop.scheduleTask( () => runloop.addViewmodel( other ) );
+			}
 
 
 			if ( newIndices ) {

--- a/test/modules/components.js
+++ b/test/modules/components.js
@@ -1730,6 +1730,26 @@ define([ 'ractive', 'helpers/Model', 'utils/log' ], function ( Ractive, Model, l
 			t.htmlEqual( fixture.innerHTML, 'forget quarrel' );
 		});
 
+		test( 'Binding from parent to computation on child that is bound to parent should update properly (#1357)', ( t ) => {
+			var ractive = new Ractive({
+				el: fixture,
+				template: '{{b}} <component a="{{a}}" b="{{b}}" />',
+				data: { a: 'a' },
+				components: {
+					component: Ractive.extend({
+						template: '{{a}} {{b}}',
+						computed: {
+							b: function() { return 'foo' + this.get('a'); }
+						}
+					})
+				}
+			});
+
+			t.htmlEqual( fixture.innerHTML, 'fooa a fooa' );
+			ractive.set( 'a', 'bar' );
+			t.htmlEqual( fixture.innerHTML, 'foobar bar foobar' );
+		});
+
 	};
 
 });


### PR DESCRIPTION
This one was a little chewy. The viewmodel for a binding can't be added to the runloop in the current sub-turn if it was the original source of the change. So, in cases where a value in root changes a computation in child that is bound to root, the root can not be updated because it is already being churned. Scheduling an additional sub-turn of the runloop gets around that, but I'm not positive that it won't have other negative effects if there are lots of strange dependencies between root and components.

The only reason this sort-of worked before was the `changes` hanging around in the root viewmodel would get picked up in subsequent turns of the runloop, usually one or two down the line.
