### PR TITLE
Add support for JSON.stringify to ComponentData

### DIFF
--- a/src/shared/parameters/createComponentData.js
+++ b/src/shared/parameters/createComponentData.js
@@ -94,18 +94,10 @@ function makeConstructor ( parameters, defined ) {
 var reservedKeys = [ '_data', '_mappings' ];
 
 function toJSON() {
-	let json = {}, mappings = this._mappings;
+	var json = {}, k;
 
-	for ( let k in this._data ) {
-		json[k] = this[k];
-	}
-
-	for ( let k in mappings ) {
-		json[k] = mappings[k].origin.get( mappings[k].keypath );
-	}
-
-	for ( let k in this ) {
-		if ( this.hasOwnProperty( k ) && reservedKeys.indexOf( k ) === -1 ) {
+	for ( k in this ) {
+		if ( reservedKeys.indexOf( k ) === -1 ) {
 			json[k] = this[k];
 		}
 	}

--- a/src/shared/resolveRef.js
+++ b/src/shared/resolveRef.js
@@ -147,5 +147,6 @@ function createMappingIfNecessary ( ractive, key ) {
 }
 
 function isRootProperty ( ractive, key ) {
-	return key in ractive.data || key in ractive.viewmodel.computations || key in ractive.viewmodel.mappings;
+	// special case for reference to root
+	return key === '' || key in ractive.data || key in ractive.viewmodel.computations || key in ractive.viewmodel.mappings;
 }

--- a/test/modules/componentData.js
+++ b/test/modules/componentData.js
@@ -1312,7 +1312,7 @@ define([
 			})
 
 			test( 'ComponentData supports JSON.stringify', (t) => {
-				new Ractive({
+				var ractive = new Ractive({
 					el: fixture,
 					template: `<cmp foo="bar" baz="{{.}}" />`,
 					components: {
@@ -1326,7 +1326,9 @@ define([
 					data: { bippy: 'boppy' }
 				});
 
-				t.htmlEqual( JSON.stringify({foo:'bar',baz:{bippy:'boppy'},bat:1}) + ' bar boppy 1', fixture.innerHTML );
+				t.ok( ractive.findComponent('cmp').data.toJSON );
+
+				t.htmlEqual( fixture.innerHTML, JSON.stringify( { bat:1, foo:'bar', baz:{ bippy:'boppy' } } ) + ' bar boppy 1' );
 			});
 
 			test( 'ComponentData supports in operator', (t) => {


### PR DESCRIPTION
I suppose this is a sort of regression corner-case. The workaround seems to be to add a `JSON.stringify`-friendly `toJSON` method to `ComponentData` that serializes its view of itself. See #1548

Is this the correct solution?
