### PR TITLE
Add support for custom inheritable extendable static members

### DIFF
--- a/src/Ractive/config/config.js
+++ b/src/Ractive/config/config.js
@@ -3,6 +3,7 @@ import adaptConfigurator from './custom/adapt';
 import cssConfigurator from './custom/css/css';
 import dataConfigurator from './custom/data';
 import templateConfigurator from './custom/template/template';
+import staticMembersConfigurator from './custom/staticMembers';
 import defaults from './defaults';
 import registries from './registries';
 import wrapPrototype from './wrapPrototypeMethod';
@@ -14,7 +15,8 @@ custom = {
 	adapt: adaptConfigurator,
 	css: cssConfigurator,
 	data: dataConfigurator,
-	template: templateConfigurator
+	template: templateConfigurator,
+	staticMembers: staticMembersConfigurator
 };
 
 defaultKeys = Object.keys( defaults );
@@ -29,7 +31,8 @@ order = [].concat(
 	registries,
 	custom.data,
 	custom.template,
-	custom.css
+	custom.css,
+	custom.staticMembers
 );
 
 config = {
@@ -77,6 +80,7 @@ function configure ( method, Parent, target, options ) {
 	adaptConfigurator[ method ]( Parent, target, options );
 	templateConfigurator[ method ]( Parent, target, options );
 	cssConfigurator[ method ]( Parent, target, options );
+	staticMembersConfigurator[ method ]( Parent, target, options );
 
 	extendOtherMethods( Parent.prototype, target, options );
 }

--- a/src/Ractive/config/custom/staticMembers.js
+++ b/src/Ractive/config/custom/staticMembers.js
@@ -1,0 +1,35 @@
+import { mapKeys, mapValues, filter, extend } from 'utils/object';
+import registries from '../registries';
+import wrapMethod from 'utils/wrapMethod';
+
+const isRegistry = mapValues(mapKeys(registries, registry => registry.name), () => true);
+
+var staticMembersConfigurator = {
+
+    extend: ( Parent, proto, options ) => {
+
+        var Child = proto.constructor,
+
+        // Note: registry names are [currently] the only other enumerable static members of `Component`s,
+        // though those are [currently] not consistent with that of `Ractive`. Should we fix that?
+            parentMembers = Parent._Parent
+                ? filter( Parent, ( value, key ) => !( key in isRegistry ) )
+                : { extend: Parent.extend },
+
+            newMembers = mapValues( options.staticMembers || {}, ( value, name ) => {
+                if ( name in isRegistry ){ throw new Error( '"' + name + '" is a reserved static member name' ); }
+                if ( (typeof value == 'function') && ( name in parentMembers ) ) {
+                    var parentMember = parentMembers[ name ];
+                    value = wrapMethod( value, typeof parentMember == 'function' ? parentMember : () => parentMember );
+                }
+                return value;
+            });
+
+        extend(Child, parentMembers, newMembers);
+
+    },
+
+    init () {}
+};
+
+export default staticMembersConfigurator;

--- a/src/extend/_extend.js
+++ b/src/extend/_extend.js
@@ -41,9 +41,6 @@ function extendOne ( Parent, options = {} ) {
 		// alias prototype as defaults
 		defaults: { value: proto },
 
-		// extendable
-		extend: { value: extend, writable: true, configurable: true },
-
 		// Parent - for IE8, can't use Object.getPrototypeOf
 		_Parent: { value: Parent }
 	});

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -101,4 +101,35 @@ export function fillGaps ( target, ...sources ) {
 	return target;
 }
 
+export function mapKeys ( object , iterator ) {
+	var result = {};
+	for (let key in object){
+		if ( object.hasOwnProperty( key ) ) {
+			let value = object[ key ];
+			result[ iterator( value , key, object ) ] = value;
+		}
+	}
+	return result;
+}
+
+export function mapValues ( object , iterator ) {
+	var result = {};
+	for (let key in object){
+		if ( object.hasOwnProperty( key ) ) {
+			result[ key ] = iterator( object[ key ] , key, object );
+		}
+	}
+	return result;
+}
+
+export function filter ( object, iterator ) {
+	var result = { };
+	for (let key in object){
+		if ( object.hasOwnProperty( key ) && iterator ( object[ key ], key, object ) ) {
+			result[ key ] = object[ key ];
+		}
+	}
+	return result;
+}
+
 export var hasOwn = Object.prototype.hasOwnProperty;

--- a/test/__tests/components.js
+++ b/test/__tests/components.js
@@ -896,3 +896,29 @@ test( 'Unresolved keypath can be safely torn down', t => {
 	ractive.set('show', false);
 
 });
+
+test( 'support for custom inheritable extendable *static* members', function (t) {
+	var Child = Ractive
+		.extend( { staticMembers: { foo () { return 'a'; }, bar: 'c' } } )
+		.extend( { staticMembers: { foo () { return this._super() + 'b'; } } } )
+		.extend( { staticMembers: { bar () { return this._super() + 'd'; } } } );
+	t.equal( Child.foo(), 'ab' );
+	t.equal( Child.bar(), 'cd' );
+} );
+
+test( 'extending the extend method (meta-extending)', function( t ) {
+	var Child = Ractive
+		.extend( {
+			foo: 'bar',
+			staticMembers: {
+				extend: function ( ...options ) {
+					// delete any option named "foo", effectively making "foo" read-only
+					options.forEach( options => { delete options.foo; });
+					// return this._super( ...options ); // ***why doesnt this work?
+					return this._super.apply(this, options);
+				}
+			}
+		} )
+		.extend( { foo: false } );
+	t.equal( Child.prototype.foo, 'bar' );
+} );


### PR DESCRIPTION
Also, the static `extend` method should be included in this and itself be user-extendable. This would allow child classes (i.e. components) to take a greater control of how options for further descendant child classes are handled, so that more functionality can be encapsulated in abstract base classes.

My latest project, [ractive-isomorphic](https://github.com/zenflow/ractive-isomorphic), depends on this feature, so if you're interested in practical use-cases, check it out!
