### PR TITLE
Fixed invalid template keypath

### DIFF
--- a/src/Ractive/config/custom/template/template.js
+++ b/src/Ractive/config/custom/template/template.js
@@ -106,7 +106,8 @@ function parseIfString ( template, ractive ) {
 
 		template = parse( template, parser.getParseOptions( ractive ) );
 	}
-
+	// Check if template is undefined because there'll be no `v` property to check for mismatch
+	else if ( typeof c === "undefined" ) throw new Error("Invalid template , make sure specified template exists !");
 	// Check we're using the correct version
 	else if ( template.v !== 2 ) {
 		throw new Error( 'Mismatched template version! Please ensure you are using the latest version of Ractive.js in your build process as well as in your app' );


### PR DESCRIPTION
Solving `Cannot read property 'v' of undefined` error while sending invalid keypath as template to Ractive instance.