### PR TITLE
Make sure named checkbox bindings stay up to date with the viewmodel

### DIFF
--- a/src/virtualdom/items/Element/Attribute/prototype/update/updateCheckboxName.js
+++ b/src/virtualdom/items/Element/Attribute/prototype/update/updateCheckboxName.js
@@ -1,20 +1,20 @@
 import { isArray } from 'utils/is';
 
 export default function Attribute$updateCheckboxName () {
-	var { element, node, value } = this, valueAttribute, i;
+	var { element, node, value } = this, { binding } = element, valueAttribute, i;
 
 	valueAttribute = element.getAttribute( 'value' );
 
 	if ( !isArray( value ) ) {
-		node.checked = ( value == valueAttribute );
+		binding.isChecked = node.checked = ( value == valueAttribute );
 	} else {
 		i = value.length;
 		while ( i-- ) {
 			if ( valueAttribute == value[i] ) {
-				node.checked = true;
+				binding.isChecked = node.checked = true;
 				return;
 			}
 		}
-		node.checked = false;
+		binding.isChecked = node.checked = false;
 	}
 }

--- a/test/modules/twoway.js
+++ b/test/modules/twoway.js
@@ -243,6 +243,23 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.ok( !ractive.nodes.green.checked );
 		});
 
+		test( 'Named checkbox bindings are kept in sync with data changes (#1610)', t => {
+			var ractive = new Ractive({
+				el: fixture,
+				template: `
+				<input type="checkbox" name="{{colors}}" value="red" />
+				<input type="checkbox" name="{{colors}}" value="blue" />
+				<input type="checkbox" name="{{colors}}" value="green" /> `,
+				data: { colors: [ 'red', 'blue' ] }
+			});
+
+			ractive.set( 'colors', [ 'green' ] );
+			t.deepEqual( ractive.get( 'colors' ), [ 'green' ] );
+
+			simulant.fire( ractive.find( 'input' ), 'click' );
+			t.deepEqual( ractive.get( 'colors' ), [ 'red', 'green' ]);
+		});
+
 		test( 'The model updates to reflect which radio input is checked at render time', function ( t ) {
 			var ractive;
 


### PR DESCRIPTION
If you change a named checkbox groups underlying array using `set`, the next time the DOM handler fires to update the array, it will be replaced by what the CheckboxNameBindings know. This modifies the `Attribute.updateCheckboxName` method to update the binding checked state at the same time the checkbox  state is updated to avoid that. Fixes #1610
