### PR TITLE
remove for...of blocks (#1554)

### DIFF
--- a/src/Ractive/prototype/resetPartial.js
+++ b/src/Ractive/prototype/resetPartial.js
@@ -10,7 +10,7 @@ export default function( name, partial, callback ) {
 		// if this is a component and it has its own partial, bail
 		if ( ractive && ractive.partials[name] ) return;
 
-		for ( let item of source ) {
+		source.forEach( item => {
 			// queue to rerender if the item is a partial and the current name matches
 			if ( item.type === types.PARTIAL && item.getPartialName() === name ) {
 				dest.push( item );
@@ -46,7 +46,7 @@ export default function( name, partial, callback ) {
 					collect( item.conditionalAttributes, dest, ractive );
 				}
 			}
-		}
+		});
 	}
 
 	collect( this.fragment.items, collection );
@@ -54,11 +54,10 @@ export default function( name, partial, callback ) {
 
 	promise = runloop.start( this, true );
 
-	// force each item to rerender
-	for ( let item of collection ) {
+	collection.forEach( item => {
 		item.value = undefined;
 		item.setValue( name );
-	}
+	});
 
 	runloop.end();
 

--- a/src/virtualdom/items/Section/_Section.js
+++ b/src/virtualdom/items/Section/_Section.js
@@ -55,7 +55,9 @@ Section.prototype = {
 	firstNode: firstNode,
 	getIndexRef: function( name ) {
 		if ( this.indexRefs ) {
-			for ( let ref of this.indexRefs ) {
+			let i = this.indexRefs.length;
+			while ( i-- ) {
+				let ref = this.indexRefs[i];
 				if ( ref.n === name ) {
 					return ref;
 				}

--- a/src/virtualdom/items/Section/prototype/setValue.js
+++ b/src/virtualdom/items/Section/prototype/setValue.js
@@ -213,10 +213,7 @@ function reevaluateListObjectSection ( section, value, fragmentOptions ) {
 		if ( fragment.index !== i ){
 			fragment.index = i;
 			if ( deps = fragment.registeredIndexRefs ) {
-				for ( let d of deps ) {
-					// the keypath doesn't actually matter here as it won't have changed
-					d.rebind( '', '' );
-				}
+				deps.forEach( blindRebind );
 			}
 		}
 	}
@@ -334,4 +331,9 @@ function isRendered ( fragment ) {
 
 function getContext ( base, index ) {
 	return ( base ? base + '.' : '' ) + index;
+}
+
+function blindRebind ( dep ) {
+	// the keypath doesn't actually matter here as it won't have changed
+	dep.rebind( '', '' );
 }

--- a/src/virtualdom/items/Section/prototype/shuffle.js
+++ b/src/virtualdom/items/Section/prototype/shuffle.js
@@ -62,10 +62,7 @@ export default function Section$shuffle ( newIndices ) {
 
 		// notify any registered index refs directly
 		if ( deps = fragment.registeredIndexRefs ) {
-			for ( let d of deps ) {
-				// the keypath doesn't actually matter here
-				d.rebind( '', '' );
-			}
+			deps.forEach( blindRebind );
 		}
 
 		fragment.rebind( oldKeypath, newKeypath );
@@ -109,4 +106,9 @@ export default function Section$shuffle ( newIndices ) {
 
 		this.fragments[i] = fragment;
 	}
+}
+
+function blindRebind ( dep ) {
+	// the keypath doesn't actually matter here as it won't have changed
+	dep.rebind( '', '' );
 }


### PR DESCRIPTION
It turns out that current transpilers do a terrible job with `for...of` blocks - see #1554. (My initial assumption was that `let` was to blame - I was mistaken.) This PR replaces most of the occurrences with `forEach`, and the other one with `while`.
