### PR TITLE
Avoid partial expression inception invovling recursive data structures

### DIFF
--- a/src/virtualdom/items/Partial/_Partial.js
+++ b/src/virtualdom/items/Partial/_Partial.js
@@ -123,9 +123,10 @@ Partial.prototype = {
 			});
 		}
 
+		this.value = value;
+
 		this.setTemplate( template || [] );
 
-		this.value = value;
 		this.bubble();
 
 		if ( this.rendered ) {

--- a/test/modules/partials.js
+++ b/test/modules/partials.js
@@ -608,5 +608,22 @@ define([ 'ractive', 'legacy' ], function ( Ractive, legacy ) {
 
 			t.htmlEqual( fixture.innerHTML, 'foo' );
 		});
+
+		test( 'Partials with expressions in recursive structures should not blow the stack', t => {
+			var ractive = new Ractive({
+				el: fixture,
+				template: '{{#items}}{{>\'item\'}}{{/}}',
+				partials: {
+					item: '{{.foo}}{{#.items}}{{>\'item\'}}{{/}}'
+				},
+				data: {
+					items: [
+						{ items: [{ foo: 'a', items: [{ foo: 'b' }] }] }
+					]
+				}
+			});
+
+			t.htmlEqual( fixture.innerHTML, 'ab' );
+		});
 	};
 });


### PR DESCRIPTION
I tripped over this when updating a project to 0.6.
