### PR TITLE
fix root reference method call parsing

### DIFF
--- a/src/parse/converters/expressions/primary/readReference.js
+++ b/src/parse/converters/expressions/primary/readReference.js
@@ -56,11 +56,10 @@ export default function readReference ( parser ) {
 	reference = ( prefix || '' ) + normalise( name );
 
 	if ( parser.matchString( '(' ) ) {
-
 		// if this is a method invocation (as opposed to a function) we need
 		// to strip the method name from the reference combo, else the context
 		// will be wrong
-		lastDotIndex = name.lastIndexOf( '.' );
+		lastDotIndex = reference.lastIndexOf( '.' );
 		if ( lastDotIndex !== -1 ) {
 			reference = reference.substr( 0, lastDotIndex );
 			parser.pos = startPos + reference.length;

--- a/test/testdeps/samples/parse.js
+++ b/test/testdeps/samples/parse.js
@@ -248,6 +248,11 @@ var parseTests = [
 		parsed: {v:3,t:[{t:2,x:{s:'/abc/.test(_0)',r:['foo']}}]}
 	},
 	{
+		name: 'Expression with root reference',
+		template: '{{~/foo.indexOf("a")}}',
+		parsed: {v:3,t:[{t:2,x:{s:'_0.indexOf("a")',r:['~/foo']}}]}
+	},
+	{
 		name: 'Whitespace before mustache type character',
 		template: '{{ # foo }}blah{{ / foo }}',
 		parsed: {v:3,t:[{t:4,r:'foo',f:['blah']}]}


### PR DESCRIPTION
Surprisingly, not a regexp literal bug; just a typo.