### PR TITLE
put all console.warn-using tests inside a conditional, for benefit of IE9

### DIFF
--- a/test/__tests/arrays.js
+++ b/test/__tests/arrays.js
@@ -279,46 +279,35 @@ test( `Array shuffling only adjusts context and doesn't tear stuff down to rebui
 
 function removedElementsTest ( action, fn ) {
 	test( 'Array elements removed via ' + action + ' do not trigger updates in removed sections', function ( t ) {
-		var warn = console.warn, observed = false;
+		let observed = false, errored = false;
 
-		expect( 4 );
+		expect( 5 );
 
-		console.warn = function (err) {
-			throw err
-		};
-
-		try {
-			let ractive = new Ractive({
-				debug: true,
-				el: fixture,
-				template: '{{#options}}{{get(this)}}{{/options}}',
-				data: {
-					options: [ 'a', 'b', 'c' ],
-					get: function ( item ){
-						if(!item) { throw new Error('item should not be undefined'); }
-						return item
-					}
+		let ractive = new Ractive({
+			debug: true,
+			el: fixture,
+			template: '{{#options}}{{get(this)}}{{/options}}',
+			data: {
+				options: [ 'a', 'b', 'c' ],
+				get: function ( item ){
+					if (!item ) errored = true;
+					return item;
 				}
-			});
+			}
+		});
 
-			ractive.observe( 'options.2', function ( n, o ) {
-				t.ok( !n );
-				t.equal( o, 'c' );
-				observed = true;
-			}, { init: false } );
+		ractive.observe( 'options.2', function ( n, o ) {
+			t.ok( !n );
+			t.equal( o, 'c' );
+			observed = true;
+		}, { init: false } );
 
-			t.ok( !observed );
+		t.ok( !observed );
 
-			fn( ractive );
-		}
-		catch(err){
-			t.ok( false, err );
-		}
-		finally {
-			console.warn = warn;
-			t.ok( observed );
-		}
+		fn( ractive );
 
+		t.ok( observed );
+		t.ok( !errored );
 	});
 }
 

--- a/test/__tests/elements.js
+++ b/test/__tests/elements.js
@@ -80,23 +80,25 @@ test( 'Wildcard proxy-events invalid on elements', t => {
 	}, /wildcards/ );
 });
 
-test( 'draggable attribute is handled correctly (#1780)', t => {
-	let ractive = new Ractive({
-		el: fixture,
-		template: '<div draggable="true" /><div draggable="false" /><div draggable="" /><div draggable /><div draggable="{{true}}" /><div draggable="{{false}}" /><div draggable="{{empty}}" />'
+if ( 'draggable' in document.createElement( 'div' ) ) {
+	test( 'draggable attribute is handled correctly (#1780)', t => {
+		let ractive = new Ractive({
+			el: fixture,
+			template: '<div draggable="true" /><div draggable="false" /><div draggable="" /><div draggable /><div draggable="{{true}}" /><div draggable="{{false}}" /><div draggable="{{empty}}" />'
+		});
+
+		let divs = ractive.findAll( 'div' );
+		t.equal( divs[0].draggable, true );
+		t.equal( divs[1].draggable, false );
+		t.equal( divs[2].draggable, false );
+		t.equal( divs[3].draggable, false );
+		t.equal( divs[4].draggable, true );
+		t.equal( divs[5].draggable, false );
+		t.equal( divs[6].draggable, false );
+
+		ractive.set( 'empty', true );
+		t.equal( divs[6].draggable, true );
+		ractive.set( 'empty', 'potato' );
+		t.equal( divs[6].draggable, false );
 	});
-
-	let divs = ractive.findAll( 'div' );
-	t.equal( divs[0].draggable, true );
-	t.equal( divs[1].draggable, false );
-	t.equal( divs[2].draggable, false );
-	t.equal( divs[3].draggable, false );
-	t.equal( divs[4].draggable, true );
-	t.equal( divs[5].draggable, false );
-	t.equal( divs[6].draggable, false );
-
-	ractive.set( 'empty', true );
-	t.equal( divs[6].draggable, true );
-	ractive.set( 'empty', 'potato' );
-	t.equal( divs[6].draggable, false );
-});
+}

--- a/test/__tests/init/hooks.js
+++ b/test/__tests/init/hooks.js
@@ -369,22 +369,24 @@ test( 'correct behaviour of deprecated beforeInit hook (#1395)', function ( t ) 
 	t.deepEqual( count, { construct: 0, beforeInit: 1 });
 });
 
-asyncTest( 'error in oncomplete sent to console', function ( t ) {
-	var ractive, error = console.error;
+if ( typeof console !== 'undefined' && console.warn ) {
+	asyncTest( 'error in oncomplete sent to console', function ( t ) {
+		var ractive, error = console.error;
 
-	expect( 1 )
-	console.error = function ( err ) {
-		t.equal( err, 'evil handler' );
-		console.error = error;
-		QUnit.start();
-	}
+		expect( 1 )
+		console.error = function ( err ) {
+			t.equal( err, 'evil handler' );
+			console.error = error;
+			QUnit.start();
+		};
 
-	ractive = new Ractive({
-		el: fixture,
-		template: 'foo',
-		data: { a: 'b' },
-		oncomplete: function(){
-			throw 'evil handler';
-		}
+		ractive = new Ractive({
+			el: fixture,
+			template: 'foo',
+			data: { a: 'b' },
+			oncomplete: function(){
+				throw 'evil handler';
+			}
+		});
 	});
-});
+}

--- a/test/__tests/misc.js
+++ b/test/__tests/misc.js
@@ -1699,19 +1699,21 @@ asyncTest( 'Promise.all works with non-promises (#1642)', t => {
 	});
 });
 
-test( 'Ractive.DEBUG can be changed', t => {
-	let DEBUG = Ractive.DEBUG;
-	Ractive.DEBUG = false;
+if ( typeof console !== 'undefined' && console.warn ) {
+	test( 'Ractive.DEBUG can be changed', t => {
+		let DEBUG = Ractive.DEBUG;
+		Ractive.DEBUG = false;
 
-	let warn = console.warn;
-	console.warn = () => t.ok( false );
+		let warn = console.warn;
+		console.warn = () => t.ok( false );
 
-	expect( 0 );
-	new Ractive({ template: '{{>thisWouldNormallyWarn}}' });
+		expect( 0 );
+		new Ractive({ template: '{{>thisWouldNormallyWarn}}' });
 
-	Ractive.DEBUG = DEBUG;
-	console.warn = warn;
-});
+		Ractive.DEBUG = DEBUG;
+		console.warn = warn;
+	});
+}
 
 // Is there a way to artificially create a FileList? Leaving this commented
 // out until someone smarter than me figures out how

--- a/test/__tests/partials.js
+++ b/test/__tests/partials.js
@@ -17,7 +17,7 @@ test( 'specify partial by function', function ( t ) {
 	t.htmlEqual( fixture.innerHTML, '<p>yes</p>' );
 });
 
-if ( console && console.warn ) {
+if ( typeof console !== 'undefined' && console.warn ) {
 	test( 'no return of partial warns in debug', function ( t ) {
 		var ractive, warn = console.warn;
 
@@ -39,6 +39,45 @@ if ( console && console.warn ) {
 				}
 			}
 		});
+
+		console.warn = warn;
+	});
+
+	test( 'Warn on unknown partial', function ( t ) {
+		var ractive, warn = console.warn;
+
+		expect( 2 );
+
+		console.warn = () => t.ok( true );
+
+		ractive = new Ractive({
+			el: fixture,
+			template: '{{>unknown}}{{>other {a:42} }}',
+			partials: {}
+		});
+
+		console.warn = warn;
+	});
+
+	test( 'Don\'t warn on empty partial', function ( t ) {
+
+		var ractive, warn = console.warn;
+
+		expect( 1 );
+
+		console.warn = function( msg ) {
+			t.ok( false );
+		}
+
+		ractive = new Ractive({
+			el: fixture,
+			template: '{{>empty}}',
+			partials: {
+				empty: ''
+			}
+		});
+
+		t.ok( true );
 
 		console.warn = warn;
 	});
@@ -590,24 +629,6 @@ test( '(Only) inline partials can be yielded', t => {
 	t.htmlEqual( fixture.innerHTML, 'foo' );
 });
 
-if ( console && console.warn ) {
-	test( 'Warn on unknown partial', function ( t ) {
-		var ractive, warn = console.warn;
-
-		expect( 2 );
-
-		console.warn = () => t.ok( true );
-
-		ractive = new Ractive({
-			el: fixture,
-			template: '{{>unknown}}{{>other {a:42} }}',
-			partials: {}
-		});
-
-		console.warn = warn;
-	});
-}
-
 test( 'Don\'t throw on empty partial', function ( t ) {
 
 	var ractive;
@@ -645,32 +666,6 @@ test( 'Dynamic empty partial ok', function ( t ) {
 	t.htmlEqual( fixture.innerHTML, 'bar' );
 
 });
-
-if ( console && console.warn ) {
-
-	test( 'Don\'t warn on empty partial', function ( t ) {
-
-		var ractive, warn = console.warn;
-
-		expect( 1 );
-
-		console.warn = function( msg ) {
-			t.ok( false );
-		}
-
-		ractive = new Ractive({
-			el: fixture,
-			template: '{{>empty}}',
-			partials: {
-				empty: ''
-			}
-		});
-
-		t.ok( true );
-
-		console.warn = warn;
-	});
-}
 
 test( 'Partials with expressions in recursive structures should not blow the stack', t => {
 	var ractive = new Ractive({

--- a/test/__tests/transitions.js
+++ b/test/__tests/transitions.js
@@ -166,7 +166,7 @@ asyncTest( 'ractive.transitionsEnabled false prevents all transitions', function
 	});
 });
 
-if ( console && console.warn ) {
+if ( typeof console !== 'undefined' && console.warn ) {
 	asyncTest( 'Missing transition functions do not cause errors, but do console.warn', function ( t ) {
 		var ractive, warn = console.warn;
 
@@ -174,7 +174,7 @@ if ( console && console.warn ) {
 
 		console.warn = function( msg ) {
 			t.ok( msg );
-		}
+		};
 
 		ractive = new Ractive({
 			el: fixture,

--- a/test/__tests/twoway.js
+++ b/test/__tests/twoway.js
@@ -498,22 +498,6 @@ test( 'Ambiguous reference expressions in two-way bindings attach to the root (#
 	t.htmlEqual( fixture.innerHTML, '<p>foo[0]: test</p><input>' );
 });
 
-test( 'Ambiguous references trigger a warning (#1692)', function ( t ) {
-	var warn = console.warn;
-	console.warn = warning => {
-		t.ok( /ambiguous/.test( warning ) );
-	};
-
-	expect( 1 );
-
-	var ractive = new Ractive({
-		el: fixture,
-		template: `{{#with whatever}}<input value='{{foo}}'>{{/with}}`
-	});
-
-	console.warn = warn;
-});
-
 test( 'Static bindings can only be one-way (#1149)', function ( t ) {
 	var ractive = new Ractive({
 		el: fixture,
@@ -621,38 +605,6 @@ test( 'input[type="checkbox"] works with array mutated on init (#1305)', functio
 	t.ok( checkboxes[2].checked );
 });
 
-test( 'Using expressions in two-way bindings triggers a warning (#1399)', function ( t ) {
-	var console_warn = console.warn;
-
-	console.warn = function ( message ) {
-		t.ok( /Two-way binding does not work with expressions/.test(message) );
-	};
-
-	new Ractive({
-		el: fixture,
-		template: '<input value="{{foo()}}">',
-		data: { foo: () => 'bar' }
-	});
-
-	console.warn = console_warn;
-});
-
-test( 'Using expressions with keypath in two-way bindings triggers a warning (#1399/#1421)', function ( t ) {
-	var console_warn = console.warn;
-
-	console.warn = function ( message ) {
-		t.ok( true );
-	};
-
-	new Ractive({
-		el: fixture,
-		template: '<input value="{{foo.bar()[\'biz.bop\']}}">',
-		data: { foo: { bar: () => 'bar' } }
-	});
-
-	console.warn = console_warn;
-});
-
 test( 'Downstream expression objects in two-way bindings do not trigger a warning (#1421)', function ( t ) {
 	var ractive;
 
@@ -723,21 +675,71 @@ test( 'Change events propagate after the model has been updated (#1371)', t => {
 	simulant.fire( ractive.find( 'select' ), 'change' );
 });
 
-test( '@key cannot be used for two-way binding', t => {
-	let warn = console.warn;
-	console.warn = msg => {
-		t.ok( /Two-way binding does not work with @key/.test( msg ) );
-	};
+if ( typeof console !== 'undefined' && console.warn ) {
+	test( 'Ambiguous references trigger a warning (#1692)', function ( t ) {
+		var warn = console.warn;
+		console.warn = warning => {
+			t.ok( /ambiguous/.test( warning ) );
+		};
 
-	expect( 1 );
+		expect( 1 );
 
-	new Ractive({
-		el: fixture,
-		template: `{{#each obj}}<input value='{{@key}}'>{{/each}}`,
-		data: {
-			obj: { foo: 1, bar: 2, baz: 3 }
-		}
+		var ractive = new Ractive({
+			el: fixture,
+			template: `{{#with whatever}}<input value='{{foo}}'>{{/with}}`
+		});
+
+		console.warn = warn;
 	});
 
-	console.warn = warn;
-});
+	test( 'Using expressions in two-way bindings triggers a warning (#1399)', function ( t ) {
+		var console_warn = console.warn;
+
+		console.warn = function ( message ) {
+			t.ok( /Two-way binding does not work with expressions/.test(message) );
+		};
+
+		new Ractive({
+			el: fixture,
+			template: '<input value="{{foo()}}">',
+			data: { foo: () => 'bar' }
+		});
+
+		console.warn = console_warn;
+	});
+
+	test( 'Using expressions with keypath in two-way bindings triggers a warning (#1399/#1421)', function ( t ) {
+		var console_warn = console.warn;
+
+		console.warn = function ( message ) {
+			t.ok( true );
+		};
+
+		new Ractive({
+			el: fixture,
+			template: '<input value="{{foo.bar()[\'biz.bop\']}}">',
+			data: { foo: { bar: () => 'bar' } }
+		});
+
+		console.warn = console_warn;
+	});
+
+	test( '@key cannot be used for two-way binding', t => {
+		let warn = console.warn;
+		console.warn = msg => {
+			t.ok( /Two-way binding does not work with @key/.test( msg ) );
+		};
+
+		expect( 1 );
+
+		new Ractive({
+			el: fixture,
+			template: `{{#each obj}}<input value='{{@key}}'>{{/each}}`,
+			data: {
+				obj: { foo: 1, bar: 2, baz: 3 }
+			}
+		});
+
+		console.warn = warn;
+	});
+}

--- a/test/__tests/yield.js
+++ b/test/__tests/yield.js
@@ -265,21 +265,23 @@ test( 'Components inherited from more than one generation off work with named yi
 	t.htmlEqual( fixture.innerHTML, '<p>this is foo</p>' );
 });
 
-test( 'Yield with missing partial (#1681)', t => {
-	/* global console */
-	let warn = console.warn;
-	console.warn = msg => {
-		t.ok( /Could not find template for partial "missing"/.test( msg ) );
-	};
+if ( typeof console !== 'undefined' && console.warn ) {
+	test( 'Yield with missing partial (#1681)', t => {
+		/* global console */
+		let warn = console.warn;
+		console.warn = msg => {
+			t.ok( /Could not find template for partial "missing"/.test( msg ) );
+		};
 
-	let Widget = Ractive.extend({
-		template: '{{yield missing}}'
+		let Widget = Ractive.extend({
+			template: '{{yield missing}}'
+		});
+
+		new Ractive({
+			template: '<Widget/>',
+			components: { Widget }
+		});
+
+		console.warn = warn;
 	});
-
-	new Ractive({
-		template: '<Widget/>',
-		components: { Widget }
-	});
-
-	console.warn = warn;
-});
+}


### PR DESCRIPTION
A few tests depend on monkey-patching `console.warn()`, which is a problem for IE9 as it doesn't have `console`. This PR wraps them in an `if ( typeof console !== 'undefined' && console.warn ) {...}` block.