### PR TITLE
More cross-platform friendly build stuffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install
 While developing the library, you can serve it with [gobble](https://github.com/gobblejs/gobble):
 
 ```bash
-npm run serve
+npm start
 ```
 
 Navigate to [localhost:4567](http://localhost:4567) - you'll see two folders, plus `ractive.js`:
@@ -55,6 +55,10 @@ To run a complete build (including linting, testing and minification):
 ```bash
 npm run build
 ```
+
+### Distribution build requirements
+* A real shell, so Linux and OS X should be good. Windows needs MSYS or something similar at least on the path.
+* On Windows, if you get an `EINVAL` when running the tests, you may need to update the `phantomjs` script in the `node_modules/.bin` to use `{ stdio: 'inherit' }` when spawning the child process instead of manually piping afterwards.
 
 
 Contributing

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     "url": "https://github.com/ractivejs/ractive.git"
   },
   "scripts": {
-    "test": "./scripts/test.sh",
-    "serve": "gobble",
-    "build": "./scripts/build.sh",
+    "test": "sh ./scripts/test.sh",
+    "start": "node_modules/.bin/gobble",
+    "build": "sh ./scripts/build.sh",
     "promises-aplus-tests": "./scripts/promises-aplus-tests.js"
   },
   "github": "https://github.com/ractivejs/ractive",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,8 +3,10 @@
 # if the tests fail, abort (errexit)
 set -e
 
+MOD='node_modules/.bin'
+
 echo "> linting..."
-jshint src
+$MOD/jshint src
 
 # build library plus tests
 echo "> emptying tmp dir..."
@@ -12,11 +14,11 @@ rm -rf tmp/*
 
 echo "> building Ractive..."
 export COMMIT_HASH=`git rev-parse HEAD`
-gobble build tmp
+$MOD/gobble build tmp
 
 # run the tests
 echo "> running tests..."
-npm run test
+./scripts/test.sh
 
 # if the tests passed, copy to the build folder...
 echo "> tests passed. minifying..."
@@ -25,7 +27,7 @@ compress () {
 	local src=$1
 	local dest=${src%.js}.min.js
 
-	../node_modules/.bin/uglifyjs \
+	$MOD/uglifyjs \
 		--compress \
 		--mangle \
 		--source-map $dest.map \
@@ -36,7 +38,7 @@ compress () {
 
 	echo "  minified $src"
 
-	../node_modules/.bin/sorcery -i $dest
+	$MOD/sorcery -i $dest
 	echo "  fixed $dest sourcemap"
 
 }
@@ -45,9 +47,13 @@ compress () {
 	for i in *.js; do compress "$i" & done
 	wait
 )
-
 echo "> emptying build folder..."
 rm -rf build/*
+
+# make sure there is a build folder
+if [[ ! -d build ]]; then
+	mkdir build
+fi
 
 echo "> copying to build folder..."
 ( cd tmp

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,9 +3,11 @@
 # if the tests fail, abort (errexit)
 set -e
 
+MOD='node_modules/.bin'
+
 # run node.js tests
 echo "> running node.js-specific tests"
-node_modules/.bin/mocha tmp/test/__nodetests/*.js --reporter progress
+$MOD/mocha tmp/test/__nodetests/*.js --reporter progress
 
 # run browser tests
-phantomjs scripts/phantom-runner.js
+$MOD/phantomjs scripts/phantom-runner.js


### PR DESCRIPTION
This should fix #1706 with the caveat that, at least on my machine, you have to modify the phantomjs wrapper script on windows to get it to actually run.

`npm run` on windows apparently uses CMD, so this adds an `sh` in front of the commands to get them to run with the npm runner. This also switches the gobble runner to the default `start` script.

The build was dying if the build folder wasn't present, so this adds a check for that as well.