### PR TITLE
Fix event expression Function scope when called

### DIFF
--- a/src/virtualdom/items/Element/EventHandler/prototype/init.js
+++ b/src/virtualdom/items/Element/EventHandler/prototype/init.js
@@ -112,7 +112,7 @@ function fireMethodCall ( event ) {
 			value = ractive.viewmodel.get( keypath );
 		}
 
-        if( typeof value == 'function' ) {
+        if( typeof value === 'function' ) {
             value = value.bind( ractive );
         }
 

--- a/src/virtualdom/items/Element/EventHandler/prototype/init.js
+++ b/src/virtualdom/items/Element/EventHandler/prototype/init.js
@@ -112,6 +112,10 @@ function fireMethodCall ( event ) {
 			value = ractive.viewmodel.get( keypath );
 		}
 
+        if( typeof value == 'function' ) {
+            value = value.bind( ractive );
+        }
+
 		return value;
 	});
 


### PR DESCRIPTION
A la https://github.com/ractivejs/ractive/issues/2019

Just adds a simple check to see if the item is a function and if so, binds it to the instance.