### PR TITLE
First attempt at supporting directives in conditional attributes - RFC

### DIFF
--- a/src/virtualdom/items/Element/prototype/bindingHelpers.js
+++ b/src/virtualdom/items/Element/prototype/bindingHelpers.js
@@ -46,7 +46,7 @@ export default {
 	},
 	unregisterEventHandlers: function( element, events ) {
 		// if events is an array of named events to remove
-		if ( isArray( events ) ) {
+		if ( isArray( events ) && element.eventHandlers ) {
 			let event;
 			
 			for ( event of events ) {

--- a/src/virtualdom/items/Element/prototype/bindingHelpers.js
+++ b/src/virtualdom/items/Element/prototype/bindingHelpers.js
@@ -1,0 +1,102 @@
+import createTwowayBinding from 'virtualdom/items/Element/prototype/init/createTwowayBinding';
+import createEventHandlers from 'virtualdom/items/Element/prototype/init/createEventHandlers';
+import Decorator from 'virtualdom/items/Element/Decorator/_Decorator';
+import isArray from 'utils/isArray';
+import runloop from 'global/runloop';
+
+export default {
+	registerTwowayBinding: function( element ) {
+		var binding, bindings;
+
+		// clear out any old binding first
+		if ( element.binding ) {
+			this.unregisterTwowayBinding( element );
+		}
+		
+		if ( element.twoway && ( binding = createTwowayBinding( element, element.template.a ) ) ) {
+			element.binding = binding;
+
+			// register element with the root, so that we can do ractive.updateModel()
+			bindings = element.root._twowayBindings[ binding.keypath ] || ( element.root._twowayBindings[ binding.keypath ] = [] );
+			bindings.push( binding );
+
+			// if the element is already rendered, render the new binding
+			if ( element.node ) {
+				binding.render();
+				element.node._ractive.binding = binding;
+			}
+		}
+	},
+	unregisterTwowayBinding: function( element ) {
+		var binding, bindings;
+		if ( binding = element.binding ) {
+			binding.unrender();
+			element.binding = undefined;
+
+			element.node._ractive.binding = null;
+			bindings = element.root._twowayBindings[ binding.keypath ];
+			bindings.splice( bindings.indexOf( binding ), 1 );
+		}
+	},
+	registerEventHandlers: function( element, events ) {
+		events = events || element.template.v;
+		let result = createEventHandlers( element, events );
+		element.eventHandlers = ( element.eventHandlers || [] ).concat( result );
+		return result;
+	},
+	unregisterEventHandlers: function( element, events ) {
+		// if events is an array of named events to remove
+		if ( isArray( events ) ) {
+			let event;
+			
+			for ( event of events ) {
+				let i = element.eventHandlers.length, h;
+
+				// look them up and remove them
+				while ( i-- ) {
+					if ( ( h = element.eventHandlers[i] ) && h.name === event ) {
+						h.unrender();
+						element.eventHandlers.splice( i, 1 );
+						break;
+					}
+				}
+			}
+		}
+
+		// othewise, drop all events
+		else if ( element.eventHandlers ) {
+			element.eventHandlers.forEach( h => h.unrender() );
+		}
+	},
+	registerDecorator: function( element, decorator ) {
+		// if there's already a decorator, drop it
+		if ( element.decorator ) {
+			this.unregisterDecorator( element );
+		}
+
+		decorator = decorator || element.template.o;
+
+		if ( decorator ) {
+			element.decorator = new Decorator( element, decorator );
+
+			// if the element is already rendered init the decorator
+			if ( element.node && element.decorator.fn ) {
+				runloop.scheduleTask( () => { 
+					if ( !element.decorator.torndown ) {
+						element.decorator.init();
+					}
+				}, true );
+			}
+		}
+	},
+	unregisterDecorator: function( element ) {
+		if ( element.decorator ) {
+			element.decorator.teardown();
+		}
+	},
+	updateLaziness: function( element ) {
+		if ( element.binding && element.binding.updateLaziness ) {
+			element.binding.updateLaziness();
+		}
+	}
+};

--- a/src/virtualdom/items/Element/prototype/init.js
+++ b/src/virtualdom/items/Element/prototype/init.js
@@ -3,9 +3,7 @@ import enforceCase from 'virtualdom/items/Element/shared/enforceCase';
 import processBindingAttributes from 'virtualdom/items/Element/prototype/init/processBindingAttributes';
 import createAttributes from 'virtualdom/items/Element/prototype/init/createAttributes';
 import createConditionalAttributes from 'virtualdom/items/Element/prototype/init/createConditionalAttributes';
-import createTwowayBinding from 'virtualdom/items/Element/prototype/init/createTwowayBinding';
-import createEventHandlers from 'virtualdom/items/Element/prototype/init/createEventHandlers';
-import Decorator from 'virtualdom/items/Element/Decorator/_Decorator';
+import bindingHelpers from 'virtualdom/items/Element/prototype/bindingHelpers';
 import bubbleSelect from 'virtualdom/items/Element/special/select/bubble';
 import initOption from 'virtualdom/items/Element/special/option/init';
 
@@ -20,10 +18,7 @@ circular.push( function () {
 export default function Element$init ( options ) {
 	var parentFragment,
 		template,
-		ractive,
-		binding,
-		bindings,
-		twoway;
+		ractive;
 
 	this.type = types.ELEMENT;
 
@@ -49,6 +44,8 @@ export default function Element$init ( options ) {
 		this.bubble = bubbleSelect; // TODO this is a kludge
 	}
 
+	this.twoway = ractive.twoway;
+	this.lazy = ractive.lazy;
 	// handle binding attributes first (twoway, lazy)
 	processBindingAttributes( this, template.a || {} );
 
@@ -66,28 +63,17 @@ export default function Element$init ( options ) {
 		});
 	}
 
-	// the element setting should override the ractive setting
-	twoway = ractive.twoway;
-	if ( this.twoway === false ) twoway = false;
-	else if ( this.twoway === true ) twoway = true;
-
 	// create twoway binding
-	if ( twoway && ( binding = createTwowayBinding( this, template.a ) ) ) {
-		this.binding = binding;
-
-		// register this with the root, so that we can do ractive.updateModel()
-		bindings = this.root._twowayBindings[ binding.keypath ] || ( this.root._twowayBindings[ binding.keypath ] = [] );
-		bindings.push( binding );
-	}
+	bindingHelpers.registerTwowayBinding( this );
 
 	// create event proxies
 	if ( template.v ) {
-		this.eventHandlers = createEventHandlers( this, template.v );
+		bindingHelpers.registerEventHandlers( this );
 	}
 
 	// create decorator
 	if ( template.o ) {
-		this.decorator = new Decorator( this, template.o );
+		bindingHelpers.registerDecorator( this );
 	}
 
 	// create transitions

--- a/src/virtualdom/items/Element/prototype/init/processBindingAttributes.js
+++ b/src/virtualdom/items/Element/prototype/init/processBindingAttributes.js
@@ -4,13 +4,15 @@ var isNumeric = /^[0-9]+$/;
 export default function( element, attributes ) {
 	var val;
 
+	element = element || {};
+
 	// attributes that are present but don't have a value (=)
 	// will be set to the number 0, which we condider to be true
 	// the string '0', however is false
 
 	val = attributes.twoway;
 	if ( val !== undefined ) {
-		element.twoway = val === 0 || truthy.test( val );
+		element.twoway = val === 'twoway' || val === '' || val === 0 || truthy.test( val );
 		delete attributes.twoway;
 	}
 
@@ -20,8 +22,10 @@ export default function( element, attributes ) {
 		if ( val !== 0 && isNumeric.test( val ) ) {
 			element.lazy = parseInt( val );
 		} else {
-			element.lazy = val === 0 || truthy.test( val );
+			element.lazy = val === 'lazy' || val === '' || val === 0 || truthy.test( val );
 		}
 		delete attributes.lazy;
 	}
+
+	return element;
 }

--- a/src/virtualdom/items/Element/prototype/unrender.js
+++ b/src/virtualdom/items/Element/prototype/unrender.js
@@ -1,9 +1,8 @@
 import runloop from 'global/runloop';
 import Transition from 'virtualdom/items/Element/Transition/_Transition';
+import bindingHelpers from 'virtualdom/items/Element/prototype/bindingHelpers';
 
 export default function Element$unrender ( shouldDestroy ) {
-	var binding, bindings;
-
 	if ( this.transition ) {
 		this.transition.complete();
 	}
@@ -24,22 +23,13 @@ export default function Element$unrender ( shouldDestroy ) {
 		this.fragment.unrender( false );
 	}
 
-	if ( binding = this.binding ) {
-		this.binding.unrender();
-
-		this.node._ractive.binding = null;
-		bindings = this.root._twowayBindings[ binding.keypath ];
-		bindings.splice( bindings.indexOf( binding ), 1 );
-	}
+	// remove binding if there is one
+	bindingHelpers.unregisterTwowayBinding( this );
 
 	// Remove event handlers
-	if ( this.eventHandlers ) {
-		this.eventHandlers.forEach( h => h.unrender() );
-	}
+	bindingHelpers.unregisterEventHandlers( this );
 
-	if ( this.decorator ) {
-		this.decorator.teardown();
-	}
+	bindingHelpers.unregisterDecorator( this );
 
 	// trigger outro transition if necessary
 	if ( this.root.transitionsEnabled && this.outro ) {


### PR DESCRIPTION
** *__Not ready to merge__* **

This takes the approach of conditional attribute handling and extends it to check for directives before updating the attributes on the parent element. The code in edge right now will let you put any sort of template that you'd like into the attributes area of an element. Then when those parts of the template update, it stringifies it, creates a `div` with the string for attributes, and reads attributes off of the `div`. This lets you do neat things, like have a partial to hold attributes and have it switch based on current context.

```js
ractive.resetPartial( 'attrs', 'class="foo" on-click="click()"');
```
```html
<button {{>attrs}}>Click</button>
```

The downside to this approach for directives is that mustaches are already processed (transcluded?), so any directive that wants to bind refs can't because it gets its value re-parsed from a rendered template. Any directives that do use mustaches, like proxy events and decorators, will get updated appropriately when their underlying refs do, but they will be completely torn down and set back up. That's not the most efficient thing to do, certainly.

I haven't been able to come up with a way to handle this at the fragment level to avoid parsing at render time. For instance, I'm not sure how to handle things like this contrivance:
```html
<button {{>attrs}}>Click</button>
```
```js
ractive.alert = function(message) { console.log(message); };
ractive.set( 'js', true );
ractive.resetPartial( 'attrs', '{{#js}}onclick="alert(\'hello\')"{{else}}on-click="alert(\'hello\')"{{/}}' );
ractive.find( 'button' ).click();
ractive.set( 'js', false );
ractive.find( 'button' ).click();
```

### What's Supported

So far, this supports events, lazy, twoway, and decorator. The code is still a little grungy with clean-up and features pending architectural guidance.