### PR TITLE
Revert 1641

### DIFF
--- a/src/Ractive/static/adaptors/magic.js
+++ b/src/Ractive/static/adaptors/magic.js
@@ -84,7 +84,7 @@ try {
 			this.updating = true;
 			this.obj[ this.prop ] = value; // trigger set() accessor
 			runloop.addViewmodel( this.ractive.viewmodel );
-			this.ractive.viewmodel.mark( this.keypath, { teardownWrapper: false } );
+			this.ractive.viewmodel.mark( this.keypath, { dontTeardownWrapper: true } );
 			this.updating = false;
 			return true;
 		},

--- a/src/Ractive/static/adaptors/magic.js
+++ b/src/Ractive/static/adaptors/magic.js
@@ -84,7 +84,7 @@ try {
 			this.updating = true;
 			this.obj[ this.prop ] = value; // trigger set() accessor
 			runloop.addViewmodel( this.ractive.viewmodel );
-			this.ractive.viewmodel.mark( this.keypath, { dontTeardownWrapper: true } );
+			this.ractive.viewmodel.mark( this.keypath, { keepExistingWrapper: true } );
 			this.updating = false;
 			return true;
 		},

--- a/src/viewmodel/prototype/clearCache.js
+++ b/src/viewmodel/prototype/clearCache.js
@@ -1,7 +1,7 @@
-export default function Viewmodel$clearCache ( keypath, teardownWrapper ) {
+export default function Viewmodel$clearCache ( keypath, dontTeardownWrapper ) {
 	var cacheMap, wrapper;
 
-	if ( teardownWrapper ) {
+	if ( !dontTeardownWrapper ) {
 		// Is there a wrapped property at this keypath?
 		if ( wrapper = this.wrapped[ keypath ] ) {
 			// Did we unwrap it?

--- a/src/viewmodel/prototype/clearCache.js
+++ b/src/viewmodel/prototype/clearCache.js
@@ -1,7 +1,7 @@
-export default function Viewmodel$clearCache ( keypath, dontTeardownWrapper ) {
+export default function Viewmodel$clearCache ( keypath, keepExistingWrapper ) {
 	var cacheMap, wrapper;
 
-	if ( !dontTeardownWrapper ) {
+	if ( !keepExistingWrapper ) {
 		// Is there a wrapped property at this keypath?
 		if ( wrapper = this.wrapped[ keypath ] ) {
 			// Did we unwrap it?

--- a/src/viewmodel/prototype/mark.js
+++ b/src/viewmodel/prototype/mark.js
@@ -24,8 +24,8 @@ export default function Viewmodel$mark ( keypath, options ) {
 		this.changes.push( keypath );
 	}
 
-	// pass on dontTeardownWrapper, if we can
-	let dontTeardownWrapper = options ? options.dontTeardownWrapper : false;
+	// pass on keepExistingWrapper, if we can
+	let keepExistingWrapper = options ? options.keepExistingWrapper : false;
 
-	this.clearCache( keypathStr, dontTeardownWrapper );
+	this.clearCache( keypathStr, keepExistingWrapper );
 }

--- a/src/viewmodel/prototype/mark.js
+++ b/src/viewmodel/prototype/mark.js
@@ -24,8 +24,8 @@ export default function Viewmodel$mark ( keypath, options ) {
 		this.changes.push( keypath );
 	}
 
-	// pass on teardownWrapper, if we can
-	let teardownWrapper = options ? options.teardownWrapper : true;
+	// pass on dontTeardownWrapper, if we can
+	let dontTeardownWrapper = options ? options.dontTeardownWrapper : false;
 
-	this.clearCache( keypathStr, teardownWrapper );
+	this.clearCache( keypathStr, dontTeardownWrapper );
 }

--- a/src/viewmodel/prototype/set.js
+++ b/src/viewmodel/prototype/set.js
@@ -2,7 +2,7 @@ import { isEqual } from 'utils/is';
 import createBranch from 'utils/createBranch';
 
 export default function Viewmodel$set ( keypath, value, options = {} ) {
-	var mapping, computation, wrapper, dontTeardownWrapper;
+	var mapping, computation, wrapper, keepExistingWrapper;
 
 	// unless data is being set for data tracking purposes
 	if ( !options.noMapping ) {
@@ -33,14 +33,14 @@ export default function Viewmodel$set ( keypath, value, options = {} ) {
 	// `reset()` method returns false, the wrapper should be torn down, and
 	// (most likely) a new one should be created later
 	if ( wrapper && wrapper.reset ) {
-		dontTeardownWrapper = ( wrapper.reset( value ) !== false );
+		keepExistingWrapper = ( wrapper.reset( value ) !== false );
 
-		if ( dontTeardownWrapper ) {
+		if ( keepExistingWrapper ) {
 			value = wrapper.get();
 		}
 	}
 
-	if ( !computation && !dontTeardownWrapper ) {
+	if ( !computation && !keepExistingWrapper ) {
 		resolveSet( this, keypath, value );
 	}
 

--- a/src/viewmodel/prototype/set.js
+++ b/src/viewmodel/prototype/set.js
@@ -2,7 +2,7 @@ import { isEqual } from 'utils/is';
 import createBranch from 'utils/createBranch';
 
 export default function Viewmodel$set ( keypath, value, options = {} ) {
-	var mapping, computation, wrapper, teardownWrapper;
+	var mapping, computation, wrapper, dontTeardownWrapper;
 
 	// unless data is being set for data tracking purposes
 	if ( !options.noMapping ) {
@@ -33,14 +33,14 @@ export default function Viewmodel$set ( keypath, value, options = {} ) {
 	// `reset()` method returns false, the wrapper should be torn down, and
 	// (most likely) a new one should be created later
 	if ( wrapper && wrapper.reset ) {
-		teardownWrapper = ( wrapper.reset( value ) === false );
+		dontTeardownWrapper = ( wrapper.reset( value ) !== false );
 
-		if ( !teardownWrapper ) {
+		if ( dontTeardownWrapper ) {
 			value = wrapper.get();
 		}
 	}
 
-	if ( !computation && teardownWrapper ) {
+	if ( !computation && !dontTeardownWrapper ) {
 		resolveSet( this, keypath, value );
 	}
 


### PR DESCRIPTION
@Madgvox I'm afraid #1641 caused 41 tests to fail! Totally my fault that it wasn't caught - in the process of updating the build/test scripts to not use grunt, I forgot to put `set -e` at the top of the scripts, which meant that Travis didn't bug out when the tests failed.

So I've had to revert the change. But I agree that double negatives are confusing - I figured that an easier way to get the tests to pass again would be to keep everything as it was, but replace `dontTeardownWrapper` with `keepExistingWrapper`.

Going to merge this immediately as there's currently no http://cdn.ractivejs.org/edge/ractive.js