### PR TITLE
Discussion: Pass thru keepExistingWrapper from adaptor reset?

### DIFF
--- a/src/viewmodel/prototype/set.js
+++ b/src/viewmodel/prototype/set.js
@@ -45,7 +45,7 @@ export default function Viewmodel$set ( keypath, value, options = {} ) {
 	}
 
 	if ( !options.silent ) {
-		this.mark( keypath );
+		this.mark( keypath, { keepExistingWrapper: keepExistingWrapper } );
 	} else {
 		// We're setting a parent of the original target keypath (i.e.
 		// creating a fresh branch) - we need to clear the cache, but


### PR DESCRIPTION
I was trying to correct what I thought was an oversight, that adaptors are always torn down because the result of `reset` is never passed through to the `mark` method so on `clearCache` `teardown` always gets call.

This PR fixes that, but breaks magic adaptor because it [cheats and goes through the back door](https://github.com/ractivejs/ractive/blob/dev/src/Ractive/static/adaptors/magic.js#L87). And teardown can also selectively control whether it actually goes away by returning a non-false value. 

It seems `adaptor.teardown` has become the new `adaptor.reset` :)

I think the adaptor teardown should happen with the viewmodel teardown and be reserved solely for that purpose of clearing up used resources. And reset needs to serve the purpose of handling re-"`set`" of the keypath on which the wrapper is attached.

But given my level of confusion, I wanted to bring it up before trying to fix it up.
