### PR TITLE
Taking a swing at the inline partial shuffle

### DIFF
--- a/src/virtualdom/items/Element/prototype/init.js
+++ b/src/virtualdom/items/Element/prototype/init.js
@@ -97,11 +97,4 @@ export default function Element$init ( options ) {
 	// create transitions
 	this.intro = template.t0 || template.t1;
 	this.outro = template.t0 || template.t2;
-
-	// if there are any partials bound here, copy them to root
-	if ( template.p ) {
-		for ( let k in template.p ) {
-			this.root.partials[k] = template.p[k];
-		}
-	}
 }

--- a/src/virtualdom/items/Element/prototype/init.js
+++ b/src/virtualdom/items/Element/prototype/init.js
@@ -97,4 +97,11 @@ export default function Element$init ( options ) {
 	// create transitions
 	this.intro = template.t0 || template.t1;
 	this.outro = template.t0 || template.t2;
+
+	// if there are any partials bound here, copy them to root
+	if ( template.p ) {
+		for ( let k in template.p ) {
+			this.root.partials[k] = template.p[k];
+		}
+	}
 }

--- a/src/virtualdom/items/Partial/_Partial.js
+++ b/src/virtualdom/items/Partial/_Partial.js
@@ -29,7 +29,7 @@ let Partial = function ( options ) {
 	// (i.e. `{{>foo}}` means 'use the foo partial', not 'use the partial
 	// whose name is the value of `foo`')
 	if ( !this.keypath ) {
-		if ( template = getPartialTemplate( this.root, this.name ) ) {
+		if ( template = getPartialTemplate( this.root, this.name, parentFragment ) ) {
 			unbind.call( this ); // prevent any further changes
 			this.isNamed = true;
 			this.setTemplate( template );
@@ -112,13 +112,13 @@ Partial.prototype = {
 		}
 
 		if ( value !== undefined ) {
-			template = getPartialTemplate( this.root, '' + value );
+			template = getPartialTemplate( this.root, '' + value, this.parentFragment );
 		}
 
 		// we may be here if we have a partial like `{{>foo}}` and `foo` is the
 		// name of both a data property (whose value ISN'T the name of a partial)
 		// and a partial. In those cases, this becomes a named partial
-		if ( !template && this.name && ( template = getPartialTemplate( this.root, this.name ) ) ) {
+		if ( !template && this.name && ( template = getPartialTemplate( this.root, this.name, this.parentFragment ) ) ) {
 			unbind.call( this );
 			this.isNamed = true;
 		}

--- a/test/__tests/partials.js
+++ b/test/__tests/partials.js
@@ -1,5 +1,7 @@
 module( 'partials' );
 
+/* global console */
+
 var partialsFn = {
 	foo () {
 		return this.get( 'foo' ) ? '<p>yes</p>' : '<h1>no</h1>';
@@ -65,9 +67,9 @@ if ( typeof console !== 'undefined' && console.warn ) {
 
 		expect( 1 );
 
-		console.warn = function( msg ) {
+		console.warn = function() {
 			t.ok( false );
-		}
+		};
 
 		ractive = new Ractive({
 			el: fixture,
@@ -170,7 +172,7 @@ test( 'partial functions selects same partial until reset', function ( t ) {
 		template: '{{#items}}{{>foo}}{{/items}}',
 		partials: {
 			foo () {
-				return this.get( 'foo' ) ? '<p>{{.}}</p>' : '<h1>{{.}}</h1>'
+				return this.get( 'foo' ) ? '<p>{{.}}</p>' : '<h1>{{.}}</h1>';
 			}
 		},
 		data: {
@@ -260,7 +262,7 @@ test( 'Partials work in attributes (#917)', function ( t ) {
 	ractive.set( 'height', 200 );
 
 	t.htmlEqual( fixture.innerHTML, '<div style="height: 200px;"></div>' );
-})
+});
 
 test( 'Partial mustaches can be references or expressions that resolve to a partial', function ( t ) {
 	// please never do anything like this
@@ -319,7 +321,7 @@ test( 'Partial mustaches can be references or expressions that resolve to a part
 });
 
 test( 'Partials with expressions may also have context', function( t ) {
-	var ractive = new Ractive({
+	new Ractive({
 		el: fixture,
 		template: '{{>(tpl + ".test") ctx}} : {{>"test." + tpl ctx.expr}}',
 		data: {
@@ -561,7 +563,7 @@ test( 'Partials in attribute blocks can be changed with resetPartial', t => {
 });
 
 test( 'Partial naming requirements are relaxed', t => {
-	var ractive = new Ractive({
+	new Ractive({
 		el: fixture,
 		template: `{{>a-partial}}{{>10-2}}{{>a - partial}}{{>delete}}`,
 		partials: {
@@ -579,7 +581,7 @@ test( 'Partial naming requirements are relaxed', t => {
 });
 
 test( 'Inline partials can override component partials', t => {
-	var ractive = new Ractive({
+	new Ractive({
 		el: fixture,
 		template: `
 			<cmp>
@@ -601,7 +603,7 @@ test( 'Inline partials can override component partials', t => {
 });
 
 test( 'Inline partials may be defined with a partial section', t => {
-	var ractive = new Ractive({
+	new Ractive({
 		el: fixture,
 		template: '{{#partial foo}}foo{{/partial}}{{>foo}}<cmp /><cmp>{{#partial foo}}bar{{/partial}}<cmp>',
 		components: {
@@ -615,7 +617,7 @@ test( 'Inline partials may be defined with a partial section', t => {
 });
 
 test( '(Only) inline partials can be yielded', t => {
-	var ractive = new Ractive({
+	new Ractive({
 		el: fixture,
 		template: '<cmp /><cmp>{{#partial foo}}foo{{/partial}}',
 		components: {
@@ -668,7 +670,7 @@ test( 'Dynamic empty partial ok', function ( t ) {
 });
 
 test( 'Partials with expressions in recursive structures should not blow the stack', t => {
-	var ractive = new Ractive({
+	new Ractive({
 		el: fixture,
 		template: '{{#items}}{{>\'item\'}}{{/}}',
 		partials: {
@@ -722,7 +724,7 @@ test( 'Several inline partials containing elements can be defined (#1736)', t =>
 	t.equal( ractive.partials.part2.length, 1 );
 });
 
-test( 'Removing a missing partial (#1808)', t => {
+test( 'Removing a missing partial (#1808)', () => {
 	expect( 0 );
 
 	let ractive = new Ractive({
@@ -739,7 +741,7 @@ test( 'Removing a missing partial (#1808)', t => {
 
 test( 'Dynamic partial can be set in oninit (#1826)', t => {
 
-	let ractive = new Ractive({
+	new Ractive({
 		el: fixture,
 		template: '{{> partialName }}',
 		partials: {
@@ -756,4 +758,23 @@ test( 'Dynamic partial can be set in oninit (#1826)', t => {
 
 	t.htmlEqual( fixture.innerHTML, 'twopart' );
 
+});
+
+test( 'Inline partials may be attached to any element (#1823)', t => {
+	new Ractive({
+		el: fixture,
+		template: '<div>{{#partial foo}}foo{{/}}</div>{{>foo}}'
+	});
+
+	t.htmlEqual( fixture.innerHTML, '<div></div>foo' );
+});
+
+test( 'Inline partials bubble to their nearest component (#1823)', t => {
+	new Ractive({
+		el: fixture,
+		template: '{{#partial foo}}parent{{/partial}}<cmp>{{#partial foo}}cmp{{/partial}}</cmp>{{>foo}}',
+		components: { cmp: Ractive.extend({ template: '{{>foo}}' }) }
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'cmpparent' );
 });

--- a/test/__tests/partials.js
+++ b/test/__tests/partials.js
@@ -778,3 +778,23 @@ test( 'Inline partials bubble to their nearest component (#1823)', t => {
 
 	t.htmlEqual( fixture.innerHTML, 'cmpparent' );
 });
+
+test( 'Inline partials can override instance partials if they exist on a node directly up-hierarchy', t => {
+	new Ractive({
+		el: fixture,
+		template: `{{#partial foo}}
+				Something happens {{>here}}
+			{{/partial}}
+
+			<div>
+				{{#partial here}}one{{/partial}}
+				<span>{{>foo}}</span>
+			</div>
+			<div>
+				{{#partial here}}two{{/partial}}
+				<span>{{>foo}}</span>
+			</div>`
+	});
+
+	t.htmlEqual( fixture.innerHTML, '<div><span>Something happens one</span></div><div><span>Something happens two</span></div>' );
+});

--- a/test/__tests/partials.js
+++ b/test/__tests/partials.js
@@ -760,23 +760,13 @@ test( 'Dynamic partial can be set in oninit (#1826)', t => {
 
 });
 
-test( 'Inline partials may be attached to any element (#1823)', t => {
+test( 'Inline partials don\'t dissipate into the ether when attached to non-components (#1838)', t => {
 	new Ractive({
 		el: fixture,
-		template: '<div>{{#partial foo}}foo{{/}}</div>{{>foo}}'
+		template: '<div>{{#partial foo}}foo{{/partial}}{{>foo}}</div>'
 	});
 
-	t.htmlEqual( fixture.innerHTML, '<div></div>foo' );
-});
-
-test( 'Inline partials bubble to their nearest component (#1823)', t => {
-	new Ractive({
-		el: fixture,
-		template: '{{#partial foo}}parent{{/partial}}<cmp>{{#partial foo}}cmp{{/partial}}</cmp>{{>foo}}',
-		components: { cmp: Ractive.extend({ template: '{{>foo}}' }) }
-	});
-
-	t.htmlEqual( fixture.innerHTML, 'cmpparent' );
+	t.htmlEqual( fixture.innerHTML, '<div>foo</div>' );
 });
 
 test( 'Inline partials can override instance partials if they exist on a node directly up-hierarchy', t => {


### PR DESCRIPTION
### Part 1

~~Per #1838's discussion, this gets inline partials scoped back to their nearest Ractive instance. It does so by simply copying the partials from the element to the element root when the element is instantiated. This does have at least one potential issue that I can think of: non-rendered segments of the template can't contribute inline partials. I don't know if that's a bug or a feature. It kinda makes sense, but then the partial hangs around if the element is unrendered, which seems a little wrong. So, I could go either way on how to handle that:~~

1. ~~Read through the whole template when it is loaded and pull in any partials that don't exist down a component tree. This is roughly the same as the previous behavior.~~
2. ~~When the element is torn down, reset any partials that it contributed at init back to what they were if they haven't been updated in the interim. For partials unique to the element, this would remove them, and for partials that override, the overridden partial would be restored.~~

~~I'm leaning toward option 2 at the moment. It seems to track better with part 2 of this.~~

After discussion, it seems that just leaving partials attached to their elements and looking for partials up the fragment hierarchy is a more consistent approach.

### Part 2

Per @martypdx's suggestion, this also lets `getPartialTemplate` look up the element hierarchy for a partial before checking the usual places. This is pretty neat for doing partial overrides outside of components.

~~Something to consider here is how this should interact with `resetPartial`. Should all instances get touched, or should partials that were originally rendered from inlines end up with their inline again, or something else?~~

The current behavior is, upon reset, partials with inline overrides reset to their nearest inline. That seems to be most consistent with inline partials as full-fledged members of a template. Inline partials at root levels can still be reset, as they are treated as normal partials.