### PR TITLE
Illegal property name fix for legacy build

### DIFF
--- a/src/utils/parseJSON.js
+++ b/src/utils/parseJSON.js
@@ -10,12 +10,13 @@ import getKey from 'parse/Parser/expressions/shared/key';
 
 var JsonParser, specials, specialsPattern, numberPattern, placeholderPattern, placeholderAtStartPattern, onlyWhitespace;
 
-specials = {
-	['true' + '']: true,
-	['false' + '']: false,
-	['undefined' + '']: undefined,
-	['null' + '']: null
-};
+specials = (( o ) => {
+	o['true'] = true;
+	o['false'] = false;
+	o['undefined'] = undefined;
+	o['null'] = null;
+	return o;
+})({});
 
 specialsPattern = new RegExp( '^(?:' + Object.keys( specials ).join( '|' ) + ')' );
 numberPattern = /^(?:[+-]?)(?:(?:(?:0|[1-9]\d*)?\.\d+)|(?:(?:0|[1-9]\d*)\.)|(?:0|[1-9]\d*))(?:[eE][+-]?\d+)?/;


### PR DESCRIPTION
IE8 only officially supports es3, which doesn't allow keywords as property names. 6to5 converts quoted property names in object literals into non-quoted names, which breaks the legacy build in the `parseJSON` module. This works around it by building the object on the fly, since there doesn't seem to be a way to turn off this particular feature of 6to5... not that there really should be, as the warning is right there on the tin (to5). I would be more worried about it if it was a pervasive problem, but it looks like it's just the one place in a patch of code that only gets run on init. Is that reasonable?
