### PR TITLE
Collapse welcome message to minimize spaminess

### DIFF
--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -6,6 +6,13 @@ import noop from 'utils/noop';
 var alreadyWarned = {}, log, printWarning, welcome;
 
 if ( hasConsole ) {
+	let welcomeIntro = [
+		`%cRactive.js %c<@version@> %cin debug mode, %cmore...`,
+		'color: rgb(114, 157, 52); font-weight: normal;',
+		'color: rgb(85, 85, 85); font-weight: normal;',
+		'color: rgb(85, 85, 85); font-weight: normal;',
+		'color: rgb(82, 140, 224); font-weight: normal; text-decoration: underline;'
+	];
 	let welcomeMessage = `You're running Ractive <@version@> in debug mode - messages will be printed to the console to help you fix problems and optimise your application.
 
 To disable debug mode, add this line at the start of your app:
@@ -26,7 +33,13 @@ Found a bug? Raise an issue:
 `;
 
 	welcome = () => {
-		console.log.apply( console, [ '%cRactive.js: %c' + welcomeMessage, 'color: rgb(114, 157, 52);', 'color: rgb(85, 85, 85);' ] );
+		let hasGroup = !!console.groupCollapsed;
+		console[ hasGroup ? 'groupCollapsed' : 'log' ].apply( console, welcomeIntro );
+		console.log( welcomeMessage );
+		if ( hasGroup ) {
+			console.groupEnd( welcomeIntro );
+		}
+
 		welcome = noop;
 	};
 


### PR DESCRIPTION
The new debug welcome message take up a lot of real estate which gets tres annoying when your running live reload or otherwise refreshing browser. This reduces it to:

![image](https://cloud.githubusercontent.com/assets/478864/6656758/83354a6e-caf1-11e4-99b8-aec9bb5d43e7.png)

The full message is available if you expand the group (which works by clicking anywhere on that line).

![image](https://cloud.githubusercontent.com/assets/478864/6656778/1f93480c-caf2-11e4-9457-5a1adf5574a3.png)

`console.groupCollapse` has [good browser support](https://developer.mozilla.org/en-US/docs/Web/API/Console/groupCollapsed#Browser_compatibility) and this falls back to `log` if not.

We might consider this pattern for some of the other lengthy messages that have code snippets, etc. attached to them.