### PR TITLE
Add error for extra chars after method call event handler

### DIFF
--- a/src/parse/converters/element/processDirective.js
+++ b/src/parse/converters/element/processDirective.js
@@ -4,6 +4,7 @@ import flattenExpression from 'parse/utils/flattenExpression';
 import parseJSON from 'utils/parseJSON';
 
 var methodCallPattern = /^([a-zA-Z_$][a-zA-Z_$0-9]*)\(/,
+	methodCallExcessPattern = /\)\s*$/,
 	ExpressionParser;
 
 ExpressionParser = Parser.extend({
@@ -11,7 +12,7 @@ ExpressionParser = Parser.extend({
 });
 
 // TODO clean this up, it's shocking
-export default function processDirective ( tokens ) {
+export default function processDirective ( tokens, parentParser ) {
 	var result,
 		match,
 		parser,
@@ -24,8 +25,15 @@ export default function processDirective ( tokens ) {
 
 	if ( typeof tokens === 'string' ) {
 		if ( match = methodCallPattern.exec( tokens ) ) {
+			let end = tokens.lastIndexOf(')');
+
+			// check for invalid method calls
+			if ( !methodCallExcessPattern.test( tokens ) ) {
+				parentParser.error( `Invalid input after method call expression '${tokens.slice(end + 1)}'` );
+			}
+
 			result = { m: match[1] };
-			args = '[' + tokens.slice( result.m.length + 1, -1 ) + ']';
+			args = '[' + tokens.slice( result.m.length + 1, end ) + ']';
 
 			parser = new ExpressionParser( args );
 			result.a = flattenExpression( parser.result[0] );

--- a/src/parse/converters/readElement.js
+++ b/src/parse/converters/readElement.js
@@ -114,13 +114,13 @@ function readElement ( parser ) {
 		if ( attribute.name ) {
 			// intro, outro, decorator
 			if ( directiveName = directives[ attribute.name ] ) {
-				element[ directiveName ] = processDirective( attribute.value );
+				element[ directiveName ] = processDirective( attribute.value, parser );
 			}
 
 			// on-click etc
 			else if ( match = proxyEventPattern.exec( attribute.name ) ) {
 				if ( !element.v ) element.v = {};
-				directive = processDirective( attribute.value );
+				directive = processDirective( attribute.value, parser );
 				addProxyEvent( match[1], directive );
 			}
 

--- a/test/__tests/events.js
+++ b/test/__tests/events.js
@@ -1523,4 +1523,13 @@ if ( !/phantomjs/i.test( window.navigator.userAgent ) ) {
 		t.ok( !event1Fired );
 		t.ok( event2Fired );
 	});
+
+	test( 'invalid content in method call event directive should have a reasonable error message', t => {
+		t.throws(() => {
+			new Ractive({
+				el: fixture,
+				template: '<button on-click="alert(foo);">Click Me</button>'
+			});
+		}, /invalid input/i );
+	});
 }


### PR DESCRIPTION
This throws a parse error if there is extra, non-space stuff beyond the last `)` on a method call event handler with the offending chars included in the message. The pos is slightly off because it's already moved to the end of the attr, but it's pretty darn close. I added a parser param for `processDirective` so that the appropriate `ParseError` can be generated.

fixes #1288