### PR TITLE
Gh 2003 components

### DIFF
--- a/src/Ractive/prototype/off.js
+++ b/src/Ractive/prototype/off.js
@@ -1,7 +1,7 @@
 import trim from './shared/trim';
 import notEmptyString from './shared/notEmptyString';
 
-export default function Ractive$off ( eventName, callback ) {
+export default function Ractive$off ( eventName, callback, options = {}  ) {
 	var eventNames;
 
 	// if no arguments specified, remove all callbacks
@@ -20,21 +20,25 @@ export default function Ractive$off ( eventName, callback ) {
 		eventNames = eventName.split( ' ' ).map( trim ).filter( notEmptyString );
 
 		eventNames.forEach( eventName => {
-			var subscribers, index;
+			if ( options.target ) {
+				options.target.removeEventListener( eventName, callback, false );
+			} else {
+				let subscribers, index;
 
-			// If we have subscribers for this event...
-			if ( subscribers = this._subs[ eventName ] ) {
-				// ...if a callback was specified, only remove that
-				if ( callback ) {
-					index = subscribers.indexOf( callback );
-					if ( index !== -1 ) {
-						subscribers.splice( index, 1 );
+				// If we have subscribers for this event...
+				if ( subscribers = this._subs[ eventName ] ) {
+					// ...if a callback was specified, only remove that
+					if ( callback ) {
+						index = subscribers.indexOf( callback );
+						if ( index !== -1 ) {
+							subscribers.splice( index, 1 );
+						}
 					}
-				}
 
-				// ...otherwise remove all callbacks
-				else {
-					this._subs[ eventName ] = [];
+					// ...otherwise remove all callbacks
+					else {
+						this._subs[ eventName ] = [];
+					}
 				}
 			}
 		});

--- a/src/Ractive/prototype/on.js
+++ b/src/Ractive/prototype/on.js
@@ -1,7 +1,7 @@
 import trim from './shared/trim';
 import notEmptyString from './shared/notEmptyString';
 
-export default function Ractive$on ( eventName, callback ) {
+export default function Ractive$on ( eventName, callback, options = {} ) {
 	var listeners, n, eventNames;
 
 	// allow mutliple listeners to be bound in one go
@@ -10,7 +10,7 @@ export default function Ractive$on ( eventName, callback ) {
 
 		for ( n in eventName ) {
 			if ( eventName.hasOwnProperty( n ) ) {
-				listeners.push( this.on( n, eventName[ n ] ) );
+				listeners.push( this.on( n, eventName[ n ], options ) );
 			}
 		}
 
@@ -29,10 +29,16 @@ export default function Ractive$on ( eventName, callback ) {
 	eventNames = eventName.split( ' ' ).map( trim ).filter( notEmptyString );
 
 	eventNames.forEach( eventName => {
-		( this._subs[ eventName ] || ( this._subs[ eventName ] = [] ) ).push( callback );
+		if ( options.target ) {
+			options.target.addEventListener( eventName, callback, false );
+
+			this.on( 'teardown', () => this.off( eventName, callback, options ) );
+		} else {
+			( this._subs[ eventName ] || ( this._subs[ eventName ] = [] ) ).push( callback );
+		}
 	});
 
 	return {
-		cancel: () => this.off( eventName, callback )
+		cancel: () => this.off( eventName, callback, options )
 	};
 }

--- a/src/virtualdom/items/Component/prototype/init.js
+++ b/src/virtualdom/items/Component/prototype/init.js
@@ -25,6 +25,8 @@ export default function Component$init ( options, Component ) {
 	createInstance( this, Component, options.template.a, options.template.f, options.template.p );
 	propagateEvents( this, options.template.v );
 
+	this.instance.getBoundEvents = () => Object.keys(options.template.v);
+
 	// intro, outro and decorator directives have no effect
 	if ( options.template.t0 || options.template.t1 || options.template.t2 || options.template.o ) {
 		warnIfDebug( 'The "intro", "outro" and "decorator" directives have no effect on components', { ractive: this.instance });


### PR DESCRIPTION
**not ready for merge**

Following my [comment](https://github.com/ractivejs/ractive/issues/2003#issuecomment-113917276) in #2003, this is more of a PoC than anything.

It (1) adds a method `getBoundEvents()` to inline components, which returns an array of events listened to by the parent component and (2) allows you to pass a third argument (`options`) to `Ractive#on()`. If `options.target` is set, Ractive will add an event listener to that target, and automatically remove it on teardown. This might be implemented in many other ways, or not at all (as it can be handled directly by the component).

Demo with `window` component:

```js
var ractive = new Ractive({
    ...
    template: '<window on-resize="resize" />',
    oninit: function () {
        this.on('resize', function (event) {
            console.log('resize', event);
        });
    },
    components: {
        window: Ractive.extend({
            oninit: function () {
                this.getBoundEvents().forEach(function (event) {
                    this.on(event, function () {
                        this.fire.apply(this, arguments);
                    }.bind(this, event), { target: window });
                }, this);
            }
        })
    }
});
```