### PR TITLE
Guard for undefined keypath

### DIFF
--- a/src/viewmodel/prototype/unregister.js
+++ b/src/viewmodel/prototype/unregister.js
@@ -7,6 +7,10 @@ export default function Viewmodel$unregister ( keypath, dependant, group = 'defa
 		return;
 	}
 
+	if ( !keypath ) {
+		return;
+	}
+	
 	if ( mapping = this.mappings[ keypath.firstKey ] ) {
 		return mapping.unregister( keypath, dependant, group );
 	}


### PR DESCRIPTION
Fix for #1721
The `keypath` was undifined at this point, causing an uncatched exception/error.
...please note that I don't really know what I'm doing here. I just notice it works that way.