### PR TITLE
fixes #1475 bug with pattern observer validation

### DIFF
--- a/src/Ractive/prototype/observe/PatternObserver.js
+++ b/src/Ractive/prototype/observe/PatternObserver.js
@@ -85,9 +85,8 @@ PatternObserver.prototype = {
 			keys = slice.call( this.regex.exec( keypath ), 1 );
 			args = [ value, this.values[ keypath ], keypath ].concat( keys );
 
-			this.callback.apply( this.context, args );
-
 			this.values[ keypath ] = value;
+			this.callback.apply( this.context, args );
 		}
 
 		this.updating = false;

--- a/test/modules/observe.js
+++ b/test/modules/observe.js
@@ -611,6 +611,48 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.htmlEqual( fixture.innerHTML, '20' );
 		});
 
+		test( 'Pattern observers used as validators behave correctly on blur (#1475)', t => {
+			let ractive, inputs;
+
+			ractive = new Ractive({
+				el: fixture,
+				template: `
+					{{#each items}}
+						<input value='{{value}}'>{{value}}
+					{{/each}}`,
+				data: {
+					items: [
+						{ min: 10, max: 90, value: 0 },
+						{ min: 10, max: 90, value: 100 }
+					]
+				}
+			});
+
+			ractive.observe( 'items.*.value', function ( n, o, k, i ) {
+				var min = this.get( 'items[' + i + '].min' ),
+					max = this.get( 'items[' + i + '].max' );
+
+				if ( n < min ) this.set( k, min );
+				if ( n > max ) this.set( k, max );
+			});
+
+			t.equal( ractive.get( 'items[0].value' ), 10 );
+			t.equal( ractive.get( 'items[1].value' ), 90 );
+
+			inputs = ractive.findAll( 'input' );
+
+			inputs[0].value = 200;
+			inputs[1].value = -200;
+
+			simulant.fire( inputs[0], 'input' );
+			simulant.fire( inputs[1], 'input' );
+			simulant.fire( inputs[0], 'blur' );
+			simulant.fire( inputs[1], 'blur' );
+
+			t.equal( ractive.get( 'items[0].value' ), 90 );
+			t.equal( ractive.get( 'items[1].value' ), 10 );
+		});
+
 	};
 
 });


### PR DESCRIPTION
As noted in #1475, pattern observers behave wonkily if you use them to validate inputs. That's because the pattern observer's hash of values (which it uses to determine whether to call the callback) is only updated _after_ the callback is called - so if it calls itself recursively (i.e. `this.set('foo',validated)`), on blur it thinks nothing has changed, and so the validation never happens. This fixes that bug
