### PR TITLE
Make name bound checkboxes uncheck if their value is dropped

### DIFF
--- a/src/virtualdom/items/Element/Attribute/prototype/update/updateCheckboxName.js
+++ b/src/virtualdom/items/Element/Attribute/prototype/update/updateCheckboxName.js
@@ -15,5 +15,6 @@ export default function Attribute$updateCheckboxName () {
 				return;
 			}
 		}
+		node.checked = false;
 	}
 }

--- a/test/modules/twoway.js
+++ b/test/modules/twoway.js
@@ -539,6 +539,11 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.ok( checkboxes[0].checked );
 			t.ok( checkboxes[1].checked );
 			t.ok( checkboxes[2].checked );
+
+			ractive.shift( 'array' );
+
+			t.ok( !checkboxes[0].checked );
+			t.ok( checkboxes[1].checked );
 		});
 
 		test( 'input[type="checkbox"] works with array of numeric values (#1305)', function ( t ) {


### PR DESCRIPTION
I think name bound checkboxes should uncheck if their value is popped, shifted, or spliced out. This popped up from #1390
