### PR TITLE
Make sure components unbind their resolvers when they unbind

### DIFF
--- a/src/virtualdom/items/Component/prototype/unbind.js
+++ b/src/virtualdom/items/Component/prototype/unbind.js
@@ -7,6 +7,7 @@ export default function Component$unbind () {
 	var instance = this.instance;
 
 	this.complexParameters.forEach( unbind );
+	this.resolvers.forEach( unbind );
 
 	removeFromLiveComponentQueries( this );
 

--- a/test/modules/components.js
+++ b/test/modules/components.js
@@ -1734,6 +1734,31 @@ define([ 'ractive', 'helpers/Model', 'utils/log' ], function ( Ractive, Model, l
 			t.htmlEqual( fixture.innerHTML, 'forget quarrel' );
 		});
 
+		test( 'Components unbind their resolvers while they are unbinding (#1428)', t => {
+			let ractive = new Ractive({
+				el: fixture,
+				template: '{{#list}}<cmp item="{{foo[.]}}" />{{/}}',
+				components: {
+					cmp: Ractive.extend({
+						template: '{{item}}'
+					})
+				},
+				data: {
+					list: [ 'a', 'b', 'c', 'd' ],
+					foo: {
+						a: 'rich',
+						b: 'john ',
+						c: 'jacob ',
+						d: 'jingleheimerschmidt'
+					}
+				}
+			});
+
+			ractive.splice('list', 0, 1);
+
+			t.htmlEqual( fixture.innerHTML, 'john jacob jingleheimerschmidt' );
+		});
+
 		// Commented out temporarily, see #1381
 		/*test( 'Binding from parent to computation on child that is bound to parent should update properly (#1357)', ( t ) => {
 			var ractive = new Ractive({


### PR DESCRIPTION
As far as I can tell, this fixes #1428 for edge. The component was being unbound but leaving a `MemberResolver` hanging around with a reference to a keypath that then got stuck on to the `Fragment` that got shifted onto it (two `config.order.0`s in the fiddle). Then when the extra resolver went to update on `applyChanges`, its buddies where no longer there.

If this is ok, should it be backported for 0.6 if possible?
