### PR TITLE
Add support for this.event for method handlers

### DIFF
--- a/src/virtualdom/items/Element/EventHandler/prototype/init.js
+++ b/src/virtualdom/items/Element/EventHandler/prototype/init.js
@@ -126,8 +126,12 @@ function fireMethodCall ( event ) {
 		return value;
 	});
 
+	ractive.event = event;
+
 	args = this.fn.apply( null, values );
 	ractive[ this.method ].apply( ractive, args );
+
+	delete ractive.event;
 }
 
 function fireEventWithParams ( event ) {

--- a/test/modules/events.js
+++ b/test/modules/events.js
@@ -820,6 +820,20 @@ define([ 'ractive' ], function ( Ractive ) {
 			simulant.fire( ractive.find( 'button' ), 'click' );
 		});
 
+		test( 'Current event is available to method handler as this.event (#1403)', t => {
+			var ractive = new Ractive({
+				el: fixture,
+				template: '<button on-click="test(event)"></button>',
+				test: function( event ) {
+					t.equal( event, this.event );
+					t.equal( ractive, this );
+				}
+			});
+
+			expect( 2 );
+			simulant.fire( ractive.find( 'button' ), 'click' );
+		});
+
 
 		var Component, Middle, View, setup;
 


### PR DESCRIPTION
Was there a reason not too? Seems like this would be useful for not having to explicitly add the event argument. It also makes the API a little more consistent.

Fixes #1403 
