### PR TITLE
encourage use of data functions with Ractive.extend()

### DIFF
--- a/src/Ractive/config/custom/data.js
+++ b/src/Ractive/config/custom/data.js
@@ -1,4 +1,5 @@
 import { fatal, warn, warnOnce } from 'utils/log';
+import { isObject, isArray } from 'utils/is';
 
 function validate ( data ) {
 	// Warn if userOptions.data is a non-POJO
@@ -17,6 +18,33 @@ var dataConfigurator = {
 	name: 'data',
 
 	extend: ( Parent, proto, options ) => {
+		let key, value;
+
+		// check for non-primitives, which could cause mutation-related bugs
+		if ( options.data && isObject( options.data ) ) {
+			for ( key in options.data ) {
+				value = options.data[ key ];
+
+				if ( value && typeof value === 'object' ) {
+					if ( isObject( value ) || isArray( value ) ) {
+						warn( `Passing a \`data\` option with object and array properties to Ractive.extend() is discouraged, as mutating them is likely to cause bugs. Consider using a data function instead:
+
+// this...
+data: function () {
+  return {
+    myObject: {}
+  };
+})
+
+// instead of this:
+data: {
+  myObject: {}
+}` );
+					}
+				}
+			}
+		}
+
 		proto.data = combine( proto.data, options.data );
 	},
 

--- a/test/__tests/components.js
+++ b/test/__tests/components.js
@@ -869,3 +869,32 @@ test( 'Unresolved keypath can be safely torn down', t => {
 	ractive.set('show', false);
 
 });
+
+test( 'Using non-primitives in data passed to Ractive.extend() triggers a warning', t => {
+	let warn = console.warn;
+	console.warn = msg => {
+		t.ok( /Passing a `data` option with object and array properties to Ractive.extend\(\) is discouraged, as mutating them is likely to cause bugs/.test( msg ) );
+	};
+
+	expect( 1 );
+
+	Ractive.extend({
+		data: {
+			foo: 42
+		}
+	});
+
+	Ractive.extend({
+		data: {
+			foo: {}
+		}
+	});
+
+	Ractive.extend({
+		data: () => ({
+			foo: {}
+		})
+	});
+
+	console.warn = warn;
+});


### PR DESCRIPTION
The idea here is to ensure that people don't run into weird bugs in which an instance of a component accidentally mutates that component's default data, by suggesting the use of data functions instead of data objects.

I'm trying something slightly different here - printing example code to the console (ES6 template strings ftw!). Takes up a few lines, but is maybe more useful than trying to explain things, or send people to an explainer page on the docs.

![screen shot 2015-03-13 at 4 13 03 pm](https://cloud.githubusercontent.com/assets/1162160/6646551/59989f04-c99c-11e4-9dae-160a59ac2c71.png)

Any thoughts?