### PR TITLE
Support escaping mustaches in templates

### DIFF
--- a/src/parse/converters/readMustache.js
+++ b/src/parse/converters/readMustache.js
@@ -25,7 +25,11 @@ function readMustacheOfType ( parser, tag ) {
 
 	start = parser.pos;
 
-	if ( !parser.matchString( tag.open ) ) {
+	if ( parser.matchString( '\\' + tag.open ) ) {
+		if ( start === 0 || parser.str[ start - 1 ] !== '\\' ) {
+			return tag.open;
+		}
+	} else if ( !parser.matchString( tag.open ) ) {
 		return null;
 	}
 

--- a/src/parse/converters/readText.js
+++ b/src/parse/converters/readText.js
@@ -12,6 +12,7 @@ export default function readText ( parser ) {
 		index = remaining.indexOf( barrier );
 	} else {
 		disallowed = parser.tags.map( t => t.open );
+		disallowed = disallowed.concat( parser.tags.map( t => '\\' + t.open ) );
 
 		// http://developers.whatwg.org/syntax.html#syntax-attributes
 		if ( parser.inAttribute === true ) {

--- a/test/testdeps/samples/parse.js
+++ b/test/testdeps/samples/parse.js
@@ -740,6 +740,16 @@ var parseTests = [
 		name: 'An unexpected closing tag is an error',
 		template: '<div></div></div>',
 		error: `Unexpected template content at line 1 character 12:\n<div></div></div>\n           ^----`
+	},
+	{
+		name: 'Escaped mustaches',
+		template: '\\[[static]] \\[[[tripleStatic]]] \\{{normal}} \\{{{triple}}}',
+		parsed: {v:3,t:['[[static]] [[[tripleStatic]]] {{normal}} {{{triple}}}']}
+	},
+	{
+		name: 'Not-really-escaped mustaches',
+		template: '\\\\[[static]] \\\\[[[tripleStatic]]] \\\\{{normal}} \\\\{{{triple}}}}',
+		parsed: {v:3,t:["\\",{"r":"static","s":true,"t":2}," \\",{"r":"tripleStatic","s":true,"t":3}," \\",{"r":"normal","t":2}," \\",{"r":"triple","t":3},"}"]}
 	}
 ];
 


### PR DESCRIPTION
This fixes #276, which was closed as wontfix. Our docs currently use handlebars, which supports escaping mustaches with '\', so this does the same for Ractive.

Feel free to close this one wontfix too. I just needed a brief distraction to clear my head, and none of the current open issues aligned with my mood correctly.