### PR TITLE
Change main from ractive.js to build/ractive.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Next-generation DOM manipulation",
   "version": "0.7.0-edge",
   "homepage": "http://ractivejs.org",
-  "main": "ractive.js",
+  "main": "build/ractive.js",
   "keywords": [
     "template",
     "templating",


### PR DESCRIPTION
I'm not sure this is an issue or not.

After I built the project locally, when I tried to use Ractive via npm link, I found that I wasn't able to require() the module because there was no ractive.js file in the root package directory.

Are there other steps that happen pre-publish?  I couldn't find another script that looked like it would move build/ractive.js to the root directory.