### PR TITLE
bump edge version -> 0.7.0-edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ractive",
   "description": "Next-generation DOM manipulation",
-  "version": "0.6.1",
+  "version": "0.7.0-edge",
   "homepage": "http://ractivejs.org",
   "main": "ractive.js",
   "keywords": [


### PR DESCRIPTION
See #1672. Probably makes sense for the edge version to reflect the future rather than the present. Anyone have any objections (i.e. could it break anything)?