### PR TITLE
Fixes computations referencing mappings that throw when the mapping resolves

### DIFF
--- a/src/shared/parameters/Mapping.js
+++ b/src/shared/parameters/Mapping.js
@@ -95,7 +95,14 @@ Mapping.prototype = {
 			this.deps.forEach( d => {
 				var keypath = this.map( d.keypath );
 				this.origin.register( keypath, d.dep, d.group );
-				d.dep.setValue( this.origin.get( keypath ) );
+
+				// if the dep has a setter, it's a reference, otherwise, a computation
+				if ( isFunction( d.dep.setValue ) ) {
+					d.dep.setValue( this.origin.get( keypath ) );
+				} else {
+					// computations have no setter, get it to recompute via viewmodel
+					this.local.mark( d.dep.key );
+				}
 			});
 
 			this.origin.mark( this.keypath );

--- a/test/__tests/components.js
+++ b/test/__tests/components.js
@@ -814,3 +814,19 @@ test( 'Two-way bindings on an unresolved key can force resolution', t => {
 
 	t.equal( ractive.find( 'input' ).value, 'hello' );
 });
+
+test( 'Component mappings used in computations resolve correctly with the mapping (#1645)', t => {
+	var ractive = new Ractive({
+		el: fixture,
+		template: '<c1/>',
+		components: {
+			c1: Ractive.extend({ template: '<c2 foo="{{bar}}" />' }),
+			c2: Ractive.extend({ template: '{{JSON.stringify(foo)}}' })
+		},
+		onrender: function() {
+			this.set( 'bar', {} );
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, ractive.toHTML() );
+});


### PR DESCRIPTION
This fixes #1645. I'm not 100% positive that this is the correct resolution for this, but it does work. Is there a better place to handle this and/or is there another corner case to cover?

Hat tip to @anton-ryzhov again for an excellent test case!