### PR TITLE
gh-1566

### DIFF
--- a/src/shared/parameters/createParameters.js
+++ b/src/shared/parameters/createParameters.js
@@ -86,11 +86,9 @@ ComponentParameters.prototype = {
 	},
 
 	addMapping: function ( key, keypath ) {
-		// map directly to the source if possible...
-		var mapping = this.parentViewmodel.mappings[ keypath ];
 		return this.mappings[ key ] = new Mapping( key, {
-			origin: mapping ? mapping.origin : this.parentViewmodel,
-			keypath: mapping ? mapping.keypath : keypath
+			origin: this.parentViewmodel,
+			keypath: keypath
 		});
 	}
 };

--- a/test/modules/components.js
+++ b/test/modules/components.js
@@ -771,6 +771,36 @@ define([
 			t.htmlEqual( fixture.innerHTML, '<p>a: bar</p><p>b: bar</p><p>c: bar</p>' );
 		});
 
+		test( 'Explicit mappings with uninitialised data', function ( t ) {
+			var ractive = new Ractive({
+				el: fixture,
+				template: '<foo/>',
+				components: {
+					foo: Ractive.extend({ template: '<bar message="{{message}}"/>' }),
+					bar: Ractive.extend({ template: '<baz message="{{message}}"/>' }),
+					baz: Ractive.extend({ template: '{{message}}' })
+				}
+			});
+
+			ractive.set( 'message', 'hello' );
+			t.htmlEqual( fixture.innerHTML, 'hello' );
+		});
+
+		test( 'Implicit mappings with uninitialised data', function ( t ) {
+			var ractive = new Ractive({
+				el: fixture,
+				template: '<foo message="{{message}}"/>',
+				components: {
+					foo: Ractive.extend({ template: '<bar/>' }),
+					bar: Ractive.extend({ template: '<baz/>' }),
+					baz: Ractive.extend({ template: '{{message}}' })
+				}
+			});
+
+			ractive.set( 'message', 'hello' );
+			t.htmlEqual( fixture.innerHTML, 'hello' );
+		});
+
 	};
 
 });


### PR DESCRIPTION
**note ready for merge**

This fixes #1566. The `addMapping()` method is sometimes called with `undefined` as the second argument - by itself that's fine (if you have `<foo bar='{{baz}}'/>` you want to create a `bar` mapping on `<foo>` even if you don't yet know what `baz` resolves to), but it causes problems when you try to create mappings that 'leapfrog' through multiple levels. One solution is to only map one level at a time. (Dependants are still registered with the viewmodel at the top of the chain.)

However it breaks a load of other tests related to reverse mappings - I'm going to raise a separate PR about that.