### PR TITLE
Fix the perfect storm of circumstances bug - #1608

### DIFF
--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -144,6 +144,7 @@ function attemptKeypathResolution () {
 			// it resolved some other way. TODO how? two-way binding? Seems
 			// weird that we'd still end up here
 			unresolved.splice( i, 1 );
+			continue; // avoid removing the wrong thing should the next condition be true
 		}
 
 		if ( keypath = resolveRef( item.root, item.ref, item.parentFragment ) ) {

--- a/test/modules/twoway.js
+++ b/test/modules/twoway.js
@@ -677,6 +677,25 @@ define([ 'ractive' ], function ( Ractive ) {
 			t.ok( !inputs[2].checked );
 		});
 
+		test( 'If there happen to be unresolved references next to binding resolved references, the unresolveds should not be evicted by mistake (#1608)', t => {
+			var ractive = new Ractive({
+				el: fixture,
+				template: `
+					{{#context}}
+					  <select value="{{bar}}"><option>baz</option></select><input type="checkbox" checked="{{foo}}" />
+					  <div>{{#foo}}true{{else}}false{{/}}</div>
+					{{/}}`,
+				data: {
+					context: {}
+				}
+			});
+
+			var div = ractive.find( 'div' );
+			t.htmlEqual( div.innerHTML, 'false' );
+			simulant.fire( ractive.find( 'input' ), 'click' );
+			t.htmlEqual( div.innerHTML, 'true' );
+		});
+
 	};
 
 });


### PR DESCRIPTION
Within a context that has no value, having two fairly specific two-way bindings before a conditional section (or probably anything else left unresolved due to the context ambiguity) would cause the mustache immediately after the second to be lost in the ether. All that was missing was a continue to avoid processing the same index twice in this type of scenario.

Hat tip to @anton-ryzhov for the excellent test-case distillery.
