### PR TITLE
tweak CSS transformation, fixes #1558

### DIFF
--- a/src/config/defaults/interpolators.js
+++ b/src/config/defaults/interpolators.js
@@ -4,13 +4,11 @@ import isArray from 'utils/isArray';
 import isObject from 'utils/isObject';
 import isNumeric from 'utils/isNumeric';
 
-var interpolators, interpolate, cssLengthPattern;
+var interpolators, interpolate;
 
 circular.push( function () {
 	interpolate = circular.interpolate;
 });
-
-cssLengthPattern = /^([+-]?[0-9]+\.?(?:[0-9]+)?)(px|em|ex|%|in|cm|mm|pt|pc)$/;
 
 interpolators = {
 	number: function ( from, to ) {

--- a/src/config/options/css/transform.js
+++ b/src/config/options/css/transform.js
@@ -1,14 +1,16 @@
 var selectorsPattern = /(?:^|\})?\s*([^\{\}]+)\s*\{/g,
 	commentsPattern = /\/\*.*?\*\//g,
-	selectorUnitPattern = /((?:(?:\[[^\]+]\])|(?:[^\s\+\>\~:]))+)((?::[^\s\+\>\~]+)?\s*[\s\+\>\~]?)\s*/g,
+	selectorUnitPattern = /((?:(?:\[[^\]+]\])|(?:[^\s\+\>\~:]))+)((?::[^\s\+\>\~\(]+(?:\([^\)]+\))?)?\s*[\s\+\>\~]?)\s*/g,
 	mediaQueryPattern = /^@media/,
-	dataRvcGuidPattern = /\[data-rvcguid="[a-z0-9-]+"]/g;
+	dataRvcGuidPattern = /\[data-ractive-css="[a-z0-9-]+"]/g;
 
-export default function transformCss( css, guid ) {
-	var transformed, addGuid;
+export default function transformCss( css, id ) {
+	var transformed, dataAttr, addGuid;
+
+	dataAttr = `[data-ractive-css="${id}"]`;
 
 	addGuid = function ( selector ) {
-		var selectorUnits, match, unit, dataAttr, base, prepended, appended, i, transformed = [];
+		var selectorUnits, match, unit, base, prepended, appended, i, transformed = [];
 
 		selectorUnits = [];
 
@@ -21,8 +23,7 @@ export default function transformCss( css, guid ) {
 		}
 
 		// For each simple selector within the selector, we need to create a version
-		// that a) combines with the guid, and b) is inside the guid
-		dataAttr = '[data-rvcguid="' + guid + '"]';
+		// that a) combines with the id, and b) is inside the id
 		base = selectorUnits.map( extractString );
 
 		i = selectorUnits.length;
@@ -43,7 +44,7 @@ export default function transformCss( css, guid ) {
 	};
 
 	if ( dataRvcGuidPattern.test( css ) ) {
-		transformed = css.replace( dataRvcGuidPattern, '[data-rvcguid="' + guid +'"]' );
+		transformed = css.replace( dataRvcGuidPattern, dataAttr );
 	} else {
 		transformed = css
 		.replace( commentsPattern, '' )

--- a/src/extend/_extend.js
+++ b/src/extend/_extend.js
@@ -1,10 +1,11 @@
 import create from 'utils/create';
 import defineProperties from 'utils/defineProperties';
-import getGuid from 'utils/getGuid';
 import config from 'config/config';
 import initialise from 'Ractive/initialise';
 import Viewmodel from 'viewmodel/Viewmodel';
 import unwrap from 'extend/unwrapExtended';
+
+var uid = 1;
 
 export default function extend ( options = {} ) {
 	var Parent = this, Child, proto, staticProperties;
@@ -22,8 +23,8 @@ export default function extend ( options = {} ) {
 	proto.constructor = Child;
 
 	staticProperties = {
-		// each component needs a guid, for managing CSS etc
-		_guid: { value: getGuid() },
+		// each component needs a unique ID, for managing CSS
+		_guid: { value: uid++ },
 
 		// alias prototype as defaults
 		defaults: { value: proto },

--- a/src/utils/getGuid.js
+++ b/src/utils/getGuid.js
@@ -1,9 +1,0 @@
-export default function () {
-	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-		var r, v;
-
-		r = Math.random()*16|0;
-		v = ( c == 'x' ? r : (r&0x3|0x8) );
-		return v.toString(16);
-	});
-}

--- a/src/virtualdom/items/Element/prototype/render.js
+++ b/src/virtualdom/items/Element/prototype/render.js
@@ -50,12 +50,12 @@ export default function Element$render () {
 	node = this.node = createElement( this.name, namespace );
 
 	// Is this a top-level node of a component? If so, we may need to add
-	// a data-rvcguid attribute, for CSS encapsulation
+	// a data-ractive-css attribute, for CSS encapsulation
 	// NOTE: css no longer copied to instance, so we check constructor.css -
 	// we can enhance to handle instance, but this is more "correct" with current
 	// functionality
 	if ( root.constructor.css && this.parentFragment.getNode() === root.el ) {
-		this.node.setAttribute( 'data-rvcguid', root.constructor._guid /*|| root._guid*/ );
+		this.node.setAttribute( 'data-ractive-css', root.constructor._guid /*|| root._guid*/ );
 	}
 
 	// Add _ractive property to the node - we use this object to store stuff

--- a/test/modules/css.js
+++ b/test/modules/css.js
@@ -210,6 +210,32 @@ define([ 'ractive', 'legacy' ], function ( Ractive, legacy ) {
 			t.equal( getHexColor( paragraph ), hexCodes.red );
 		});
 
+		test( 'nth-child selectors work', function ( t ) {
+			var ZebraList, ractive, lis;
+
+			ZebraList = Ractive.extend({
+				css: 'li { color: green; } li:nth-child(2n+1) { color: red; }',
+				template: `
+					<ul>
+						{{#each items}}
+							<li>{{this}}</li>
+						{{/each}}
+					</ul>`
+			});
+
+			ractive = new ZebraList({
+				el: fixture,
+				data: { items: [ 'a', 'b', 'c', 'd', 'e' ] }
+			});
+
+			lis = ractive.findAll( 'li' );
+			t.equal( getHexColor( lis[0] ), hexCodes.red );
+			t.equal( getHexColor( lis[1] ), hexCodes.green );
+			t.equal( getHexColor( lis[2] ), hexCodes.red );
+			t.equal( getHexColor( lis[3] ), hexCodes.green );
+			t.equal( getHexColor( lis[4] ), hexCodes.red );
+		});
+
 	};
 
 });


### PR DESCRIPTION
This changes the regex in [css/transform.js](https://github.com/ractivejs/ractive/blob/dev/src/config/options/css/transform.js#L3) to accommodate selector modifiers like `nth-child(2n+1)`. While I was at it I changed a couple of other things:
- `data-rvcguid` is now `data-ractive-css` - this should make it much less mysterious for anyone seeing it in their devtools
- rather than using globally unique IDs, it just uses a simple counter - the guid thing was supposed to prevent anyone from mucking about with the encapsulated styles, but a) it doesn't actually do that (you can just target `[data-rvcguid]`, you don't need to specify a value), b) so what if someone does?, and c) we can now get rid of the unused `getGuid()` module
