### PR TITLE
Render should still work with selectors

### DIFF
--- a/src/Ractive/prototype/render.js
+++ b/src/Ractive/prototype/render.js
@@ -9,18 +9,6 @@ var renderHook = new Hook( 'render' ),
 export default function Ractive$render ( target, anchor ) {
 	var promise, instances, transitionsEnabled;
 
-	if ( !this.append && target ) {
-		// Teardown any existing instances *before* trying to set up the new one -
-		// avoids certain weird bugs
-		let others = target.__ractive_instances__;
-		if ( others && others.length ) {
-			removeOtherInstances( others );
-		}
-
-		// make sure we are the only occupants
-		target.innerHTML = ''; // TODO is this quicker than removeChild? Initial research inconclusive
-	}
-
 	// if `noIntro` is `true`, temporarily disable transitions
 	transitionsEnabled = this.transitionsEnabled;
 	if ( this.noIntro ) {
@@ -39,6 +27,18 @@ export default function Ractive$render ( target, anchor ) {
 
 	this.el = target;
 	this.anchor = anchor;
+
+	if ( !this.append && target ) {
+		// Teardown any existing instances *before* trying to set up the new one -
+		// avoids certain weird bugs
+		let others = target.__ractive_instances__;
+		if ( others && others.length ) {
+			removeOtherInstances( others );
+		}
+
+		// make sure we are the only occupants
+		target.innerHTML = ''; // TODO is this quicker than removeChild? Initial research inconclusive
+	}
 
 	// Add CSS, if applicable
 	if ( this.constructor.css ) {

--- a/test/modules/render.js
+++ b/test/modules/render.js
@@ -195,7 +195,7 @@ define([ 'ractive', 'samples/render' ], function ( Ractive, tests ) {
 
 		});
 
-		test( 'Rendering a non-append instance into an already-occupied element removes the other instance', t => {
+		test( 'Rendering a non-append instance into an already-occupied element removes the other instance (#1430)', t => {
 			var ractive;
 
 			ractive = new Ractive({
@@ -211,6 +211,18 @@ define([ 'ractive', 'samples/render' ], function ( Ractive, tests ) {
 			ractive.render( fixture );
 
 			t.htmlEqual( fixture.innerHTML, 'instance2' );
+		});
+
+		test( 'Render may be called with a selector (#1430)', t => {
+			let ractive = new Ractive({
+				template: 'foo'
+			});
+
+			fixture.innerHTML = '<div id="foo">bar</div>';
+
+			ractive.render( '#foo' );
+
+			t.htmlEqual( fixture.innerHTML, '<div id="foo">foo</div>' );
 		});
 
 	};


### PR DESCRIPTION
This cropped up from #1430 and #1432. #1432 broke using render to target a selector instead of a direct node reference.

There is now a test to make sure a render to a selector string works.
