### PR TITLE
Add safeToStringValue for objects with no toString method (gh-1825)

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -130,4 +130,8 @@ function detachNode ( node ) {
 	return node;
 }
 
-export { createElement, detachNode, getElement, matches };
+function safeToStringValue( value ) {
+	return ( value == null || !value.toString ) ? '' : value;
+}
+
+export { createElement, detachNode, getElement, matches, safeToStringValue };

--- a/src/virtualdom/items/Element/Attribute/prototype/update/updateClassName.js
+++ b/src/virtualdom/items/Element/Attribute/prototype/update/updateClassName.js
@@ -1,12 +1,4 @@
+import { safeToStringValue } from 'utils/dom';
 export default function Attribute$updateClassName () {
-	var node, value;
-
-	node = this.node;
-	value = this.value;
-
-	if ( value === undefined ) {
-		value = '';
-	}
-
-	node.className = value;
+	this.node.className = safeToStringValue( this.value );
 }

--- a/src/virtualdom/items/Interpolator.js
+++ b/src/virtualdom/items/Interpolator.js
@@ -1,7 +1,7 @@
 import { INTERPOLATOR } from 'config/types';
 import runloop from 'global/runloop';
 import { escapeHtml } from 'utils/html';
-import { detachNode } from 'utils/dom';
+import { detachNode, safeToStringValue } from 'utils/dom';
 import { isEqual } from 'utils/is';
 import unbind from './shared/unbind';
 import Mustache from './shared/Mustache/_Mustache';
@@ -24,7 +24,7 @@ Interpolator.prototype = {
 
 	render () {
 		if ( !this.node ) {
-			this.node = document.createTextNode( this.value != undefined ? this.value : '' );
+			this.node = document.createTextNode( safeToStringValue(this.value) );
 		}
 
 		return this.node;
@@ -62,7 +62,7 @@ Interpolator.prototype = {
 	},
 
 	toString ( escape ) {
-		var string = ( this.value != undefined ? '' + this.value : '' );
+		var string = ( '' + safeToStringValue(this.value) );
 		return escape ? escapeHtml( string ) : string;
 	}
 };

--- a/test/__tests/render.js
+++ b/test/__tests/render.js
@@ -284,6 +284,21 @@ test( 'Sections survive unrender-render (#1553)', t => {
 	t.htmlEqual( fixture.innerHTML, '<p>1</p><p>2</p><p>3</p>' );
 });
 
+test( 'data of type Object.create(null) (#1825)', t => {
+	var ractive, expected;
+
+	ractive = new Ractive({
+		el: fixture,
+		template: '<hr class="{{ noproto }}">{{ noproto }}',
+		data: { noproto: Object.create(null) }
+	});
+
+	expected = '<hr class>';
+
+	t.htmlEqual( fixture.innerHTML, expected );
+	t.equal( ractive.toHTML(), expected );
+});
+
 function deepClone ( source ) {
 	var target, key;
 


### PR DESCRIPTION
Fixes #1825: situations where the DOM object properties like `.className` expect objects that can be converted via `toString`