### PR TITLE
Use hasOwnProperty, prevent log from undefined error

### DIFF
--- a/src/Ractive/config/config.js
+++ b/src/Ractive/config/config.js
@@ -52,7 +52,7 @@ function configure ( method, Parent, target, options ) {
 	deprecate( options );
 
 	for ( let key in options ) {
-		if ( isStandardKey[ key ] ) {
+		if ( isStandardKey.hasOwnProperty( key ) ) {
 			let value = options[ key ];
 
 			// warn the developer if they passed a function and ignore its value

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -49,7 +49,7 @@ Found a bug? Raise an issue:
 		// extract information about the instance this message pertains to, if applicable
 		if ( typeof args[ args.length - 1 ] === 'object' ) {
 			let options = args.pop();
-			let ractive = options && options.ractive;
+			let ractive = options ? options.ractive : null;
 
 			if ( ractive ) {
 				// if this is an instance of a component that we know the name of, add

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -49,7 +49,7 @@ Found a bug? Raise an issue:
 		// extract information about the instance this message pertains to, if applicable
 		if ( typeof args[ args.length - 1 ] === 'object' ) {
 			let options = args.pop();
-			let ractive = options.ractive;
+			let ractive = options && options.ractive;
 
 			if ( ractive ) {
 				// if this is an instance of a component that we know the name of, add


### PR DESCRIPTION
Couple of issues that came up with #1885:

1. isStandardKey was returning true for object prototype props like `constructor`.
2. if `log` `options` was undefined, `options.ractive` was failing.