### PR TITLE
Added .toHtml as an alias for .toHTML

### DIFF
--- a/src/Ractive/prototype.js
+++ b/src/Ractive/prototype.js
@@ -66,6 +66,7 @@ export default {
 	teardown: teardown,
 	toggle: toggle,
 	toHTML: toHTML,
+	toHtml: toHTML,
 	unrender: unrender,
 	unshift: unshift,
 	update: update,


### PR DESCRIPTION
Added lowerCamelCase alias of .toHTML to the ractive prototype, to adhere to the [principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).

Comments and concerns are welcome.
