### PR TITLE
check for Promise on window

### DIFF
--- a/src/utils/Promise.js
+++ b/src/utils/Promise.js
@@ -3,9 +3,9 @@ var _Promise,
 	FULFILLED = {},
 	REJECTED = {};
 
-if ( typeof Promise === 'function' ) {
+if ( typeof self !== 'undefined' && typeof self.Promise === 'function' ) {
 	// use native Promise
-	_Promise = Promise;
+	_Promise = self.Promise;
 } else {
 	_Promise = function ( callback ) {
 		var fulfilledHandlers = [],

--- a/src/utils/Promise.js
+++ b/src/utils/Promise.js
@@ -1,3 +1,4 @@
+/*global self */
 var _Promise,
 	PENDING = {},
 	FULFILLED = {},


### PR DESCRIPTION
We can’t just check for `typeof Promise === “function”` for reliance on native promises, because `Promise` is the declared name of the entire Class and therefore will be considered `undefined`. If we check against `self.Promise`, we’ll know that teh scope that we’re checking in is at least a worker or window scope, and we'll be able to utilize those native Promises.

FYI, this means that native promises were never really being used previously, and were always using to the Ractive version.

To test, put a breakpoint inside the ractive cdn latest at line 350, and check `typeof Promise` in the console there.

The other option for this is to change the name of the class from `Promise` to something else.