### PR TITLE
fix #1860 - ensure `parse` is declared

### DIFF
--- a/gobblefile.js
+++ b/gobblefile.js
@@ -30,18 +30,16 @@ lib = (function () {
 		.replace( '${time}', new Date() )
 		.replace( '${commitHash}', process.env.COMMIT_HASH || 'unknown' );
 
-	var bundleTransform = function ( src, path ) {
-		if ( /(Ractive\.js|utils\/log\.js)$/.test( path ) ) {
-			return src.replace( /<@version@>/g, version );
-		}
-
-		return src;
-	};
-
 	var lib = [
 		es5.transform( 'esperanto-bundle', {
 			type: 'umd',
-			transform: bundleTransform,
+			transform: function ( src, path ) {
+				if ( /(Ractive\.js|utils\/log\.js)$/.test( path ) ) {
+					return src.replace( /<@version@>/g, version );
+				}
+
+				return src;
+			},
 			banner: banner,
 			entry: 'Ractive.js',
 			name: 'Ractive',
@@ -54,32 +52,59 @@ lib = (function () {
 		lib.push(
 			es5.transform( 'esperanto-bundle', {
 				type: 'umd',
-				transform: bundleTransform,
+				transform: function ( src, path ) {
+					if ( /(Ractive\.js|utils\/log\.js)$/.test( path ) ) {
+						return src.replace( /<@version@>/g, version );
+					}
+
+					if ( /legacy\.js/.test( path ) ) {
+						return 'export default null;';
+					}
+
+					return src;
+				},
 				banner: banner,
 				entry: 'Ractive.js',
 				name: 'Ractive',
-				dest: 'ractive.js',
-				skip: [ 'legacy' ]
+				dest: 'ractive.js'
 			}),
 
 			es5.transform( 'esperanto-bundle', {
 				type: 'umd',
-				transform: bundleTransform,
+				transform: function ( src, path ) {
+					if ( /(Ractive\.js|utils\/log\.js)$/.test( path ) ) {
+						return src.replace( /<@version@>/g, version );
+					}
+
+					if ( /legacy\.js|_parse\.js/.test( path ) ) {
+						return 'export default null;';
+					}
+
+					return src;
+				},
 				banner: banner,
 				entry: 'Ractive.js',
 				name: 'Ractive',
-				dest: 'ractive.runtime.js',
-				skip: [ 'legacy', 'parse/_parse' ]
+				dest: 'ractive.runtime.js'
 			}),
 
 			es5.transform( 'esperanto-bundle', {
 				type: 'umd',
-				transform: bundleTransform,
+				transform: function ( src, path ) {
+					if ( /(Ractive\.js|utils\/log\.js)$/.test( path ) ) {
+						return src.replace( /<@version@>/g, version );
+					}
+
+					if ( /_parse\.js/.test( path ) ) {
+						return 'export default null;';
+					}
+
+					return src;
+				},
 				banner: banner,
 				entry: 'Ractive.js',
 				name: 'Ractive',
-				dest: 'ractive-legacy.runtime.js',
-				skip: [ 'parse/_parse' ]
+				dest: 'ractive-legacy.runtime.js'
 			})
 		);
 	}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ractive",
   "description": "Next-generation DOM manipulation",
-  "version": "0.7.1",
+  "version": "0.7.2-edge",
   "homepage": "http://ractivejs.org",
   "main": "build/ractive.js",
   "keywords": [

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,5 +9,8 @@ MOD='node_modules/.bin'
 echo "> running node.js-specific tests. working directory is $PWD"
 $MOD/mocha ./tmp/test/__nodetests/index.js --reporter progress
 
+# check ractive.runtime doesn't error (#1860)
+node tmp/ractive.runtime.js
+
 # run browser tests
 $MOD/phantomjs scripts/phantom-runner.js


### PR DESCRIPTION
This is a stopgap measure of sorts - esperanto needs a better API for overriding module contents (see https://github.com/esperantojs/esperanto/pull/141), and ultimately it'd be nice to have far more flexible custom builds, of which legacy/runtime are just two of many possible combinations.

But it fixes the regression introduced in 0.7.1 and means that people can continue to use `ractive.runtime.js`.