### PR TITLE
replace ractive.debug with Ractive.DEBUG (#1793)

### DIFF
--- a/gobblefile.js
+++ b/gobblefile.js
@@ -29,8 +29,8 @@ lib = (function () {
 		.replace( '${commitHash}', process.env.COMMIT_HASH || 'unknown' );
 
 	var bundleTransform = function ( src, path ) {
-		if ( /Ractive\.js$/.test( path ) ) {
-			return src.replace( '${version}', version );
+		if ( /(Ractive\.js|Ractive\/initialise\.js)$/.test( path ) ) {
+			return src.replace( '<@version@>', version );
 		}
 
 		return src;

--- a/gobblefile.js
+++ b/gobblefile.js
@@ -29,7 +29,7 @@ lib = (function () {
 		.replace( '${commitHash}', process.env.COMMIT_HASH || 'unknown' );
 
 	var bundleTransform = function ( src, path ) {
-		if ( /(Ractive\.js|Ractive\/initialise\.js)$/.test( path ) ) {
+		if ( /(Ractive\.js|utils\/log\.js)$/.test( path ) ) {
 			return src.replace( '<@version@>', version );
 		}
 

--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -22,6 +22,9 @@ Ractive = function ( options ) {
 // Ractive properties
 properties = {
 
+	// debug flag
+	DEBUG:         { value: true },
+
 	// static methods:
 	extend:        { value: extend },
 	getNodeInfo:   { value: getNodeInfo },

--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -38,7 +38,7 @@ properties = {
 	magic:         { value: magic },
 
 	// version
-	VERSION:       { value: '${version}' },
+	VERSION:       { value: '<@version@>' },
 
 	// Plugins
 	adaptors:      { writable: true, value: {} },

--- a/src/Ractive/config/config.js
+++ b/src/Ractive/config/config.js
@@ -44,7 +44,7 @@ config = {
 
 	// this defines the order. TODO this isn't used anywhere in the codebase,
 	// only in the test suite - should get rid of it
-	order: order,
+	order,
 };
 
 function configure ( method, Parent, target, options ) {
@@ -67,7 +67,6 @@ function configure ( method, Parent, target, options ) {
 	});
 
 	adaptConfigurator[ method ]( Parent, target, options );
-	//dataConfigurator[ method ]( Parent, target, options );
 	templateConfigurator[ method ]( Parent, target, options );
 	cssConfigurator[ method ]( Parent, target, options );
 

--- a/src/Ractive/config/custom/data.js
+++ b/src/Ractive/config/custom/data.js
@@ -27,7 +27,7 @@ var dataConfigurator = {
 
 				if ( value && typeof value === 'object' ) {
 					if ( isObject( value ) || isArray( value ) ) {
-						warn( `Passing a \`data\` option with object and array properties to Ractive.extend() is discouraged, as mutating them is likely to cause bugs. Consider using a data function instead:
+						warnIfDebug( `Passing a \`data\` option with object and array properties to Ractive.extend() is discouraged, as mutating them is likely to cause bugs. Consider using a data function instead:
 
   // this...
   data: function () {

--- a/src/Ractive/config/custom/data.js
+++ b/src/Ractive/config/custom/data.js
@@ -1,4 +1,4 @@
-import { fatal, warnIfDebug, warnOnce } from 'utils/log';
+import { fatal, warnIfDebug, warnOnceIfDebug } from 'utils/log';
 
 function validate ( data ) {
 	// Warn if userOptions.data is a non-POJO

--- a/src/Ractive/config/custom/data.js
+++ b/src/Ractive/config/custom/data.js
@@ -1,4 +1,4 @@
-import { fatal, warn, warnOnce } from 'utils/log';
+import { fatal, warnIfDebug, warnOnce } from 'utils/log';
 
 function validate ( data ) {
 	// Warn if userOptions.data is a non-POJO
@@ -8,7 +8,7 @@ function validate ( data ) {
 		} else if ( typeof data !== 'object' ) {
 			fatal( `data option must be an object or a function, \`${data}\` is not valid` );
 		} else {
-			warn( 'If supplied, options.data should be a plain JavaScript object - using a non-POJO as the root object may work, but is discouraged' );
+			warnIfDebug( 'If supplied, options.data should be a plain JavaScript object - using a non-POJO as the root object may work, but is discouraged' );
 		}
 	}
 }
@@ -77,7 +77,7 @@ function callDataFunction ( fn, context ) {
 	}
 
 	if ( data.constructor !== Object ) {
-		warnOnce( 'Data function returned something other than a plain JavaScript object. This might work, but is strongly discouraged' );
+		warnOnceIfDebug( 'Data function returned something other than a plain JavaScript object. This might work, but is strongly discouraged' );
 	}
 
 	return data;

--- a/src/Ractive/config/defaults.js
+++ b/src/Ractive/config/defaults.js
@@ -34,10 +34,7 @@ var defaultOptions = {
 
 	// css:
 	css:                null,
-	noCssTransform:     false,
-
-	// debug:
-	debug:              false
+	noCssTransform:     false
 };
 
 export default defaultOptions;

--- a/src/Ractive/config/deprecate.js
+++ b/src/Ractive/config/deprecate.js
@@ -1,4 +1,4 @@
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 import { isArray } from 'utils/is';
 
 function getMessage( deprecated, correct, isError ) {
@@ -9,7 +9,7 @@ function getMessage( deprecated, correct, isError ) {
 function deprecateOption ( options, deprecatedOption, correct ) {
 	if ( deprecatedOption in options ) {
 		if( !( correct in options ) ) {
-			warn( getMessage( deprecatedOption, correct ) );
+			warnIfDebug( getMessage( deprecatedOption, correct ) );
 			options[ correct ] = options[ deprecatedOption ];
 		} else {
 			throw new Error( getMessage( deprecatedOption, correct, true ) );

--- a/src/Ractive/config/deprecate.js
+++ b/src/Ractive/config/deprecate.js
@@ -2,8 +2,8 @@ import { warnIfDebug } from 'utils/log';
 import { isArray } from 'utils/is';
 
 function getMessage( deprecated, correct, isError ) {
-	return 'options.' + deprecated + ' has been deprecated in favour of options.' + correct + '.'
-		+ ( isError ? ' You cannot specify both options, please use options.' + correct + '.' : '' );
+	return `options.${deprecated} has been deprecated in favour of options.${correct}.`
+		+ ( isError ? ` You cannot specify both options, please use options.${correct}.` : '' );
 }
 
 function deprecateOption ( options, deprecatedOption, correct ) {

--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -1,4 +1,4 @@
-import { fatal, warnIfDebug, welcome } from 'utils/log';
+import { fatal, welcome } from 'utils/log';
 import { missingPlugin } from 'config/errors';
 import { magic as magicSupported } from 'config/environment';
 import { ensureArray } from 'utils/array';

--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -1,4 +1,4 @@
-import { fatal } from 'utils/log';
+import { fatal, warnIfDebug } from 'utils/log';
 import { missingPlugin } from 'config/errors';
 import { magic as magicSupported } from 'config/environment';
 import { ensureArray } from 'utils/array';
@@ -16,14 +16,15 @@ import Viewmodel from 'viewmodel/Viewmodel';
 import Hook from './prototype/shared/hooks/Hook';
 import HookQueue from './prototype/shared/hooks/HookQueue';
 import getComputationSignatures from './helpers/getComputationSignatures';
+import Ractive from '../Ractive';
 
-var constructHook = new Hook( 'construct' ),
-	configHook = new Hook( 'config' ),
-	initHook = new HookQueue( 'init' ),
-	uid = 0,
-	registryNames;
+let constructHook = new Hook( 'construct' );
+let configHook = new Hook( 'config' );
+let initHook = new HookQueue( 'init' );
+let firstRun = true;
+let uid = 0;
 
-registryNames = [
+let registryNames = [
 	'adaptors',
 	'components',
 	'decorators',
@@ -34,10 +35,41 @@ registryNames = [
 	'transitions'
 ];
 
+let welcomeMessage = `You're running Ractive <@version@> in debug mode - messages will be printed to the console to help you find problems and optimise your application.
+
+To disable debug mode, add this line at the start of your app:
+
+  Ractive.DEBUG = false;
+
+To disable debug mode when your app is minified, add this snippet:
+
+  Ractive.DEBUG = (function () {
+    // this comment will be removed by the minifier
+  }).toString().indexOf( '//' ) !== -1;
+
+Get help and support:
+
+* http://docs.ractivejs.org
+* http://stackoverflow.com/questions/tagged/ractivejs
+* http://groups.google.com/forum/#!forum/ractive-js
+* http://twitter.com/ractivejs
+
+Found a bug? Raise an issue:
+
+* https://github.com/ractivejs/ractive/issues
+
+`;
+
+
 export default initialiseRactiveInstance;
 
 function initialiseRactiveInstance ( ractive, userOptions = {}, options = {} ) {
 	var el, viewmodel;
+
+	if ( firstRun && Ractive.DEBUG ) {
+		warnIfDebug( welcomeMessage );
+		firstRun = false; // not using warnOnceIfDebug here, this is a hot code path
+	}
 
 	initialiseProperties( ractive, options );
 

--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -38,23 +38,19 @@ let registryNames = [
 let welcomeMessage = `You're running Ractive <@version@> in debug mode - messages will be printed to the console to help you find problems and optimise your application.
 
 To disable debug mode, add this line at the start of your app:
-
   Ractive.DEBUG = false;
 
 To disable debug mode when your app is minified, add this snippet:
-
   Ractive.DEBUG = /unminified/.test(function(){/*unminified*/});
 
 Get help and support:
-
-* http://docs.ractivejs.org
-* http://stackoverflow.com/questions/tagged/ractivejs
-* http://groups.google.com/forum/#!forum/ractive-js
-* http://twitter.com/ractivejs
+  http://docs.ractivejs.org
+  http://stackoverflow.com/questions/tagged/ractivejs
+  http://groups.google.com/forum/#!forum/ractive-js
+  http://twitter.com/ractivejs
 
 Found a bug? Raise an issue:
-
-* https://github.com/ractivejs/ractive/issues
+  https://github.com/ractivejs/ractive/issues
 
 `;
 

--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -43,9 +43,7 @@ To disable debug mode, add this line at the start of your app:
 
 To disable debug mode when your app is minified, add this snippet:
 
-  Ractive.DEBUG = (function () {
-    // this comment will be removed by the minifier
-  }).toString().indexOf( '//' ) !== -1;
+  Ractive.DEBUG = /unminified/.test(function(){/*unminified*/});
 
 Get help and support:
 

--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -1,4 +1,4 @@
-import { fatal, warnIfDebug } from 'utils/log';
+import { fatal, warnIfDebug, welcome } from 'utils/log';
 import { missingPlugin } from 'config/errors';
 import { magic as magicSupported } from 'config/environment';
 import { ensureArray } from 'utils/array';
@@ -21,7 +21,6 @@ import Ractive from '../Ractive';
 let constructHook = new Hook( 'construct' );
 let configHook = new Hook( 'config' );
 let initHook = new HookQueue( 'init' );
-let firstRun = true;
 let uid = 0;
 
 let registryNames = [
@@ -35,34 +34,13 @@ let registryNames = [
 	'transitions'
 ];
 
-let welcomeMessage = `You're running Ractive <@version@> in debug mode - messages will be printed to the console to help you find problems and optimise your application.
-
-To disable debug mode, add this line at the start of your app:
-  Ractive.DEBUG = false;
-
-To disable debug mode when your app is minified, add this snippet:
-  Ractive.DEBUG = /unminified/.test(function(){/*unminified*/});
-
-Get help and support:
-  http://docs.ractivejs.org
-  http://stackoverflow.com/questions/tagged/ractivejs
-  http://groups.google.com/forum/#!forum/ractive-js
-  http://twitter.com/ractivejs
-
-Found a bug? Raise an issue:
-  https://github.com/ractivejs/ractive/issues
-
-`;
-
-
 export default initialiseRactiveInstance;
 
 function initialiseRactiveInstance ( ractive, userOptions = {}, options = {} ) {
 	var el, viewmodel;
 
-	if ( firstRun && Ractive.DEBUG ) {
-		warnIfDebug( welcomeMessage );
-		firstRun = false; // not using warnOnceIfDebug here, this is a hot code path
+	if ( Ractive.DEBUG ) {
+		welcome();
 	}
 
 	initialiseProperties( ractive, options );

--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -63,7 +63,6 @@ function initialiseRactiveInstance ( ractive, userOptions = {}, options = {} ) {
 	});
 
 	ractive.viewmodel = viewmodel;
-	viewmodel.debug = ractive.debug;
 
 	// This can't happen earlier, because computed properties may call `ractive.get()`, etc
 	viewmodel.init();

--- a/src/Ractive/prototype/animate/Animation.js
+++ b/src/Ractive/prototype/animate/Animation.js
@@ -1,4 +1,4 @@
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 import runloop from 'global/runloop';
 import interpolate from 'shared/interpolate';
 
@@ -47,7 +47,7 @@ Animation.prototype = {
 
 				// TODO investigate why this happens
 				if ( index === -1 ) {
-					warn( 'Animation was not found' );
+					warnIfDebug( 'Animation was not found' );
 				}
 
 				this.root._animations.splice( index, 1 );
@@ -84,7 +84,7 @@ Animation.prototype = {
 
 		// TODO investigate why this happens
 		if ( index === -1 ) {
-			warn( 'Animation was not found' );
+			warnIfDebug( 'Animation was not found' );
 		}
 
 		this.root._animations.splice( index, 1 );

--- a/src/Ractive/prototype/shared/hooks/Hook.js
+++ b/src/Ractive/prototype/shared/hooks/Hook.js
@@ -1,4 +1,4 @@
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 
 // TODO: deprecate in future release
 var deprecations = {
@@ -40,9 +40,9 @@ Hook.prototype.fire = function ( ractive, arg ) {
 
 	if ( !ractive[ this.method ] && this.deprecate && call( this.deprecate.deprecated ) ) {
 		if ( this.deprecate.message ) {
-			warn( this.deprecate.message );
+			warnIfDebug( this.deprecate.message );
 		} else {
-			warn( 'The method "%s" has been deprecated in favor of "%s" and will likely be removed in a future release. See http://docs.ractivejs.org/latest/migrating for more information.', this.deprecate.deprecated, this.deprecate.replacement );
+			warnIfDebug( 'The method "%s" has been deprecated in favor of "%s" and will likely be removed in a future release. See http://docs.ractivejs.org/latest/migrating for more information.', this.deprecate.deprecated, this.deprecate.replacement );
 		}
 	}
 

--- a/src/Ractive/prototype/shared/makeQuery/test.js
+++ b/src/Ractive/prototype/shared/makeQuery/test.js
@@ -1,6 +1,6 @@
 import { matches } from 'utils/dom';
 
-export default function ( item, noDirty ) {
+export default function Query$test ( item, noDirty ) {
 	var itemMatches;
 
 	if ( this._isComponentQuery ) {

--- a/src/Ractive/prototype/unrender.js
+++ b/src/Ractive/prototype/unrender.js
@@ -1,5 +1,5 @@
 import Hook from './shared/hooks/Hook';
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 import Promise from 'utils/Promise';
 import { removeFromArray } from 'utils/array';
 import runloop from 'global/runloop';
@@ -10,7 +10,7 @@ export default function Ractive$unrender () {
 	var promise, shouldDestroy;
 
 	if ( !this.fragment.rendered ) {
-		warn( 'ractive.unrender() was called on a Ractive instance that was not rendered' );
+		warnIfDebug( 'ractive.unrender() was called on a Ractive instance that was not rendered' );
 		return Promise.resolve();
 	}
 

--- a/src/shared/Ticker.js
+++ b/src/shared/Ticker.js
@@ -1,4 +1,4 @@
-import { warnOnce } from 'utils/log';
+import { fatal } from 'utils/log';
 import { missingPlugin } from 'config/errors';
 import getTime from 'utils/getTime';
 import animations from 'shared/animations';
@@ -18,7 +18,7 @@ var Ticker = function ( options ) {
 		easing = options.root.easing[ options.easing ];
 
 		if ( !easing ) {
-			warnOnce( missingPlugin( options.easing, 'easing' ) );
+			fatal( missingPlugin( options.easing, 'easing' ) );
 			easing = linear;
 		}
 	} else if ( typeof options.easing === 'function' ) {

--- a/src/shared/interpolate.js
+++ b/src/shared/interpolate.js
@@ -1,4 +1,4 @@
-import { warnOnce } from 'utils/log';
+import { fatal } from 'utils/log';
 import { missingPlugin } from 'config/errors';
 import interpolators from 'Ractive/static/interpolators';
 import { findInViewHierarchy } from 'shared/registry';
@@ -15,7 +15,7 @@ var interpolate = function ( from, to, ractive, type ) {
 			return interpol( from, to ) || snap( to );
 		}
 
-		warnOnce( missingPlugin( type, 'interpolator' ) );
+		fatal( missingPlugin( type, 'interpolator' ) );
 	}
 
 	return interpolators.number( from, to ) ||

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -3,10 +3,35 @@ import { hasConsole } from 'config/environment';
 import Ractive from 'Ractive';
 import noop from 'utils/noop';
 
-var alreadyWarned = {}, log, printWarning;
+var alreadyWarned = {}, log, printWarning, welcome;
 
 if ( hasConsole ) {
+	let welcomeMessage = `You're running Ractive <@version@> in debug mode - messages will be printed to the console to help you find problems and optimise your application.
+
+To disable debug mode, add this line at the start of your app:
+  Ractive.DEBUG = false;
+
+To disable debug mode when your app is minified, add this snippet:
+  Ractive.DEBUG = /unminified/.test(function(){/*unminified*/});
+
+Get help and support:
+  http://docs.ractivejs.org
+  http://stackoverflow.com/questions/tagged/ractivejs
+  http://groups.google.com/forum/#!forum/ractive-js
+  http://twitter.com/ractivejs
+
+Found a bug? Raise an issue:
+  https://github.com/ractivejs/ractive/issues
+
+`;
+
+	welcome = () => {
+		console.log.apply( console, [ '%cRactive.js: %c' + welcomeMessage, 'color: rgb(114, 157, 52);', 'color: rgb(85, 85, 85);' ] );
+		welcome = noop;
+	};
+
 	printWarning = ( message, args ) => {
+		welcome();
 		console.warn.apply( console, [ '%cRactive.js: %c' + message, 'color: rgb(114, 157, 52);', 'color: rgb(85, 85, 85);' ].concat( args ) );
 	};
 
@@ -14,14 +39,14 @@ if ( hasConsole ) {
 		console.log.apply( console, arguments );
 	};
 } else {
-	printWarning = log = noop;
+	printWarning = log = welcome = noop;
 }
 
 function format ( message, args ) {
 	return message.replace( /%s/g, () => args.shift() );
 }
 
-export function consoleError ( err ) {
+function consoleError ( err ) {
 	if ( hasConsole ) {
 		console.error( err );
 	} else {
@@ -29,25 +54,23 @@ export function consoleError ( err ) {
 	}
 }
 
-export function fatal ( message, ...args ) {
+function fatal ( message, ...args ) {
 	message = format( message, args );
 	throw new Error( message );
 }
 
-export { log };
-
-export function logIfDebug () {
+function logIfDebug () {
 	if ( Ractive.DEBUG ) {
 		log.apply( null, arguments );
 	}
 }
 
-export function warn ( message, ...args ) {
+function warn ( message, ...args ) {
 	message = format( message, args );
 	printWarning( message, args );
 }
 
-export function warnOnce ( message, ...args ) {
+function warnOnce ( message, ...args ) {
 	message = format( message, args );
 
 	if ( alreadyWarned[ message ] ) {
@@ -58,14 +81,16 @@ export function warnOnce ( message, ...args ) {
 	printWarning( message, args );
 }
 
-export function warnIfDebug () {
+function warnIfDebug () {
 	if ( Ractive.DEBUG ) {
 		warn.apply( null, arguments );
 	}
 }
 
-export function warnOnceIfDebug () {
+function warnOnceIfDebug () {
 	if ( Ractive.DEBUG ) {
 		warnOnce.apply( null, arguments );
 	}
 }
+
+export { consoleError, fatal, log, logIfDebug, warn, warnOnce, warnIfDebug, warnOnceIfDebug, welcome };

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -6,7 +6,7 @@ import noop from 'utils/noop';
 var alreadyWarned = {}, log, printWarning, welcome;
 
 if ( hasConsole ) {
-	let welcomeMessage = `You're running Ractive <@version@> in debug mode - messages will be printed to the console to help you find problems and optimise your application.
+	let welcomeMessage = `You're running Ractive <@version@> in debug mode - messages will be printed to the console to help you fix problems and optimise your application.
 
 To disable debug mode, add this line at the start of your app:
   Ractive.DEBUG = false;
@@ -32,6 +32,27 @@ Found a bug? Raise an issue:
 
 	printWarning = ( message, args ) => {
 		welcome();
+
+		// extract information about the instance this message pertains to, if applicable
+		if ( typeof args[ args.length - 1 ] === 'object' ) {
+			let options = args.pop();
+			let ractive = options.ractive;
+
+			if ( ractive ) {
+				// if this is an instance of a component that we know the name of, add
+				// it to the message
+				let name;
+				if ( ractive.component && ( name = ractive.component.name ) ) {
+					message = `<${name}> ${message}`;
+				}
+
+				let node;
+				if ( node = ( options.node || ( ractive.fragment && ractive.fragment.rendered && ractive.find( '*' ) ) ) ) {
+					args.push( node );
+				}
+			}
+		}
+
 		console.warn.apply( console, [ '%cRactive.js: %c' + message, 'color: rgb(114, 157, 52);', 'color: rgb(85, 85, 85);' ].concat( args ) );
 	};
 

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,5 +1,6 @@
 /* global console */
 import { hasConsole } from 'config/environment';
+import Ractive from 'Ractive';
 import noop from 'utils/noop';
 
 var alreadyWarned = {}, log, printWarning;
@@ -35,6 +36,12 @@ export function fatal ( message, ...args ) {
 
 export { log };
 
+export function logIfDebug () {
+	if ( Ractive.DEBUG ) {
+		log.apply( null, arguments );
+	}
+}
+
 export function warn ( message, ...args ) {
 	message = format( message, args );
 	printWarning( message, args );
@@ -49,4 +56,16 @@ export function warnOnce ( message, ...args ) {
 
 	alreadyWarned[ message ] = true;
 	printWarning( message, args );
+}
+
+export function warnIfDebug () {
+	if ( Ractive.DEBUG ) {
+		warn.apply( null, arguments );
+	}
+}
+
+export function warnOnceIfDebug () {
+	if ( Ractive.DEBUG ) {
+		warnOnce.apply( null, arguments );
+	}
 }

--- a/src/viewmodel/Computation/Computation.js
+++ b/src/viewmodel/Computation/Computation.js
@@ -1,5 +1,5 @@
 import runloop from 'global/runloop';
-import { log, warn, warnOnce } from 'utils/log';
+import { logIfDebug, warnIfDebug, warnOnce } from 'utils/log';
 import { isEqual } from 'utils/is';
 import UnresolvedDependency from './UnresolvedDependency';
 
@@ -91,10 +91,8 @@ Computation.prototype = {
 				try {
 					this.value = this.getter();
 				} catch ( err ) {
-					if ( this.viewmodel.debug ) {
-						warn( 'Failed to compute "%s"', this.key.str );
-						log( err.stack || err );
-					}
+					warnIfDebug( 'Failed to compute "%s"', this.key.str );
+					logIfDebug( err.stack || err );
 
 					this.value = void 0;
 				}

--- a/src/viewmodel/Viewmodel.js
+++ b/src/viewmodel/Viewmodel.js
@@ -28,7 +28,6 @@ var Viewmodel = function ( options ) {
 	this.ractive = ractive;
 
 	this.adaptors = adapt;
-	this.debug = options.debug;
 	this.onchange = options.onchange;
 
 	this.cache = {}; // we need to be able to use hasOwnProperty, so can't inherit from null

--- a/src/viewmodel/prototype/merge.js
+++ b/src/viewmodel/prototype/merge.js
@@ -1,4 +1,4 @@
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 import mapOldToNewIndex from './merge/mapOldToNewIndex';
 
 var comparators = {};
@@ -21,13 +21,7 @@ export default function Viewmodel$merge ( keypath, currentArray, array, options 
 		} catch ( err ) {
 			// fallback to an identity check - worst case scenario we have
 			// to do more DOM manipulation than we thought...
-
-			// ...unless we're in debug mode of course
-			if ( this.debug ) {
-				throw err;
-			} else {
-				warn( 'Merge operation: comparison failed. Falling back to identity checking' );
-			}
+			warnIfDebug( 'merge(): "%s" comparison failed. Falling back to identity checking', keypath );
 
 			oldArray = currentArray;
 			newArray = array;

--- a/src/virtualdom/items/Component/getComponent.js
+++ b/src/virtualdom/items/Component/getComponent.js
@@ -19,7 +19,7 @@ export default function getComponent ( ractive, name ) {
 			Component = fn();
 
 			if ( !Component ) {
-				warnIfDebug( noRegistryFunctionReturn, name, 'component', 'component' );
+				warnIfDebug( noRegistryFunctionReturn, name, 'component', 'component', { ractive });
 
 				return;
 			}

--- a/src/virtualdom/items/Component/getComponent.js
+++ b/src/virtualdom/items/Component/getComponent.js
@@ -1,5 +1,5 @@
 import { noRegistryFunctionReturn } from 'config/errors';
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 import { findInstance } from 'shared/registry';
 
 // finds the component constructor in the registry or view hierarchy registries
@@ -19,9 +19,7 @@ export default function getComponent ( ractive, name ) {
 			Component = fn();
 
 			if ( !Component ) {
-				if ( ractive.debug ) {
-					warn( noRegistryFunctionReturn, name, 'component', 'component' );
-				}
+				warnIfDebug( noRegistryFunctionReturn, name, 'component', 'component' );
 
 				return;
 			}

--- a/src/virtualdom/items/Component/initialise/createInstance.js
+++ b/src/virtualdom/items/Component/initialise/createInstance.js
@@ -1,5 +1,5 @@
 import { INTERPOLATOR, YIELDER } from 'config/types';
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 import { create, extend } from 'utils/object';
 import { isArray } from 'utils/is';
 import parseJSON from 'utils/parseJSON';
@@ -25,7 +25,7 @@ export default function ( component, Component, attributes, yieldTemplate, parti
 	inlinePartials[''] = partials.content;
 
 	if ( Component.defaults.el ) {
-		warn( 'The <%s/> component has a default `el` property; it has been disregarded', component.name );
+		warnIfDebug( 'The <%s/> component has a default `el` property; it has been disregarded', component.name );
 	}
 
 	// find container

--- a/src/virtualdom/items/Component/initialise/createInstance.js
+++ b/src/virtualdom/items/Component/initialise/createInstance.js
@@ -110,18 +110,18 @@ export default function ( component, Component, attributes, yieldTemplate, parti
 	initialise( instance, {
 		el: null,
 		append: true,
-		data: data,
-		partials: partials,
+		data,
+		partials,
 		magic: ractive.magic || Component.defaults.magic,
 		modifyArrays: ractive.modifyArrays,
 		// need to inherit runtime parent adaptors
 		adapt: ractive.adapt
 	}, {
 		parent: ractive,
-		component: component,
-		container: container,
-		mappings: mappings,
-		inlinePartials: inlinePartials,
+		component,
+		container,
+		mappings,
+		inlinePartials,
 		cssIds: parentFragment.cssIds
 	});
 

--- a/src/virtualdom/items/Component/initialise/propagateEvents.js
+++ b/src/virtualdom/items/Component/initialise/propagateEvents.js
@@ -1,5 +1,5 @@
 import fireEvent from 'Ractive/prototype/shared/fireEvent';
-import { warn } from 'utils/log';
+import { fatal } from 'utils/log';
 
 // TODO how should event arguments be handled? e.g.
 // <widget on-foo='bar:1,2,3'/>
@@ -19,7 +19,7 @@ export default function propagateEvents ( component, eventsDescriptor ) {
 
 function propagateEvent ( childInstance, parentInstance, eventName, proxyEventName ) {
 	if ( typeof proxyEventName !== 'string' ) {
-		warn( 'Components currently only support simple events - you cannot include arguments. Sorry!' );
+		fatal( 'Components currently only support simple events - you cannot include arguments. Sorry!' );
 	}
 
 	childInstance.on( eventName, function () {

--- a/src/virtualdom/items/Component/prototype/init.js
+++ b/src/virtualdom/items/Component/prototype/init.js
@@ -27,7 +27,7 @@ export default function Component$init ( options, Component ) {
 
 	// intro, outro and decorator directives have no effect
 	if ( options.template.t1 || options.template.t2 || options.template.o ) {
-		warnIfDebug( 'The "intro", "outro" and "decorator" directives have no effect on components' );
+		warnIfDebug( 'The "intro", "outro" and "decorator" directives have no effect on components', { ractive: this.instance });
 	}
 
 	updateLiveQueries( this );

--- a/src/virtualdom/items/Component/prototype/init.js
+++ b/src/virtualdom/items/Component/prototype/init.js
@@ -2,7 +2,7 @@ import createInstance from 'virtualdom/items/Component/initialise/createInstance
 import propagateEvents from 'virtualdom/items/Component/initialise/propagateEvents';
 import { COMPONENT } from 'config/types';
 import updateLiveQueries from 'virtualdom/items/Component/initialise/updateLiveQueries';
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 
 export default function Component$init ( options, Component ) {
 	var parentFragment, root;
@@ -27,7 +27,7 @@ export default function Component$init ( options, Component ) {
 
 	// intro, outro and decorator directives have no effect
 	if ( options.template.t1 || options.template.t2 || options.template.o ) {
-		warn( 'The "intro", "outro" and "decorator" directives have no effect on components' );
+		warnIfDebug( 'The "intro", "outro" and "decorator" directives have no effect on components' );
 	}
 
 	updateLiveQueries( this );

--- a/src/virtualdom/items/Element/Binding/Binding.js
+++ b/src/virtualdom/items/Element/Binding/Binding.js
@@ -1,5 +1,5 @@
 import runloop from 'global/runloop';
-import { warn, warnOnce } from 'utils/log';
+import { warnOnceIfDebug } from 'utils/log';
 import { create, extend } from 'utils/object';
 import { removeFromArray } from 'utils/array';
 
@@ -15,12 +15,12 @@ var Binding = function ( element ) {
 
 	if ( keypath = interpolator.keypath ) {
 		if ( keypath.str.slice( -1 ) === '}' ) {
-			warn( 'Two-way binding does not work with expressions (`%s` on <%s>)', interpolator.resolver.uniqueString, element.name );
+			warnOnceIfDebug( 'Two-way binding does not work with expressions (`%s` on <%s>)', interpolator.resolver.uniqueString, element.name );
 			return false;
 		}
 
 		if ( keypath.isSpecial ) {
-			warnOnce( 'Two-way binding does not work with %s', interpolator.resolver.ref );
+			warnOnceIfDebug( 'Two-way binding does not work with %s', interpolator.resolver.ref );
 			return false;
 		}
 	}
@@ -41,7 +41,7 @@ var Binding = function ( element ) {
 		// be explicit when using two-way data-binding about what keypath you're
 		// updating. Using it in lists is probably a recipe for confusion...
 		let ref = interpolator.template.r ? `'${interpolator.template.r}' reference` : 'expression';
-		warn( 'The %s being used for two-way binding is ambiguous, and may cause unexpected results. Consider initialising your data to eliminate the ambiguity', ref );
+		warnOnceIfDebug( 'The %s being used for two-way binding is ambiguous, and may cause unexpected results. Consider initialising your data to eliminate the ambiguity', ref );
 		interpolator.resolver.forceResolution();
 		keypath = interpolator.keypath;
 	}

--- a/src/virtualdom/items/Element/Binding/Binding.js
+++ b/src/virtualdom/items/Element/Binding/Binding.js
@@ -1,5 +1,5 @@
 import runloop from 'global/runloop';
-import { warnOnceIfDebug } from 'utils/log';
+import { warnIfDebug, warnOnceIfDebug } from 'utils/log';
 import { create, extend } from 'utils/object';
 import { removeFromArray } from 'utils/array';
 
@@ -41,7 +41,7 @@ var Binding = function ( element ) {
 		// be explicit when using two-way data-binding about what keypath you're
 		// updating. Using it in lists is probably a recipe for confusion...
 		let ref = interpolator.template.r ? `'${interpolator.template.r}' reference` : 'expression';
-		warnOnceIfDebug( 'The %s being used for two-way binding is ambiguous, and may cause unexpected results. Consider initialising your data to eliminate the ambiguity', ref );
+		warnIfDebug( 'The %s being used for two-way binding is ambiguous, and may cause unexpected results. Consider initialising your data to eliminate the ambiguity', ref );
 		interpolator.resolver.forceResolution();
 		keypath = interpolator.keypath;
 	}

--- a/src/virtualdom/items/Element/Binding/Binding.js
+++ b/src/virtualdom/items/Element/Binding/Binding.js
@@ -15,12 +15,12 @@ var Binding = function ( element ) {
 
 	if ( keypath = interpolator.keypath ) {
 		if ( keypath.str.slice( -1 ) === '}' ) {
-			warnOnceIfDebug( 'Two-way binding does not work with expressions (`%s` on <%s>)', interpolator.resolver.uniqueString, element.name );
+			warnOnceIfDebug( 'Two-way binding does not work with expressions (`%s` on <%s>)', interpolator.resolver.uniqueString, element.name, { ractive: this.root });
 			return false;
 		}
 
 		if ( keypath.isSpecial ) {
-			warnOnceIfDebug( 'Two-way binding does not work with %s', interpolator.resolver.ref );
+			warnOnceIfDebug( 'Two-way binding does not work with %s', interpolator.resolver.ref, { ractive: this.root });
 			return false;
 		}
 	}
@@ -41,7 +41,7 @@ var Binding = function ( element ) {
 		// be explicit when using two-way data-binding about what keypath you're
 		// updating. Using it in lists is probably a recipe for confusion...
 		let ref = interpolator.template.r ? `'${interpolator.template.r}' reference` : 'expression';
-		warnIfDebug( 'The %s being used for two-way binding is ambiguous, and may cause unexpected results. Consider initialising your data to eliminate the ambiguity', ref );
+		warnIfDebug( 'The %s being used for two-way binding is ambiguous, and may cause unexpected results. Consider initialising your data to eliminate the ambiguity', ref, { ractive: this.root });
 		interpolator.resolver.forceResolution();
 		keypath = interpolator.keypath;
 	}

--- a/src/virtualdom/items/Element/Decorator/_Decorator.js
+++ b/src/virtualdom/items/Element/Decorator/_Decorator.js
@@ -1,4 +1,4 @@
-import { warn } from 'utils/log';
+import { fatal } from 'utils/log';
 import { missingPlugin } from 'config/errors';
 import Fragment from 'virtualdom/Fragment';
 import { findInViewHierarchy } from 'shared/registry';
@@ -53,7 +53,7 @@ var Decorator = function ( element, template ) {
 	this.fn = findInViewHierarchy( 'decorators', ractive, name );
 
 	if ( !this.fn ) {
-		warn( missingPlugin( name, 'decorator' ) );
+		fatal( missingPlugin( name, 'decorator' ) );
 	}
 };
 

--- a/src/virtualdom/items/Element/EventHandler/prototype/init.js
+++ b/src/virtualdom/items/Element/EventHandler/prototype/init.js
@@ -3,7 +3,7 @@ import createReferenceResolver from 'virtualdom/items/shared/Resolvers/createRef
 import Fragment from 'virtualdom/Fragment';
 import eventStack from 'Ractive/prototype/shared/eventStack';
 import fireEvent from 'Ractive/prototype/shared/fireEvent';
-import { fatal, warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 
 var eventPattern = /^event(?:\.(.+))?/;
 
@@ -16,7 +16,7 @@ export default function EventHandler$init ( element, name, template ) {
 	this.name = name;
 
 	if ( name.indexOf( '*' ) !== -1 ) {
-		( this.root.debug ? fatal : warn )( 'Only component proxy-events may contain "*" wildcards, <%s on-%s="..."/> is not valid', element.name, name );
+		warnIfDebug( 'Only component proxy-events may contain "*" wildcards, <%s on-%s="..."/> is not valid', element.name, name );
 		this.invalid = true;
 	}
 

--- a/src/virtualdom/items/Element/EventHandler/prototype/init.js
+++ b/src/virtualdom/items/Element/EventHandler/prototype/init.js
@@ -3,7 +3,7 @@ import createReferenceResolver from 'virtualdom/items/shared/Resolvers/createRef
 import Fragment from 'virtualdom/Fragment';
 import eventStack from 'Ractive/prototype/shared/eventStack';
 import fireEvent from 'Ractive/prototype/shared/fireEvent';
-import { warnIfDebug } from 'utils/log';
+import { fatal } from 'utils/log';
 
 var eventPattern = /^event(?:\.(.+))?/;
 
@@ -16,7 +16,7 @@ export default function EventHandler$init ( element, name, template ) {
 	this.name = name;
 
 	if ( name.indexOf( '*' ) !== -1 ) {
-		warnIfDebug( 'Only component proxy-events may contain "*" wildcards, <%s on-%s="..."/> is not valid', element.name, name );
+		fatal( 'Only component proxy-events may contain "*" wildcards, <%s on-%s="..."/> is not valid', element.name, name );
 		this.invalid = true;
 	}
 

--- a/src/virtualdom/items/Element/EventHandler/prototype/listen.js
+++ b/src/virtualdom/items/Element/EventHandler/prototype/listen.js
@@ -15,7 +15,6 @@ var customHandlers = {},
 	};
 
 export default function EventHandler$listen () {
-
 	var definition, name = this.name;
 
 	if ( this.invalid ) { return; }
@@ -28,7 +27,7 @@ export default function EventHandler$listen () {
 
 			// okay to use touch events if this browser doesn't support them
 			if ( !touchEvents[ name ] ) {
-				warnOnceIfDebug( missingPlugin( name, 'event' ) );
+				warnOnceIfDebug( missingPlugin( name, 'event' ), { node: this.node });
 			}
 
 			return;
@@ -38,7 +37,6 @@ export default function EventHandler$listen () {
 	}
 
 	this.hasListener = true;
-
 }
 
 function getCustomHandler ( name ) {

--- a/src/virtualdom/items/Element/EventHandler/prototype/listen.js
+++ b/src/virtualdom/items/Element/EventHandler/prototype/listen.js
@@ -1,4 +1,4 @@
-import { warnOnce } from 'utils/log';
+import { warnOnceIfDebug } from 'utils/log';
 import { isJsdom } from 'config/environment';
 import { missingPlugin } from 'config/errors';
 import genericHandler from '../shared/genericHandler';
@@ -28,7 +28,7 @@ export default function EventHandler$listen () {
 
 			// okay to use touch events if this browser doesn't support them
 			if ( !touchEvents[ name ] ) {
-				warnOnce( missingPlugin( name, 'event' ) );
+				warnOnceIfDebug( missingPlugin( name, 'event' ) );
 			}
 
 			return;

--- a/src/virtualdom/items/Element/Transition/prototype/animateStyle/_animateStyle.js
+++ b/src/virtualdom/items/Element/Transition/prototype/animateStyle/_animateStyle.js
@@ -1,4 +1,4 @@
-import { warn } from 'utils/log';
+import { warnOnceIfDebug } from 'utils/log';
 import { isClient } from 'config/environment';
 import legacy from 'legacy';
 import prefix from 'virtualdom/items/Element/Transition/helpers/prefix';
@@ -43,7 +43,7 @@ if ( !isClient ) {
 
 		// TODO remove this check in a future version
 		if ( !options ) {
-			warn( 'The "%s" transition does not supply an options object to `t.animateStyle()`. This will break in a future version of Ractive. For more info see https://github.com/RactiveJS/Ractive/issues/340', this.name );
+			warnOnceIfDebug( 'The "%s" transition does not supply an options object to `t.animateStyle()`. This will break in a future version of Ractive. For more info see https://github.com/RactiveJS/Ractive/issues/340', this.name );
 			options = this;
 		}
 

--- a/src/virtualdom/items/Element/Transition/prototype/animateStyle/createTransitions.js
+++ b/src/virtualdom/items/Element/Transition/prototype/animateStyle/createTransitions.js
@@ -127,7 +127,7 @@ if ( !isClient ) {
 						// will get confused
 						index = changedProperties.indexOf( prop );
 						if ( index === -1 ) {
-							warnIfDebug( 'Something very strange happened with transitions. Please raise an issue at https://github.com/ractivejs/ractive/issues - thanks!' );
+							warnIfDebug( 'Something very strange happened with transitions. Please raise an issue at https://github.com/ractivejs/ractive/issues - thanks!', { node: t.node });
 						} else {
 							changedProperties.splice( index, 1 );
 						}

--- a/src/virtualdom/items/Element/Transition/prototype/animateStyle/createTransitions.js
+++ b/src/virtualdom/items/Element/Transition/prototype/animateStyle/createTransitions.js
@@ -1,5 +1,5 @@
 import { isClient } from 'config/environment';
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 import { createElement } from 'utils/dom';
 import camelCase from 'utils/camelCase';
 import interpolate from 'shared/interpolate';
@@ -127,7 +127,7 @@ if ( !isClient ) {
 						// will get confused
 						index = changedProperties.indexOf( prop );
 						if ( index === -1 ) {
-							warn( 'Something very strange happened with transitions. Please raise an issue at https://github.com/ractivejs/ractive/issues - thanks!' );
+							warnIfDebug( 'Something very strange happened with transitions. Please raise an issue at https://github.com/ractivejs/ractive/issues - thanks!' );
 						} else {
 							changedProperties.splice( index, 1 );
 						}

--- a/src/virtualdom/items/Element/Transition/prototype/init.js
+++ b/src/virtualdom/items/Element/Transition/prototype/init.js
@@ -1,4 +1,4 @@
-import { warnOnce } from 'utils/log';
+import { warnOnceIfDebug } from 'utils/log';
 import { missingPlugin } from 'config/errors';
 import Fragment from 'virtualdom/Fragment';
 import { findInViewHierarchy } from 'shared/registry';
@@ -50,6 +50,6 @@ export default function Transition$init ( element, template, isIntro ) {
 	this._fn = findInViewHierarchy( 'transitions', ractive, name );
 
 	if ( !this._fn ) {
-		warnOnce( missingPlugin( name, 'transition' ) );
+		warnOnceIfDebug( missingPlugin( name, 'transition' ) );
 	}
 }

--- a/src/virtualdom/items/Element/Transition/prototype/init.js
+++ b/src/virtualdom/items/Element/Transition/prototype/init.js
@@ -50,6 +50,6 @@ export default function Transition$init ( element, template, isIntro ) {
 	this._fn = findInViewHierarchy( 'transitions', ractive, name );
 
 	if ( !this._fn ) {
-		warnOnceIfDebug( missingPlugin( name, 'transition' ) );
+		warnOnceIfDebug( missingPlugin( name, 'transition' ), { ractive: this.root });
 	}
 }

--- a/src/virtualdom/items/Element/prototype/init/createTwowayBinding.js
+++ b/src/virtualdom/items/Element/prototype/init/createTwowayBinding.js
@@ -1,4 +1,4 @@
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 import ContentEditableBinding from '../../Binding/ContentEditableBinding';
 import RadioBinding from '../../Binding/RadioBinding';
 import RadioNameBinding from '../../Binding/RadioNameBinding';
@@ -40,7 +40,7 @@ export default function createTwowayBinding ( element ) {
 
 			// we can either bind the name attribute, or the checked attribute - not both
 			if ( bindName && bindChecked ) {
-				warn( 'A radio input can have two-way binding on its name attribute, or its checked attribute - not both' );
+				warnIfDebug( 'A radio input can have two-way binding on its name attribute, or its checked attribute - not both' );
 			}
 
 			if ( bindName ) {

--- a/src/virtualdom/items/Element/prototype/init/createTwowayBinding.js
+++ b/src/virtualdom/items/Element/prototype/init/createTwowayBinding.js
@@ -40,7 +40,7 @@ export default function createTwowayBinding ( element ) {
 
 			// we can either bind the name attribute, or the checked attribute - not both
 			if ( bindName && bindChecked ) {
-				warnIfDebug( 'A radio input can have two-way binding on its name attribute, or its checked attribute - not both' );
+				warnIfDebug( 'A radio input can have two-way binding on its name attribute, or its checked attribute - not both', { ractive: element.root });
 			}
 
 			if ( bindName ) {

--- a/src/virtualdom/items/Element/prototype/render.js
+++ b/src/virtualdom/items/Element/prototype/render.js
@@ -1,6 +1,6 @@
 import { namespaces } from 'config/environment';
 import { isArray } from 'utils/is';
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 import { create, defineProperty } from 'utils/object';
 import { createElement } from 'utils/dom';
 import noop from 'utils/noop';
@@ -34,7 +34,7 @@ updateCss = function () {
 
 updateScript = function () {
 	if ( !this.node.type || this.node.type === 'text/javascript' ) {
-		warn( 'Script tag was updated. This does not cause the code to be re-evaluated!' );
+		warnIfDebug( 'Script tag was updated. This does not cause the code to be re-evaluated!' );
 		// As it happens, we ARE in a position to re-evaluate the code if we wanted
 		// to - we could eval() it, or insert it into a fresh (temporary) script tag.
 		// But this would be a terrible idea with unpredictable results, so let's not.

--- a/src/virtualdom/items/Element/prototype/render.js
+++ b/src/virtualdom/items/Element/prototype/render.js
@@ -34,7 +34,7 @@ updateCss = function () {
 
 updateScript = function () {
 	if ( !this.node.type || this.node.type === 'text/javascript' ) {
-		warnIfDebug( 'Script tag was updated. This does not cause the code to be re-evaluated!' );
+		warnIfDebug( 'Script tag was updated. This does not cause the code to be re-evaluated!', { ractive: this.root });
 		// As it happens, we ARE in a position to re-evaluate the code if we wanted
 		// to - we could eval() it, or insert it into a fresh (temporary) script tag.
 		// But this would be a terrible idea with unpredictable results, so let's not.

--- a/src/virtualdom/items/Partial/_Partial.js
+++ b/src/virtualdom/items/Partial/_Partial.js
@@ -116,7 +116,7 @@ Partial.prototype = {
 		}
 
 		if ( !template ) {
-			warnOnceIfDebug( 'Could not find template for partial "%s"', this.name );
+			warnOnceIfDebug( 'Could not find template for partial "%s"', this.name, { ractive: this.root });
 		}
 
 		this.value = value;

--- a/src/virtualdom/items/Partial/_Partial.js
+++ b/src/virtualdom/items/Partial/_Partial.js
@@ -34,7 +34,7 @@ let Partial = function ( options ) {
 
 			this.setTemplate( template );
 		} else {
-			warnOnce( missingPartialMessage, this.name );
+			warnOnceIfDebug( missingPartialMessage, this.name );
 		}
 	}
 };

--- a/src/virtualdom/items/Partial/_Partial.js
+++ b/src/virtualdom/items/Partial/_Partial.js
@@ -1,4 +1,4 @@
-import { fatal, warnOnce } from 'utils/log';
+import { warnOnceIfDebug } from 'utils/log';
 import { PARTIAL, TEXT } from 'config/types';
 import runloop from 'global/runloop';
 import Fragment from 'virtualdom/Fragment';
@@ -116,7 +116,7 @@ Partial.prototype = {
 		}
 
 		if ( !template ) {
-			( this.root.debug ? fatal : warnOnce )( 'Could not find template for partial "%s"', this.name );
+			warnOnceIfDebug( 'Could not find template for partial "%s"', this.name );
 		}
 
 		this.value = value;

--- a/src/virtualdom/items/Partial/getPartialTemplate.js
+++ b/src/virtualdom/items/Partial/getPartialTemplate.js
@@ -1,5 +1,5 @@
 import { noRegistryFunctionReturn } from 'config/errors';
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 import parser from 'Ractive/config/custom/template/parser';
 import { findInstance } from 'shared/registry';
 import deIndent from './deIndent';
@@ -43,7 +43,7 @@ function getPartialFromRegistry ( ractive, name ) {
 	}
 
 	if ( !partial && partial !== '' ) {
-		warn( noRegistryFunctionReturn, name, 'partial', 'partial' );
+		warnIfDebug( noRegistryFunctionReturn, name, 'partial', 'partial' );
 		return;
 	}
 
@@ -57,7 +57,7 @@ function getPartialFromRegistry ( ractive, name ) {
 		// Partials cannot contain nested partials!
 		// TODO add a test for this
 		if ( parsed.p ) {
-			warn( 'Partials ({{>%s}}) cannot contain nested inline partials', name );
+			warnIfDebug( 'Partials ({{>%s}}) cannot contain nested inline partials', name );
 		}
 
 		// if fn, use instance to store result, otherwise needs to go

--- a/src/virtualdom/items/Partial/getPartialTemplate.js
+++ b/src/virtualdom/items/Partial/getPartialTemplate.js
@@ -43,7 +43,7 @@ function getPartialFromRegistry ( ractive, name ) {
 	}
 
 	if ( !partial && partial !== '' ) {
-		warnIfDebug( noRegistryFunctionReturn, name, 'partial', 'partial' );
+		warnIfDebug( noRegistryFunctionReturn, name, 'partial', 'partial', { ractive });
 		return;
 	}
 
@@ -57,7 +57,7 @@ function getPartialFromRegistry ( ractive, name ) {
 		// Partials cannot contain nested partials!
 		// TODO add a test for this
 		if ( parsed.p ) {
-			warnIfDebug( 'Partials ({{>%s}}) cannot contain nested inline partials', name );
+			warnIfDebug( 'Partials ({{>%s}}) cannot contain nested inline partials', name, { ractive });
 		}
 
 		// if fn, use instance to store result, otherwise needs to go

--- a/src/virtualdom/items/Yielder.js
+++ b/src/virtualdom/items/Yielder.js
@@ -22,7 +22,7 @@ var Yielder = function ( options ) {
 	let template = container._inlinePartials[ name ];
 
 	if ( !template ) {
-		warnIfDebug( `Could not find template for partial "${name}"` );
+		warnIfDebug( `Could not find template for partial "${name}"`, { ractive: options.root });
 		template = [];
 	}
 

--- a/src/virtualdom/items/Yielder.js
+++ b/src/virtualdom/items/Yielder.js
@@ -1,5 +1,5 @@
 import { YIELDER } from 'config/types';
-import { warn } from 'utils/log';
+import { warnIfDebug } from 'utils/log';
 import runloop from 'global/runloop';
 import { removeFromArray } from 'utils/array';
 import Fragment from 'virtualdom/Fragment';
@@ -22,7 +22,7 @@ var Yielder = function ( options ) {
 	let template = container._inlinePartials[ name ];
 
 	if ( !template ) {
-		warn( `Could not find template for partial "${name}"` );
+		warnIfDebug( `Could not find template for partial "${name}"` );
 		template = [];
 	}
 

--- a/test/__tests/elements.js
+++ b/test/__tests/elements.js
@@ -69,20 +69,15 @@ test( 'Textarea is stringified correctly', function ( t ) {
 });
 
 test( 'Wildcard proxy-events invalid on elements', t => {
-	let warn = console.warn;
-	console.warn = msg => {
-		t.ok( /wildcards/.test( msg ) );
-	};
-
 	expect( 1 );
 
-	new Ractive({
-		el: fixture,
-		debug: true,
-		template: '<p on-foo.*="foo"></p>'
-	});
-
-	console.warn = warn;
+	t.throws( () => {
+		new Ractive({
+			el: fixture,
+			debug: true,
+			template: '<p on-foo.*="foo"></p>'
+		});
+	}, /wildcards/ );
 });
 
 test( 'draggable attribute is handled correctly (#1780)', t => {

--- a/test/__tests/elements.js
+++ b/test/__tests/elements.js
@@ -68,14 +68,21 @@ test( 'Textarea is stringified correctly', function ( t ) {
 	t.equal( ractive.toHTML(), '<textarea>123&lt;div&gt;&lt;/div&gt;</textarea>' );
 });
 
-test( 'Wildcard proxy-events invalid on elements', () => {
-	throws( function () {
-		new Ractive({
-			el: fixture,
-			debug: true,
-			template: '<p on-foo.*="foo"></p>'
-		});
-	}, /wildcards/ );
+test( 'Wildcard proxy-events invalid on elements', t => {
+	let warn = console.warn;
+	console.warn = msg => {
+		t.ok( /wildcards/.test( msg ) );
+	};
+
+	expect( 1 );
+
+	new Ractive({
+		el: fixture,
+		debug: true,
+		template: '<p on-foo.*="foo"></p>'
+	});
+
+	console.warn = warn;
 });
 
 test( 'draggable attribute is handled correctly (#1780)', t => {

--- a/test/__tests/init/config.js
+++ b/test/__tests/init/config.js
@@ -5,11 +5,13 @@ import { findInViewHierarchy } from 'shared/registry';
 
 module( 'Configuration' );
 
+const test = QUnit.test; // necessary due to a bug in esperanto
+
 test( 'Ractive.defaults', t => {
 	t.equal( Ractive.defaults, Ractive.prototype, 'defaults aliases prototype' );
 
 	for( let key in defaults ) {
-		t.ok( Ractive.defaults.hasOwnProperty( key ), 'has default ' + key )
+		t.ok( Ractive.defaults.hasOwnProperty( key ), 'has default ' + key );
 	}
 });
 

--- a/test/__tests/partials.js
+++ b/test/__tests/partials.js
@@ -21,25 +21,23 @@ if ( console && console.warn ) {
 	test( 'no return of partial warns in debug', function ( t ) {
 		var ractive, warn = console.warn;
 
-		expect( 2 ); //throws counts as an assertion
+		expect( 2 );
 
 		console.warn = function( msg ) {
 			t.ok( msg );
 		};
 
 		// will throw on no-partial found
-		throws( () => {
-			ractive = new Ractive({
-				el: fixture,
-				template: '{{>foo}}',
-				data: { foo: true },
-				debug: true,
-				partials: {
-					foo () {
-						// where's my partial?
-					}
+		ractive = new Ractive({
+			el: fixture,
+			template: '{{>foo}}',
+			data: { foo: true },
+			debug: true,
+			partials: {
+				foo () {
+					// where's my partial?
 				}
-			});
+			}
 		});
 
 		console.warn = warn;

--- a/test/__tests/rebind.js
+++ b/test/__tests/rebind.js
@@ -7,6 +7,8 @@ import { getKeypath } from 'shared/keypaths';
 
 module( 'rebind' );
 
+const test = QUnit.test; // necessary due to a bug in esperanto
+
 function contextUpdate(opt){
 	test( 'update context path: ' + opt.test, function ( t ) {
 		var resolved, fragment, el, triple;
@@ -45,7 +47,7 @@ function contextUpdate(opt){
 		});
 
 		triple.resolve = function(keypath){
-		 	resolved = keypath
+			resolved = keypath;
 		};
 
 		fragment.items.push(el, triple);


### PR DESCRIPTION
**not ready for merge**

This PR replaces the per-instance (or per-component) `debug` option with a much simpler-to-understand global `Ractive.DEBUG` flag. See #1793 for the discussion that led here.

Remaining tasks:

* [x] Print a message to the console saying 'we're in debug mode, disable it with Ractive.DEBUG = false' OWTTE. (This can't happen immediately on load, because the app developer wouldn't have a chance to disable debug mode before that line was reached. We could `setTimeout` it or, perhaps better, print that on the occasion of the first `new Ractive()`. Suggestions welcome)
* [x] Decide whether it should be `true` by default, or `true` by default if unminified, or what. Right now it's `true` by default (personally I think disabling it should always be an explicit choice on the part of the developer, since many devs might download `ractive.min.js` from the CDN and put that in their `<script>` tag - because they've been told not to use unminified code - and would never see the helpful debugging messages. Though the alternative does imply either having a build step that injects environment variables into your bundle, or manually changing `Ractive.DEBUG` to `false` before each deployment)
* [x] Add a way to pass through a Ractive instance or a specific node to the various warning functions, so that we can print useful stuff to the console