### PR TITLE
Illegal property name fix for legacy build - take 2

### DIFF
--- a/src/utils/parseJSON.js
+++ b/src/utils/parseJSON.js
@@ -10,13 +10,12 @@ import getKey from 'parse/Parser/expressions/shared/key';
 
 var JsonParser, specials, specialsPattern, numberPattern, placeholderPattern, placeholderAtStartPattern, onlyWhitespace;
 
-specials = (( o ) => {
-	o['true'] = true;
-	o['false'] = false;
-	o['undefined'] = undefined;
-	o['null'] = null;
-	return o;
-})({});
+specials = {
+	['true' + '']: true,
+	['false' + '']: false,
+	['undefined' + '']: undefined,
+	['null' + '']: null
+};
 
 specialsPattern = new RegExp( '^(?:' + Object.keys( specials ).join( '|' ) + ')' );
 numberPattern = /^(?:[+-]?)(?:(?:(?:0|[1-9]\d*)?\.\d+)|(?:(?:0|[1-9]\d*)\.)|(?:0|[1-9]\d*))(?:[eE][+-]?\d+)?/;


### PR DESCRIPTION
Eesh. This fixes my screwup on the previous fix wherein 6to5 _still_ output keywords as property names, albeit in a different format.
