### PR TITLE
Debug message fun!

### DIFF
--- a/src/Ractive/config/custom/data.js
+++ b/src/Ractive/config/custom/data.js
@@ -27,19 +27,18 @@ var dataConfigurator = {
 
 				if ( value && typeof value === 'object' ) {
 					if ( isObject( value ) || isArray( value ) ) {
+						let dataString = JSON.stringify( options.data, null, 2 ).split( '\n' );
+						let example1 = dataString.map( ( line, i ) => { return i > 0 ? '    ' + line : line; } ).join('\n');
+						let example2 = dataString.map( ( line, i ) => { return i > 0 ? '  ' + line : line; } ).join('\n');
 						warnIfDebug( `Passing a \`data\` option with object and array properties to Ractive.extend() is discouraged, as mutating them is likely to cause bugs. Consider using a data function instead:
 
   // this...
   data: function () {
-    return {
-      myObject: {}
-    };
+    return ${example1};
   })
 
   // instead of this:
-  data: {
-    myObject: {}
-  }` );
+  data: ${example2}` );
 					}
 				}
 			}


### PR DESCRIPTION
**not ready for merge**

I'm creating this as a dumping ground for improved debugging messages including, but not limited to the suggestions provided in https://github.com/ractivejs/ractive/issues/1911. I'll be updating the branch whenever I get the gumption, but anyone else is welcome to commit improvements as well.
- [ ] Improved deprecated partial warning (from #1911)
- [x] Non-primitives on component definitions (I checked it off even though I'm not super happy at how hackish it feels to get the spacing to look right. I'll clean it up at some point.) (from #1911)
- [ ] Improved missing decorator warning (from #1911)
- [ ] Remove/Update missing animation warning (from #1755)
- [x] Ambiguous keypath warning throws an error in chrome (from #1962)
- [ ] Improve spec violation warning in templates (from #1974)
- [x] Throw error from `find` and `findAll` if the instance is unrendered (from #2008)
- [ ] Throw warning on attempted two-way binding with triple mustaches (from #2033)
