### PR TITLE
Keep bindings, mappings, and upstream computations from recursively marking forever

### DIFF
--- a/src/viewmodel/prototype/applyChanges.js
+++ b/src/viewmodel/prototype/applyChanges.js
@@ -46,7 +46,10 @@ export default function Viewmodel$applyChanges () {
 	upstreamChanges.forEach( keypath => {
 		var computations;
 
-		if ( computations = self.deps.computed[ keypath ] ) {
+		// make sure we haven't already been down this particular keypath in this turn
+		if ( changes.indexOf( keypath ) === -1 && ( computations = self.deps.computed[ keypath ] ) ) {
+			this.changes.push( keypath );
+
 			computations.forEach( c => {
 				c.viewmodel.mark( c.key );
 			});

--- a/test/modules/init/initialisation.js
+++ b/test/modules/init/initialisation.js
@@ -524,6 +524,16 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.strictEqual( ractive.findComponent( 'inner' ).findContainer( 'nope' ), null );
 		});
 
+		test( 'Bindings, mappings, and upstream computations should not cause infinite mark recursion (#1526)', t => {
+			var ractive = new Ractive({
+				el: fixture,
+				template: '{{JSON.stringify(.)}}<widget foo="{{bar}}" /><input value="{{bar}}" />',
+				components: { widget: Ractive.extend({ template: '{{foo}}' }) }
+			});
+
+			t.htmlEqual( fixture.innerHTML, '{"bar":""}<input />' );
+		});
+
 		/* Not supported, do we need it?
 		test( 'Instantiated component with template function plus instantiation template', t => {
 			var Component, ractive;


### PR DESCRIPTION
`addViewmodel` calls `applyChanges`, which calls `mark`, which calls `addViewmodel`. This is a quick-n-dirty fix that pushes upstream keypaths into the change list and makes sure they haven't already been marked before marking again.

Having the change queue clear would catch this case, but it breaks other tests. Would this be better handled with a separate tracking array (or something else entirely) to avoid having `cascade` called on upstream keypaths?

fixes #1526
