### PR TITLE
teardown decorators immediately before node detach

### DIFF
--- a/src/global/TransitionManager.js
+++ b/src/global/TransitionManager.js
@@ -11,6 +11,7 @@ var TransitionManager = function ( callback, parent ) {
 	this.totalChildren = this.outroChildren = 0;
 
 	this.detachQueue = [];
+	this.decoratorQueue = [];
 	this.outrosComplete = false;
 
 	if ( parent ) {
@@ -41,6 +42,10 @@ TransitionManager.prototype = {
 		list.push( transition );
 	},
 
+	addDecorator: function ( decorator ) {
+		this.decoratorQueue.push( decorator );
+	},
+
 	remove: function ( transition ) {
 		var list = transition.isIntro ? this.intros : this.outros;
 		removeFromArray( list, transition );
@@ -53,10 +58,15 @@ TransitionManager.prototype = {
 	},
 
 	detachNodes: function () {
+		this.decoratorQueue.forEach( teardown );
 		this.detachQueue.forEach( detach );
 		this.children.forEach( detachNodes );
 	}
 };
+
+function teardown ( decorator ) {
+	decorator.teardown();
+}
 
 function detach ( element ) {
 	element.detach();

--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -58,6 +58,10 @@ runloop = {
 		batch.transitionManager.add( transition );
 	},
 
+	registerDecorator: function ( decorator ) {
+		batch.transitionManager.addDecorator( decorator );
+	},
+
 	addView: function ( view ) {
 		batch.views.push( view );
 	},

--- a/src/virtualdom/items/Element/prototype/unrender.js
+++ b/src/virtualdom/items/Element/prototype/unrender.js
@@ -38,7 +38,7 @@ export default function Element$unrender ( shouldDestroy ) {
 	}
 
 	if ( this.decorator ) {
-		this.decorator.teardown();
+		runloop.registerDecorator( this.decorator );
 	}
 
 	// trigger outro transition if necessary


### PR DESCRIPTION
This fixes #1483 - decorator `teardown` methods are called _after_ outro transitions have completed (previously, they were called immediately, which meant undecorated nodes hanging around in the DOM for the duration of transitions)
