### PR TITLE
Allow wildcards to be used with ractive.toggle(), ractive.add() and ractive.subtract()

### DIFF
--- a/src/Ractive/prototype/observe/getPattern.js
+++ b/src/Ractive/prototype/observe/getPattern.js
@@ -3,7 +3,7 @@ import { getMatchingKeypaths } from 'shared/keypaths';
 export default function getPattern ( ractive, pattern ) {
 	var matchingKeypaths, values;
 
-	matchingKeypaths = getMatchingKeypaths( ractive, pattern.str );
+	matchingKeypaths = getMatchingKeypaths( ractive, pattern );
 
 	values = {};
 	matchingKeypaths.forEach( keypath => {

--- a/src/Ractive/prototype/set.js
+++ b/src/Ractive/prototype/set.js
@@ -30,7 +30,7 @@ export default function Ractive$set ( keypath, value ) {
 		// TODO a) wildcard test should probably happen at viewmodel level,
 		// b) it should apply to multiple/single set operations
 		if ( wildcard.test( keypath.str ) ) {
-			getMatchingKeypaths( this, keypath.str ).forEach( keypath => {
+			getMatchingKeypaths( this, keypath ).forEach( keypath => {
 				this.viewmodel.set( keypath, value );
 			});
 		} else {

--- a/src/Ractive/prototype/shared/add.js
+++ b/src/Ractive/prototype/shared/add.js
@@ -1,17 +1,36 @@
 import { isNumeric } from 'utils/is';
+import { getKeypath, getMatchingKeypaths, normalise } from 'shared/keypaths';
+
+const errorMessage = 'Cannot add to a non-numeric value';
 
 export default function add ( root, keypath, d ) {
-	var value;
-
 	if ( typeof keypath !== 'string' || !isNumeric( d ) ) {
 		throw new Error( 'Bad arguments' );
 	}
 
-	value = +root.get( keypath ) || 0;
+	let value, changes;
 
-	if ( !isNumeric( value ) ) {
-		throw new Error( 'Cannot add to a non-numeric value' );
+	if ( /\*/.test( keypath ) ) {
+		changes = {};
+
+		getMatchingKeypaths( root, getKeypath( normalise( keypath ) ) ).forEach( keypath => {
+			let value = root.viewmodel.get( keypath );
+
+			if ( !isNumeric( value ) ) {
+				throw new Error( errorMessage );
+			}
+
+			changes[ keypath.str ] = value + d;
+		});
+
+		return root.set( changes );
 	}
 
-	return root.set( keypath, value + d );
+	value = root.get( keypath );
+
+	if ( !isNumeric( value ) ) {
+		throw new Error( errorMessage );
+	}
+
+	return root.set( keypath, +value + d );
 }

--- a/src/Ractive/prototype/toggle.js
+++ b/src/Ractive/prototype/toggle.js
@@ -1,8 +1,19 @@
 import { badArguments } from 'config/errors';
+import { getKeypath, getMatchingKeypaths, normalise } from 'shared/keypaths';
 
 export default function Ractive$toggle ( keypath ) {
 	if ( typeof keypath !== 'string' ) {
 		throw new TypeError( badArguments );
+	}
+
+	if ( /\*/.test( keypath ) ) {
+		let changes = {};
+
+		getMatchingKeypaths( this, getKeypath( normalise( keypath ) ) ).forEach( keypath => {
+			changes[ keypath.str ] = !this.viewmodel.get( keypath );
+		});
+
+		return this.set( changes );
 	}
 
 	return this.set( keypath, !this.get( keypath ) );

--- a/src/Ractive/prototype/toggle.js
+++ b/src/Ractive/prototype/toggle.js
@@ -6,8 +6,10 @@ export default function Ractive$toggle ( keypath ) {
 		throw new TypeError( badArguments );
 	}
 
+	let changes;
+
 	if ( /\*/.test( keypath ) ) {
-		let changes = {};
+		changes = {};
 
 		getMatchingKeypaths( this, getKeypath( normalise( keypath ) ) ).forEach( keypath => {
 			changes[ keypath.str ] = !this.viewmodel.get( keypath );

--- a/src/shared/keypaths.js
+++ b/src/shared/keypaths.js
@@ -101,8 +101,10 @@ export function getKeypath ( str ) {
 	return keypathCache[ str ];
 }
 
-export function getMatchingKeypaths ( ractive, pattern ) {
+export function getMatchingKeypaths ( ractive, keypath ) {
 	var keys, key, matchingKeypaths;
+
+	let pattern = keypath.str;
 
 	keys = pattern.split( '.' );
 	matchingKeypaths = [ rootKeypath ];

--- a/src/shared/keypaths.js
+++ b/src/shared/keypaths.js
@@ -104,9 +104,7 @@ export function getKeypath ( str ) {
 export function getMatchingKeypaths ( ractive, keypath ) {
 	var keys, key, matchingKeypaths;
 
-	let pattern = keypath.str;
-
-	keys = pattern.split( '.' );
+	keys = keypath.str.split( '.' );
 	matchingKeypaths = [ rootKeypath ];
 
 	while ( key = keys.shift() ) {

--- a/test/__tests/add.js
+++ b/test/__tests/add.js
@@ -1,0 +1,81 @@
+module( 'add/subtract' );
+
+test( 'ractive.add("foo") adds 1 to the value of foo', t => {
+	let ractive = new Ractive({
+		data: { foo: 0 }
+	});
+
+	ractive.add( 'foo' );
+	t.equal( ractive.get( 'foo' ), 1 );
+
+	ractive.add( 'foo' );
+	t.equal( ractive.get( 'foo' ), 2 );
+});
+
+test( 'ractive.add("foo",x) adds x to the value of foo', t => {
+	let ractive = new Ractive({
+		data: { foo: 0 }
+	});
+
+	ractive.add( 'foo', 2 );
+	t.equal( ractive.get( 'foo' ), 2 );
+
+	ractive.add( 'foo', 3 );
+	t.equal( ractive.get( 'foo' ), 5 );
+});
+
+test( 'ractive.subtract("foo") subtracts 1 from the value of foo', t => {
+	let ractive = new Ractive({
+		data: { foo: 10 }
+	});
+
+	ractive.subtract( 'foo' );
+	t.equal( ractive.get( 'foo' ), 9 );
+
+	ractive.subtract( 'foo' );
+	t.equal( ractive.get( 'foo' ), 8 );
+});
+
+test( 'ractive.subtract("foo",x) subtracts x from the value of foo', t => {
+	let ractive = new Ractive({
+		data: { foo: 10 }
+	});
+
+	ractive.subtract( 'foo', 2 );
+	t.equal( ractive.get( 'foo' ), 8 );
+
+	ractive.subtract( 'foo', 3 );
+	t.equal( ractive.get( 'foo' ), 5 );
+});
+
+test( 'non-numeric values are an error', t => {
+	let ractive = new Ractive({
+		data: { foo: 'potato' }
+	});
+
+	t.throws( () => ractive.add( 'foo' ), /Cannot add to a non-numeric value/ );
+});
+
+test( 'each keypath that matches a wildcard is added to individually (#1604)', t => {
+	let items = [
+		{ count: 1 },
+		{ count: 2 },
+		{ count: 3 }
+	];
+
+	let ractive = new Ractive({
+		data: { items }
+	});
+
+	ractive.add( 'items[*].count', 3 );
+
+	t.equal( ractive.get( 'items[0].count' ), 4 );
+	t.equal( ractive.get( 'items[1].count' ), 5 );
+	t.equal( ractive.get( 'items[2].count' ), 6 );
+
+	ractive.subtract( 'items[*].count', 2 );
+
+	t.equal( ractive.get( 'items[0].count' ), 2 );
+	t.equal( ractive.get( 'items[1].count' ), 3 );
+	t.equal( ractive.get( 'items[2].count' ), 4 );
+});

--- a/test/__tests/toggle.js
+++ b/test/__tests/toggle.js
@@ -1,0 +1,51 @@
+module( 'toggle' );
+
+test( 'ractive.toggle("foo") toggles the value of foo', t => {
+	let ractive = new Ractive({
+		data: { foo: false }
+	});
+
+	ractive.toggle( 'foo' );
+	t.ok( ractive.get( 'foo' ) );
+
+	ractive.toggle( 'foo' );
+	t.ok( !ractive.get( 'foo' ) );
+});
+
+test( 'non-boolean values are effectively coerced', t => {
+	let ractive = new Ractive({
+		data: {
+			foo: null,
+			bar: 0,
+			baz: 'str'
+		}
+	});
+
+	ractive.toggle( 'foo' );
+	ractive.toggle( 'bar' );
+	ractive.toggle( 'baz' );
+	ractive.toggle( 'qux' );
+
+	t.ok(  ractive.get( 'foo' ) );
+	t.ok(  ractive.get( 'bar' ) );
+	t.ok( !ractive.get( 'baz' ) );
+	t.ok(  ractive.get( 'qux' ) );
+});
+
+test( 'each keypath that matches a wildcard is toggled individually (#1604)', t => {
+	let items = [
+		{ active: true },
+		{ active: false },
+		{ active: true }
+	];
+
+	let ractive = new Ractive({
+		data: { items }
+	});
+
+	ractive.toggle( 'items[*].active' );
+
+	t.ok( !ractive.get( 'items[0].active' ) );
+	t.ok(  ractive.get( 'items[1].active' ) );
+	t.ok( !ractive.get( 'items[2].active' ) );
+});


### PR DESCRIPTION
This fixes the unexpected behaviour in #1604:

```js
// before
let items = [{ active: false }, { active: true }, { active: false }]
ractive = new Ractive({
  data: { items }
});

ractive.toggle( 'items[*].active' );
console.log( items ); // [{ active: true }, { active: true }, { active: true }] // broken

ractive.toggle( 'items[*].active' );
console.log( items ); // [{ active: true }, { active: true }, { active: true }] // very broken

// after
let items = [{ active: false }, { active: true }, { active: false }]
ractive = new Ractive({
  data: { items }
});

ractive.toggle( 'items[*].active' );
console.log( items ); // [{ active: true }, { active: false }, { active: true }]

ractive.toggle( 'items[*].active' );
console.log( items ); // [{ active: false }, { active: true }, { active: false }]
```