### PR TITLE
remove support for long-since-deprecated callbacks from promise-returning methods

### DIFF
--- a/src/Ractive/prototype/merge.js
+++ b/src/Ractive/prototype/merge.js
@@ -1,10 +1,8 @@
 import { isArray } from 'utils/is';
-import log from 'utils/log/log';
 import { getKeypath, normalise } from 'shared/keypaths';
 import runloop from 'global/runloop';
 
 export default function Ractive$merge ( keypath, array, options ) {
-
 	var currentArray,
 		promise;
 
@@ -21,27 +19,6 @@ export default function Ractive$merge ( keypath, array, options ) {
 	promise = runloop.start( this, true );
 	this.viewmodel.merge( keypath, currentArray, array, options );
 	runloop.end();
-
-	// attach callback as fulfilment handler, if specified
-	if ( options && options.complete ) {
-
-		log.warn({
-			debug: this.debug,
-			message: 'usePromise',
-			args: {
-				method: 'ractive.merge'
-			}
-		});
-
-		promise
-			.then( options.complete )
-			.then( null, err => {
-				log.consoleError({
-					debug: this.debug,
-					err: err
-				});
-			});
-	}
 
 	return promise;
 }

--- a/src/Ractive/prototype/reset.js
+++ b/src/Ractive/prototype/reset.js
@@ -1,23 +1,16 @@
 import config from 'Ractive/config/config';
 import Fragment from 'virtualdom/Fragment';
 import Hook from './shared/hooks/Hook';
-import log from 'utils/log/log';
 import runloop from 'global/runloop';
 import { rootKeypath } from 'shared/keypaths';
 
 var shouldRerender = [ 'template', 'partials', 'components', 'decorators', 'events' ],
 	resetHook = new Hook( 'reset' );
 
-export default function Ractive$reset ( data, callback ) {
-
+export default function Ractive$reset ( data ) {
 	var promise, wrapper, changes, i, rerender;
 
-	if ( typeof data === 'function' && !callback ) {
-		callback = data;
-		data = {};
-	} else {
-		data = data || {};
-	}
+	data = data || {};
 
 	if ( typeof data !== 'object' ) {
 		throw new Error( 'The reset method takes either no arguments, or an object containing new data' );
@@ -83,26 +76,6 @@ export default function Ractive$reset ( data, callback ) {
 	}
 
 	resetHook.fire( this, data );
-
-	if ( callback ) {
-
-		log.warn({
-			debug: this.debug,
-			message: 'usePromise',
-			args: {
-				method: 'ractive.reset'
-			}
-		});
-
-		promise
-			.then( callback )
-			.then( null, err => {
-				log.consoleError({
-					debug: this.debug,
-					err: err
-				});
-			});
-	}
 
 	return promise;
 }

--- a/src/Ractive/prototype/resetPartial.js
+++ b/src/Ractive/prototype/resetPartial.js
@@ -1,9 +1,8 @@
 import { isArray } from 'utils/is';
-import log from 'utils/log/log';
 import runloop from 'global/runloop';
 import { PARTIAL, COMPONENT, ELEMENT } from 'config/types';
 
-export default function( name, partial, callback ) {
+export default function ( name, partial ) {
 	var promise, collection = [];
 
 	function collect( source, dest, ractive ) {
@@ -60,26 +59,6 @@ export default function( name, partial, callback ) {
 	});
 
 	runloop.end();
-
-	if ( callback ) {
-
-		log.warn({
-			debug: this.debug,
-			message: 'usePromise',
-			args: {
-				method: 'ractive.resetPartial'
-			}
-		});
-
-		promise
-			.then( callback.bind( this ) )
-			.then( null, err => {
-				log.consoleError({
-					debug: this.debug,
-					err: err
-				});
-			});
-	}
 
 	return promise;
 }

--- a/src/Ractive/prototype/set.js
+++ b/src/Ractive/prototype/set.js
@@ -1,12 +1,11 @@
 import { isObject } from 'utils/is';
 import { getMatchingKeypaths } from 'shared/keypaths';
-import log from 'utils/log/log';
 import { getKeypath, normalise } from 'shared/keypaths';
 import runloop from 'global/runloop';
 
 var wildcard = /\*/;
 
-export default function Ractive$set ( keypath, value, callback ) {
+export default function Ractive$set ( keypath, value ) {
 	var map, promise;
 
 	promise = runloop.start( this, true );
@@ -14,7 +13,6 @@ export default function Ractive$set ( keypath, value, callback ) {
 	// Set multiple keypaths in one go
 	if ( isObject( keypath ) ) {
 		map = keypath;
-		callback = value;
 
 		for ( keypath in map ) {
 			if ( map.hasOwnProperty( keypath) ) {
@@ -42,26 +40,6 @@ export default function Ractive$set ( keypath, value, callback ) {
 	}
 
 	runloop.end();
-
-	if ( callback ) {
-
-		log.warn({
-			debug: this.debug,
-			message: 'usePromise',
-			args: {
-				method: 'ractive.set'
-			}
-		});
-
-		promise
-			.then( callback.bind( this ) )
-			.then( null, err => {
-				log.consoleError({
-					debug: this.debug,
-					err: err
-				});
-			});
-	}
 
 	return promise;
 }

--- a/src/Ractive/prototype/teardown.js
+++ b/src/Ractive/prototype/teardown.js
@@ -1,5 +1,4 @@
 import Hook from './shared/hooks/Hook';
-import log from 'utils/log/log';
 import Promise from 'utils/Promise';
 import { removeFromArray } from 'utils/array';
 
@@ -8,7 +7,7 @@ var teardownHook = new Hook( 'teardown' );
 // Teardown. This goes through the root fragment and all its children, removing observers
 // and generally cleaning up after itself
 
-export default function Ractive$teardown ( callback ) {
+export default function Ractive$teardown () {
 	var promise;
 
 	this.fragment.unbind();
@@ -22,26 +21,6 @@ export default function Ractive$teardown ( callback ) {
 	promise = ( this.fragment.rendered ? this.unrender() : Promise.resolve() );
 
 	teardownHook.fire( this );
-
-	if ( callback ) {
-
-		log.warn({
-			debug: this.debug,
-			message: 'usePromise',
-			args: {
-				method: 'ractive.teardown'
-			}
-		});
-
-		promise
-			.then( callback.bind( this ) )
-			.then( null, err => {
-				log.consoleError({
-					debug: this.debug,
-					err: err
-				});
-			});
-	}
 
 	this._boundFunctions.forEach( deleteFunctionCopy );
 

--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -1,46 +1,19 @@
 import Hook from './shared/hooks/Hook';
-import log from 'utils/log/log';
 import runloop from 'global/runloop';
 import { getKeypath, rootKeypath } from 'shared/keypaths';
 
 var updateHook = new Hook( 'update' );
 
-export default function Ractive$update ( keypath, callback ) {
+export default function Ractive$update ( keypath ) {
 	var promise;
 
-	if ( typeof keypath === 'function' ) {
-		callback = keypath;
-		keypath = rootKeypath;
-	} else {
-		keypath = getKeypath( keypath ) || rootKeypath;
-	}
+	keypath = getKeypath( keypath ) || rootKeypath;
 
 	promise = runloop.start( this, true );
-
 	this.viewmodel.mark( keypath );
 	runloop.end();
 
 	updateHook.fire( this, keypath );
-
-	if ( callback ) {
-
-		log.warn({
-			debug: this.debug,
-			message: 'usePromise',
-			args: {
-				method: 'ractive.teardown'
-			}
-		});
-
-		promise
-			.then( callback.bind( this ) )
-			.then( null, err => {
-				log.consoleError({
-					debug: this.debug,
-					err: err
-				});
-			});
-	}
 
 	return promise;
 }

--- a/src/config/errors.js
+++ b/src/config/errors.js
@@ -41,9 +41,6 @@ export default {
 	methodDeprecated:
 		'The method "{deprecated}" has been deprecated in favor of "{replacement}" and will likely be removed in a future release. See http://docs.ractivejs.org/latest/migrating for more information.',
 
-	usePromise:
-		'{method} now returns a Promise, use {method}(...).then(callback) instead.',
-
 	noTwowayExpressions:
 		'Two-way binding does not work with expressions. Encountered ( {expression} ) on element {element}.',
 

--- a/src/virtualdom/items/Element/Transition/prototype/animateStyle/_animateStyle.js
+++ b/src/virtualdom/items/Element/Transition/prototype/animateStyle/_animateStyle.js
@@ -1,7 +1,6 @@
 import warn from 'utils/log/warn';
 import { isClient } from 'config/environment';
 import legacy from 'legacy';
-import log from 'utils/log/log';
 import prefix from 'virtualdom/items/Element/Transition/helpers/prefix';
 import Promise from 'utils/Promise';
 import createTransitions from './createTransitions';
@@ -14,9 +13,12 @@ if ( !isClient ) {
 } else {
 	getComputedStyle = window.getComputedStyle || legacy.getComputedStyle;
 
-	animateStyle = function ( style, value, options, complete ) {
-
+	animateStyle = function ( style, value, options ) {
 		var to;
+
+		if ( arguments.length === 4 ) {
+			throw new Error( 't.animateStyle() returns a promise - use .then() instead of passing a callback' );
+		}
 
 		// Special case - page isn't visible. Don't animate anything, because
 		// that way you'll never get CSS transitionend events
@@ -32,7 +34,6 @@ if ( !isClient ) {
 			to = style;
 
 			// shuffle arguments
-			complete = options;
 			options = value;
 		}
 
@@ -43,9 +44,7 @@ if ( !isClient ) {
 		// TODO remove this check in a future version
 		if ( !options ) {
 			warn( 'The "' + this.name + '" transition does not supply an options object to `t.animateStyle()`. This will break in a future version of Ractive. For more info see https://github.com/RactiveJS/Ractive/issues/340' );
-
 			options = this;
-			complete = this.complete;
 		}
 
 		var promise = new Promise( resolve => {
@@ -94,28 +93,6 @@ if ( !isClient ) {
 
 			createTransitions( this, to, options, changedProperties, resolve );
 		});
-
-		// If a callback was supplied, do the honours
-		// TODO remove this check in future
-		if ( complete ) {
-
-			log.warn({
-				debug: true, // no ractive instance to govern this
-				message: 'usePromise',
-				args: {
-					method: 't.animateStyle'
-				}
-			});
-
-			promise
-				.then( complete )
-				.then( null, err => {
-					log.consoleError({
-						debug: true,
-						err: err
-					});
-				});
-		}
 
 		return promise;
 	};

--- a/test/modules/animate.js
+++ b/test/modules/animate.js
@@ -50,29 +50,6 @@ define([ 'ractive' ], function ( Ractive ) {
 			});
 		});
 
-
-		asyncTest( 'error in callback sent to console', function ( t ) {
-			var ractive, error = console.error;
-
-			expect( 1 )
-
-			console.error = function ( err ) {
-				t.equal( err, 'evil animate' );
-				console.error = error;
-				QUnit.start();
-			}
-
-			ractive = new Ractive({
-				el: fixture,
-				template: '{{~~foo}}',
-				data: { foo: 0 }
-			});
-
-			ractive.animate({ foo: 100 }, { duration: 10, complete: function () {
-				throw 'evil animate';
-			} });
-		});
-
 	};
 
 });

--- a/test/modules/merge.js
+++ b/test/modules/merge.js
@@ -335,29 +335,6 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.htmlEqual( ractive.toHTML(), 'ba' );
 		});
 
-
-		asyncTest( 'error in promise sent to console', function ( t ) {
-			var ractive, error = console.error;
-
-			expect( 1 )
-			console.error = function ( err ) {
-				t.equal( err, 'evil resolve' );
-				console.error = error;
-				QUnit.start();
-			}
-
-			ractive = new Ractive({
-				template: "{{#items}}{{.}}{{/}}",
-				data: {
-					items: [ 'a','b' ]
-				}
-			});
-
-			ractive.merge( 'items', [ 'b', 'a' ], { complete: () => {
-				throw 'evil resolve';
-			} });
-		});
-
 	};
 
 	function isOrphan ( node ) {

--- a/test/modules/reset.js
+++ b/test/modules/reset.js
@@ -38,7 +38,7 @@ define([ 'ractive' ], function ( Ractive ) {
 
 		});
 
-		asyncTest( 'Callback and promise with reset', function ( t ) {
+		asyncTest( 'ractive.reset() returns a promise', function ( t ) {
 			var ractive, callback, counter, done;
 
 			ractive = new Ractive({
@@ -56,11 +56,11 @@ define([ 'ractive' ], function ( Ractive ) {
 			};
 
 			expect(6)
-			ractive.reset({ two: 4 }, callback);
+			ractive.reset({ two: 4 }).then(callback);
 			t.htmlEqual( fixture.innerHTML, '4' );
 			ractive.reset({ one: 9 }).then(callback);
 			t.htmlEqual( fixture.innerHTML, '9' );
-			ractive.reset(callback);
+			ractive.reset().then(callback);
 			t.htmlEqual( fixture.innerHTML, '' );
 		});
 
@@ -81,7 +81,7 @@ define([ 'ractive' ], function ( Ractive ) {
 			});
 		});
 
-		asyncTest( 'Callback and promise with dynamic template functions are recalled on reset', function ( t ) {
+		asyncTest( 'Promise with dynamic template functions are recalled on reset', function ( t ) {
 			var ractive, callback, counter, done;
 
 			ractive = new Ractive({
@@ -107,7 +107,7 @@ define([ 'ractive' ], function ( Ractive ) {
 			ractive.reset(ractive.data).then(callback);
 			t.htmlEqual( fixture.innerHTML, 'bizz' );
 			ractive.set('condition', true)
-			ractive.reset(ractive.data, callback);
+			ractive.reset(ractive.data).then(callback);
 			t.htmlEqual( fixture.innerHTML, 'fizz' );
 
 		});


### PR DESCRIPTION
This PR removes support for the callback in `ractive.set(keypath, value, callback)`, which was deprecated long ago - `ractive.set()` and [various other methods](http://docs.ractivejs.org/latest/promises) return a promise. 
