### PR TITLE
Named partials shouldn't try to rebind themselves...

### DIFF
--- a/src/virtualdom/items/Partial/_Partial.js
+++ b/src/virtualdom/items/Partial/_Partial.js
@@ -83,7 +83,11 @@ Partial.prototype = {
 	},
 
 	rebind: function ( indexRef, newIndex, oldKeypath, newKeypath ) {
-		rebind.call( this, indexRef, newIndex, oldKeypath, newKeypath );
+		// named partials aren't bound, so don't rebind
+		if ( !this.isNamed ) {
+			rebind.call( this, indexRef, newIndex, oldKeypath, newKeypath );
+		}
+
 		this.fragment.rebind( indexRef, newIndex, oldKeypath, newKeypath );
 	},
 

--- a/test/modules/partials.js
+++ b/test/modules/partials.js
@@ -713,5 +713,24 @@ define([ 'ractive', 'legacy' ], function ( Ractive, legacy ) {
 			t.htmlEqual( fixture.innerHTML, 'ab' );
 		});
 
+		test( 'Named partials should not get rebound if they happen to have the same name as a reference (#1507)', t => {
+			var ractive = new Ractive({
+				el: fixture,
+				template: '{{#each items}}{{>item}}{{/each}}{{#if items.length > 1}}{{#with items[items.length-1]}}{{>item}}{{/with}}{{/if}}',
+				partials: {
+					item: '{{item}}'
+				},
+				data: {
+					items: []
+				}
+			});
+
+			ractive.push( 'items', { item: 'a' } );
+			ractive.push( 'items', { item: 'b' } );
+			ractive.push( 'items', { item: 'c' } );
+
+			t.htmlEqual( fixture.innerHTML, 'abcc' );
+		});
+
 	};
 });


### PR DESCRIPTION
as they are inherently unbound. This is a very difficult to achieve circumstance, but it has an easy and obvious fix. Fixes #1507
