### PR TITLE
Include mappings and computations on root get

### DIFF
--- a/src/Ractive/prototype/get.js
+++ b/src/Ractive/prototype/get.js
@@ -3,7 +3,8 @@ import resolveRef from 'shared/resolveRef';
 
 var options = {
 	capture: true, // top-level calls should be intercepted
-	noUnwrap: true // wrapped values should NOT be unwrapped
+	noUnwrap: true, // wrapped values should NOT be unwrapped
+	fullRootGet: true // root get should return computations and mappings
 };
 
 export default function Ractive$get ( keypath ) {

--- a/src/Ractive/prototype/get.js
+++ b/src/Ractive/prototype/get.js
@@ -4,7 +4,7 @@ import resolveRef from 'shared/resolveRef';
 var options = {
 	capture: true, // top-level calls should be intercepted
 	noUnwrap: true, // wrapped values should NOT be unwrapped
-	fullRootGet: true // root get should return computations and mappings
+	fullRootGet: true // root get should return mappings
 };
 
 export default function Ractive$get ( keypath ) {

--- a/src/viewmodel/prototype/get.js
+++ b/src/viewmodel/prototype/get.js
@@ -10,7 +10,8 @@ export default function Viewmodel$get ( keypath, options ) {
 		computation,
 		wrapped,
 		captureGroup,
-		keypathStr = keypath.str;
+		keypathStr = keypath.str,
+		key;
 
 	options = options || empty;
 
@@ -60,6 +61,17 @@ export default function Viewmodel$get ( keypath, options ) {
 
 	if ( !options.noUnwrap && ( wrapped = this.wrapped[ keypathStr ] ) ) {
 		value = wrapped.get();
+	}
+
+	if ( keypath.isRoot && options.fullRootGet ) {
+		// this.mappings.forEach( m => value[ m ] = m.getValue() );
+		for ( var key in this.mappings ) {
+			value[ key ] = this.mappings[ key ].getValue();
+		}
+
+		for ( var key in this.computations ) {
+			value[ key ] = this.computations[ key ].get();
+		}
 	}
 
 	return value === FAILED_LOOKUP ? void 0 : value;

--- a/src/viewmodel/prototype/get.js
+++ b/src/viewmodel/prototype/get.js
@@ -64,13 +64,8 @@ export default function Viewmodel$get ( keypath, options ) {
 	}
 
 	if ( keypath.isRoot && options.fullRootGet ) {
-		// this.mappings.forEach( m => value[ m ] = m.getValue() );
-		for ( var key in this.mappings ) {
+		for ( key in this.mappings ) {
 			value[ key ] = this.mappings[ key ].getValue();
-		}
-
-		for ( var key in this.computations ) {
-			value[ key ] = this.computations[ key ].get();
 		}
 	}
 

--- a/src/virtualdom/items/shared/Resolvers/ExpressionResolver.js
+++ b/src/virtualdom/items/shared/Resolvers/ExpressionResolver.js
@@ -80,7 +80,7 @@ ExpressionResolver.prototype = {
 				}
 
 				return () => {
-					var value = this.root.viewmodel.get( keypath, { noUnwrap: true });
+					var value = this.root.viewmodel.get( keypath, { noUnwrap: true, fullRootGet: true });
 					if ( typeof value === 'function' ) {
 						value = wrapFunction( value, this.root );
 					}

--- a/test/__tests/get.js
+++ b/test/__tests/get.js
@@ -1,33 +1,9 @@
 /*global test, module, simulant */
 module( 'get()' );
 
-test( 'Returns computations on root .get()', t => {
-	var ractive, result;
-
-	ractive = new Ractive({
-		el: fixture,
-		// template: '{{JSON.stringify(.)}}',
-		data: {
-			foo: 'foo'
-		},
-		computed: {
-			bar: '${foo} + "bar"'
-		}
-	});
-
-	result = { foo: 'foo', bar: 'foobar' };
-	t.deepEqual( ractive.get(), result );
-	// t.equal( fixture.innerHTML, JSON.stringify(result) );
-});
 
 test( 'Returns mappings on root .get()', t => {
-	var ractive, component;
-
-	component = Ractive.extend({
-		data: {
-			foo: 'foo'
-		}
-	});
+	var ractive;
 
 	ractive = new Ractive({
 		el: fixture,
@@ -38,6 +14,7 @@ test( 'Returns mappings on root .get()', t => {
 		},
 		components: {
 			c: Ractive.extend({
+				template: '{{JSON.stringify(.)}}',
 				data: {
 					foo: 'mine'
 				}
@@ -45,5 +22,7 @@ test( 'Returns mappings on root .get()', t => {
 		}
 	});
 
-	t.deepEqual( ractive.findComponent('c').get(), { foo: 'mine', bar: 'foo', qux: 'qux' } );
+	var expected = { foo: 'mine', bar: 'foo', qux: 'qux' };
+	t.deepEqual( ractive.findComponent('c').get(), expected );
+	t.deepEqual( fixture.innerHTML, JSON.stringify( expected ) );
 });

--- a/test/__tests/get.js
+++ b/test/__tests/get.js
@@ -1,0 +1,49 @@
+/*global test, module, simulant */
+module( 'get()' );
+
+test( 'Returns computations on root .get()', t => {
+	var ractive, result;
+
+	ractive = new Ractive({
+		el: fixture,
+		// template: '{{JSON.stringify(.)}}',
+		data: {
+			foo: 'foo'
+		},
+		computed: {
+			bar: '${foo} + "bar"'
+		}
+	});
+
+	result = { foo: 'foo', bar: 'foobar' };
+	t.deepEqual( ractive.get(), result );
+	// t.equal( fixture.innerHTML, JSON.stringify(result) );
+});
+
+test( 'Returns mappings on root .get()', t => {
+	var ractive, component;
+
+	component = Ractive.extend({
+		data: {
+			foo: 'foo'
+		}
+	});
+
+	ractive = new Ractive({
+		el: fixture,
+		template: `<c bar='{{foo}}' qux='{{qux}}'/>`,
+		data: {
+			foo: 'foo',
+			qux: 'qux'
+		},
+		components: {
+			c: Ractive.extend({
+				data: {
+					foo: 'mine'
+				}
+			})
+		}
+	});
+
+	t.deepEqual( ractive.findComponent('c').get(), { foo: 'mine', bar: 'foo', qux: 'qux' } );
+});


### PR DESCRIPTION
~~Some unanswered questions remain, see #1783~~

Only mappings are included on root gets from `ractive.get()` and when used as an input to an expression, `{{ JSON.stringify(this) }}`.