### PR TITLE
Guard for undefined keypath (bis)

### DIFF
--- a/src/viewmodel/prototype/map.js
+++ b/src/viewmodel/prototype/map.js
@@ -42,7 +42,10 @@ Mapping.prototype = {
 	},
 
 	map ( keypath ) {
-		return keypath.replace( this.localKey, this.keypath );
+    		if( typeof this.keypath === undefined ) { 
+    			return this.localKey;
+    		}
+    		return keypath.replace( this.localKey, this.keypath );
 	},
 
 	register ( keypath, dependant, group ) {


### PR DESCRIPTION
Hi,
The keypath was undifined at this point, causing an uncatched exception/error.
This is the alternative fix for #1721, more general than the previous fix  #1724.
Cheers,
Arnaud