### PR TITLE
allow inline partials, and named yields, to have hyphenated names

### DIFF
--- a/src/parse/converters/mustache/readPartialDefinitionSection.js
+++ b/src/parse/converters/mustache/readPartialDefinitionSection.js
@@ -12,7 +12,7 @@ export default function readPartialDefinitionSection ( parser, tag ) {
 
 	start = parser.pos;
 
-	name = parser.matchPattern( /^[a-zA-Z_$][a-zA-Z_$0-9]*/ );
+	name = parser.matchPattern( /^[a-zA-Z_$][a-zA-Z_$0-9\-]*/ );
 
 	if ( !name ) {
 		parser.error( 'expected legal partial name' );

--- a/src/parse/converters/mustache/readYielder.js
+++ b/src/parse/converters/mustache/readYielder.js
@@ -10,7 +10,7 @@ export default function readYielder ( parser, tag ) {
 	}
 
 	start = parser.pos;
-	name = parser.matchPattern( /^[a-zA-Z_$][a-zA-Z_$0-9]*/ );
+	name = parser.matchPattern( /^[a-zA-Z_$][a-zA-Z_$0-9\-]*/ );
 
 	parser.allowWhitespace();
 

--- a/src/parse/converters/mustache/readYielder.js
+++ b/src/parse/converters/mustache/readYielder.js
@@ -15,8 +15,7 @@ export default function readYielder ( parser, tag ) {
 	parser.allowWhitespace();
 
 	if ( !parser.matchString( tag.close ) ) {
-		parser.pos = start;
-		return null;
+		parser.error( `expected legal partial name` );
 	}
 
 	yielder = { t: YIELDER };

--- a/test/__tests/yield.js
+++ b/test/__tests/yield.js
@@ -173,3 +173,26 @@ test( 'A component {{yield}} should be parented by the fragment holding the yiel
 
 	t.htmlEqual( fixture.innerHTML, '<div>foo! foo!</div>' );
 });
+
+test( 'Named yield with a hyphenated name (#1681)', t => {
+	let template, widget;
+
+	template = `
+		<widget>
+			{{#partial foo-bar}}
+				<p>this is foo-bar</p>
+			{{/partial}}
+		</widget>`;
+
+	widget = Ractive.extend({
+		template: '{{yield foo-bar}}'
+	});
+
+	new Ractive({
+		el: fixture,
+		template: template,
+		components: { widget }
+	});
+
+	t.htmlEqual( fixture.innerHTML, '<p>this is foo-bar</p>' );
+});

--- a/test/__tests/yield.js
+++ b/test/__tests/yield.js
@@ -196,3 +196,11 @@ test( 'Named yield with a hyphenated name (#1681)', t => {
 
 	t.htmlEqual( fixture.innerHTML, '<p>this is foo-bar</p>' );
 });
+
+test( 'Named yield must have valid name, not expression (#1681)', t => {
+	t.throws( () => {
+		let widget = Ractive.extend({
+			template: '{{yield "<p>nope</p>"}}'
+		});
+	}, /expected legal partial name/ );
+});

--- a/test/gobblefile.js
+++ b/test/gobblefile.js
@@ -71,8 +71,7 @@ testModules = gobble([
 testPages = testModules.transform( function () {
 	return templates.testpage({
 		testModule: path.basename( this.filename ),
-		name: this.filename.replace( /\.js$/, '' ),
-		pathPrefix: getPathPrefix( this.filename )
+		name: this.filename.replace( /\.js$/, '' )
 	});
 }, { accept: '.js', ext: '.html' });
 


### PR DESCRIPTION
See #1681