### PR TITLE
Keep magic wrappers from causing themselves to be torn down during reset

### DIFF
--- a/src/viewmodel/prototype/get/magicAdaptor.js
+++ b/src/viewmodel/prototype/get/magicAdaptor.js
@@ -85,8 +85,9 @@ try {
 			this.updating = true;
 			this.obj[ this.prop ] = value; // trigger set() accessor
 			runloop.addViewmodel( this.ractive.viewmodel );
-			this.ractive.viewmodel.mark( this.keypath );
+			this.ractive.viewmodel.mark( this.keypath, { dontTeardownWrapper: true } );
 			this.updating = false;
+			return true;
 		},
 		set: function ( key, value ) {
 			if ( this.updating ) {

--- a/src/viewmodel/prototype/mark.js
+++ b/src/viewmodel/prototype/mark.js
@@ -24,5 +24,8 @@ export default function Viewmodel$mark ( keypath, options ) {
 		this.changes.push( keypath );
 	}
 
-	this.clearCache( keypath );
+	// pass on dontTeardownWrapper, if we can
+	let dontTeardownWrapper = options ? options.dontTeardownWrapper : false;
+
+	this.clearCache( keypath, dontTeardownWrapper );
 }

--- a/test/modules/magic.js
+++ b/test/modules/magic.js
@@ -213,6 +213,25 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.htmlEqual( fixture.innerHTML, '<p>David Copperfield</p>' );
 		});
 
+		test( "Magic adapters shouldn't tear themselves down while resetting (#1342)", t => {
+			let list = 'abcde'.split('');
+			let ractive = new Ractive({
+				el: fixture,
+				template: '{{#list}}{{.}}{{/}}',
+				data: { list: list },
+				magic: true
+			});
+
+			t.htmlEqual( fixture.innerHTML, 'abcde' );
+			// if the wrapper causes itself to be recreated, this is where it happens
+			// during reset
+			list.pop();
+			t.htmlEqual( fixture.innerHTML, 'abcd' );
+			// since the wrapper now has two magic adapters, two fragments get popped
+			list.pop();
+			t.htmlEqual( fixture.innerHTML, 'abc' );
+		});
+
 	};
 
 });


### PR DESCRIPTION
The realm of wrappers and magic is indeed magically wrapped. I haven't entirely wrapped my head around what different wrappers are supposed to do, but I did track down what was causing the error in #1342. The wrapper gets `reset` during `pop` when `set` is called on the viewmodel. During `reset`, the wrapper calls `mark`, which calls `clearCache`, which tears down wrappers if not advised not to. I'm not positive that the magic `reset` isn't wrong, but passing `dontTeardownWrappers` through `mark` to `clearCache` resolves this issue.

Fixes #1342
