### PR TITLE
more informative error for broken attributes. closes #1339

### DIFF
--- a/src/parse/Parser.js
+++ b/src/parse/Parser.js
@@ -75,16 +75,21 @@ Parser.prototype = {
 	},
 
 	error: function ( message ) {
-		var pos, lineNum, columnNum, line, annotation, error;
+		let pos = this.getLinePos( this.pos );
+		let lineNum = pos[0];
+		let columnNum = pos[1];
 
-		pos = this.getLinePos( this.pos );
-		lineNum = pos[0];
-		columnNum = pos[1];
+		let line = this.lines[ pos[0] - 1 ];
+		let numTabs = 0;
+		let annotation = line.replace( /\t/g, ( match, char ) => {
+			if ( char < pos[1] ) {
+				numTabs += 1;
+			}
 
-		line = this.lines[ pos[0] - 1 ];
-		annotation = line + '\n' + new Array( pos[1] ).join( ' ' ) + '^----';
+			return '  ';
+		}) + '\n' + new Array( pos[1] + numTabs ).join( ' ' ) + '^----';
 
-		error = new ParseError( message + ' at line ' + lineNum + ' character ' + columnNum + ':\n' + annotation );
+		let error = new ParseError( `${message} at line ${lineNum} character ${columnNum}:\n${annotation}` );
 
 		error.line = pos[0];
 		error.character = pos[1];

--- a/src/parse/converters/element/readAttribute.js
+++ b/src/parse/converters/element/readAttribute.js
@@ -15,9 +15,7 @@ export default function readAttribute ( parser ) {
 		return null;
 	}
 
-	attr = {
-		name: name
-	};
+	attr = { name };
 
 	value = readAttributeValue( parser );
 	if ( value != null ) { // not null/undefined
@@ -31,6 +29,11 @@ function readAttributeValue ( parser ) {
 	var start, valueStart, startDepth, value;
 
 	start = parser.pos;
+
+	// next character must be `=`, `/`, `>` or whitespace
+	if ( !/[=\/>\s]/.test( parser.nextChar() ) ) {
+		parser.error( 'Expected `=`, `/`, `>` or whitespace' );
+	}
 
 	parser.allowWhitespace();
 

--- a/test/testdeps/samples/parse.js
+++ b/test/testdeps/samples/parse.js
@@ -750,6 +750,13 @@ var parseTests = [
 		name: 'Not-really-escaped mustaches',
 		template: '\\\\[[static]] \\\\[[[tripleStatic]]] \\\\{{normal}} \\\\{{{triple}}}}',
 		parsed: {v:3,t:["\\",{"r":"static","s":true,"t":2}," \\",{"r":"tripleStatic","s":true,"t":3}," \\",{"r":"normal","t":2}," \\",{"r":"triple","t":3},"}"]}
+	},
+	{
+		name: 'Attribute/directive without =',
+		template: '<button on-click-"select">fire</button>',
+		error: `Expected \`=\`, \`/\`, \`>\` or whitespace at line 1 character 18:
+<button on-click-"select">fire</button>
+                 ^----`
 	}
 ];
 


### PR DESCRIPTION
As well as fixing #1339 I snuck in a fix for how hard tabs are dealt with when reporting errors, so that the `^----` lines up with the actual error, whether you're seeing it in browser or on the command line