### PR TITLE
fixes #1703 - encapsulated styles are forwarded to components until they can be applied

### DIFF
--- a/src/Ractive/config/custom/css/transform.js
+++ b/src/Ractive/config/custom/css/transform.js
@@ -2,12 +2,12 @@ var selectorsPattern = /(?:^|\})?\s*([^\{\}]+)\s*\{/g,
 	commentsPattern = /\/\*.*?\*\//g,
 	selectorUnitPattern = /((?:(?:\[[^\]+]\])|(?:[^\s\+\>\~:]))+)((?::[^\s\+\>\~\(]+(?:\([^\)]+\))?)?\s*[\s\+\>\~]?)\s*/g,
 	mediaQueryPattern = /^@media/,
-	dataRvcGuidPattern = /\[data-ractive-css="[a-z0-9-]+"]/g;
+	dataRvcGuidPattern = /\[data-ractive-css~="\{[a-z0-9-]+\}"]/g;
 
 export default function transformCss( css, id ) {
 	var transformed, dataAttr, addGuid;
 
-	dataAttr = `[data-ractive-css="${id}"]`;
+	dataAttr = `[data-ractive-css~="{${id}}"]`;
 
 	addGuid = function ( selector ) {
 		var selectorUnits, match, unit, base, prepended, appended, i, transformed = [];

--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -48,10 +48,21 @@ function initialiseRactiveInstance ( ractive, userOptions = {}, options = {} ) {
 
 	// Render our *root fragment*
 	if ( ractive.template ) {
+		let cssIds;
+
+		if ( options.cssIds || ractive.constructor.css ) {
+			cssIds = options.cssIds ? options.cssIds.slice() : [];
+
+			if ( ractive.constructor.css ) {
+				cssIds.push( ractive.constructor._guid );
+			}
+		}
+
 		ractive.fragment = new Fragment({
 			template: ractive.template,
 			root: ractive,
 			owner: ractive, // saves doing `if ( this.parent ) { /*...*/ }` later on
+			cssIds
 		});
 	}
 

--- a/src/virtualdom/Fragment/prototype/init.js
+++ b/src/virtualdom/Fragment/prototype/init.js
@@ -23,6 +23,9 @@ export default function Fragment$init ( options ) {
 	this.key = options.key;
 	this.registeredIndexRefs = [];
 
+	// encapsulated styles should be inherited until they get applied by an element
+	this.cssIds = options.cssIds || ( this.parent ? this.parent.cssIds : null );
+
 	this.items = options.template.map( ( template, i ) => createItem({
 		parentFragment: this,
 		pElement: options.pElement,

--- a/src/virtualdom/items/Component/initialise/createInstance.js
+++ b/src/virtualdom/items/Component/initialise/createInstance.js
@@ -49,7 +49,8 @@ export default function ( component, Component, parameters, yieldTemplate, parti
 		component: component,
 		container: container,
 		mappings: parameters.mappings,
-		inlinePartials: inlinePartials
+		inlinePartials: inlinePartials,
+		cssIds: parentFragment.cssIds
 	});
 
 	return instance;

--- a/src/virtualdom/items/Element/prototype/init.js
+++ b/src/virtualdom/items/Element/prototype/init.js
@@ -63,6 +63,7 @@ export default function Element$init ( options ) {
 			root:     ractive,
 			owner:    this,
 			pElement: this,
+			cssIds: null
 		});
 	}
 

--- a/src/virtualdom/items/Element/prototype/render.js
+++ b/src/virtualdom/items/Element/prototype/render.js
@@ -51,11 +51,8 @@ export default function Element$render () {
 
 	// Is this a top-level node of a component? If so, we may need to add
 	// a data-ractive-css attribute, for CSS encapsulation
-	// NOTE: css no longer copied to instance, so we check constructor.css -
-	// we can enhance to handle instance, but this is more "correct" with current
-	// functionality
-	if ( root.constructor.css && this.parentFragment.getNode() === root.el ) {
-		this.node.setAttribute( 'data-ractive-css', root.constructor._guid /*|| root._guid*/ );
+	if ( this.parentFragment.cssIds ) {
+		this.node.setAttribute( 'data-ractive-css', this.parentFragment.cssIds.map( x => `{${x}}` ).join( ' ' ) );
 	}
 
 	// Add _ractive property to the node - we use this object to store stuff

--- a/test/__tests/css.js
+++ b/test/__tests/css.js
@@ -228,3 +228,54 @@ test( 'nth-child selectors work', function ( t ) {
 	t.equal( getHexColor( lis[3] ), hexCodes.green );
 	t.equal( getHexColor( lis[4] ), hexCodes.red );
 });
+
+test( 'Components forward encapsulation instructions to top-level components in their own templates', t => {
+	let inner = Ractive.extend({
+		template: '<p>red, bold, italic</p>',
+		css: 'p { color: red; }'
+	});
+
+	let middle = Ractive.extend({
+		template: '<inner/>',
+		css: 'p { font-weight: bold; }',
+		components: { inner }
+	});
+
+	let Outer = Ractive.extend({
+		template: '<middle/>',
+		css: 'p { font-style: italic; }',
+		components: { middle }
+	});
+
+	let ractive = new Outer({
+		el: fixture
+	});
+
+	let p = ractive.find( 'p' );
+	let style = getComputedStyle( p );
+
+	t.equal( getHexColor( p ), hexCodes.red );
+	t.equal( style.fontWeight, 'bold' );
+	t.equal( style.fontStyle, 'italic' );
+});
+
+test( 'Yielded content gets encapsulated styles', t => {
+	let wrapper = Ractive.extend({
+		template: `<div class='blue'>{{yield}}</div>`,
+		css: '.blue { color: blue; }'
+	});
+
+	let Widget = Ractive.extend({
+	    template: '<wrapper><p>this should be blue</p></wrapper>',
+	    css: 'p { font-family: "Comic Sans MS"; }',
+	    components: { wrapper }
+	});
+
+	let ractive = new Widget({ el: fixture });
+
+	let p = ractive.find( 'p' );
+	let style = getComputedStyle( p );
+
+	t.equal( getHexColor( p ), hexCodes.blue );
+	t.ok( /Comic Sans MS/.test( style.fontFamily ) );
+});


### PR DESCRIPTION
Aside from the bug (#1703) this fixes, I think I prefer this approach anyway - CSS IDs (i.e., the unique IDs of component constructors that have encapsulated CSS) are passed down from fragment to fragment until they get applied by an element. Seems like the correct way to do it, rather than the slightly hacky approach of each element testing whether its parent element is the component's root element.