### PR TITLE
different treatment of internal/external init options

### DIFF
--- a/src/config/defaults/options.js
+++ b/src/config/defaults/options.js
@@ -6,7 +6,6 @@ var defaultOptions = {
 
 	// template:
 	template:           {v:1,t:[]},
-	yield:              null,
 
 	// parse:
 	preserveWhitespace: false,
@@ -15,7 +14,6 @@ var defaultOptions = {
 
 	// data & binding:
 	data:               {},
-	mappings:           {},
 	computed:           {},
 	magic:              false,
 	modifyArrays:       true,

--- a/src/viewmodel/Viewmodel.js
+++ b/src/viewmodel/Viewmodel.js
@@ -28,7 +28,7 @@ catch ( err ) {
 	noMagic = true; // no magic in this environment :(
 }
 
-var Viewmodel = function ( ractive ) {
+var Viewmodel = function ( ractive, mappings ) {
 	var key, mapping;
 
 	this.ractive = ractive; // TODO eventually, we shouldn't need this reference
@@ -37,8 +37,8 @@ var Viewmodel = function ( ractive ) {
 
 	// set up explicit mappings
 	this.mappings = create( null );
-	for ( key in ractive.mappings ) { // TODO shouldn't live on ractive, even temporarily
-		this.map( key, ractive.mappings[ key ] );
+	for ( key in mappings ) {
+		this.map( key, mappings[ key ] );
 	}
 
 	// if data exists locally, but is missing on the parent,

--- a/src/virtualdom/items/Yielder.js
+++ b/src/virtualdom/items/Yielder.js
@@ -19,8 +19,8 @@ var Yielder = function ( options ) {
 
 	this.fragment = new Fragment({
 		owner: this,
-		root: componentInstance.yield.instance,
-		template: componentInstance.yield.template,
+		root: componentInstance._parent,
+		template: componentInstance._yield,
 		pElement: this.surrogateParent.pElement
 	});
 


### PR DESCRIPTION
Realised the [other day](https://github.com/ractivejs/ractive/pull/1381#issuecomment-60323677) that we should have a cleaner separation between the initialisation options that a developer would use with `new Ractive(...)` or `Ractive.extend(...)`, and the options Ractive uses internally when creating inline components.

This is a start in that direction, though it bumps up against #1411, so we should lock that down first before merging this
