### PR TITLE
Add missing package.json entry for phantom.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "jshint": "^2.5.11",
     "mocha": "^2.1.0",
     "node-qunit-phantomjs": "^1.2.0",
+    "phantomjs": "^1.9.15",
     "promises-aplus-tests": "*",
     "sander": "^0.2.1",
     "uglify-js": "^2.4.16"


### PR DESCRIPTION
Did an `npm install` after `rm -rf node_modules` and `npm cache clean` and `npm run build` failed missing phantomjs. Any reason it shouldn't be in the dev dependencies?