### PR TITLE
Replace asterisks in computation keypaths to avoid blowing up pattern observers

### DIFF
--- a/src/virtualdom/items/shared/Resolvers/ExpressionResolver.js
+++ b/src/virtualdom/items/shared/Resolvers/ExpressionResolver.js
@@ -140,7 +140,8 @@ function getUniqueString ( str, keypaths ) {
 function getKeypath ( uniqueString ) {
 	// Sanitize by removing any periods or square brackets. Otherwise
 	// we can't split the keypath into keys!
-	return '${' + uniqueString.replace( /[\.\[\]]/g, '-' ) + '}';
+	// Remove asterisks too, since they mess with pattern observers
+	return '${' + uniqueString.replace( /[\.\[\]]/g, '-' ).replace( /\*/, '#MUL#' ) + '}';
 }
 
 function isValidDependency ( keypath ) {

--- a/test/modules/observe.js
+++ b/test/modules/observe.js
@@ -590,8 +590,26 @@ define([ 'ractive' ], function ( Ractive ) {
 
 			ractive.set( 'foo', 'fizz' );
 			ractive.set( 'foo', 'qux' );
-		})
+		});
 
+		test( 'Asterisks should not be left in computation keypaths (#1472)', t => {
+			let ractive = new Ractive({
+				el: fixture,
+				template: '{{foo * 2}}',
+				data: { foo: 3 }
+			});
+
+			ractive.observe( '*', () => {} );
+
+			// this will blow the stack if the bug is present
+			// qunit doesn't like it when your tests straight-up overflow
+			// the try helps, but it will still cascade to other tests
+			try {
+				ractive.set( 'foo', 10 );
+			} catch (e) {}
+
+			t.htmlEqual( fixture.innerHTML, '20' );
+		});
 
 	};
 


### PR DESCRIPTION
This fixes #1472. Out of curiosity, should computations even be considered for a pattern observer? It seems that something like `/\$\{/.test(keypath)` should maybe be used to avoid computation keypaths in pattern observers altogether. Or is being able to observe computation changes useful?
