### PR TITLE
add support for custom element typeExtensions

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -4,20 +4,29 @@ var createElement, matches, div, methodNames, unprefixed, prefixed, i, j, makeFu
 
 // Test for SVG support
 if ( !svg ) {
-	createElement = function ( type, ns ) {
+	createElement = function ( type, ns, extend ) {
 		if ( ns && ns !== namespaces.html ) {
 			throw 'This browser does not support namespaces other than http://www.w3.org/1999/xhtml. The most likely cause of this error is that you\'re trying to render SVG in an older browser. See http://docs.ractivejs.org/latest/svg-and-older-browsers for more information';
 		}
 
-		return document.createElement( type );
+		if ( extend )
+			return document.createElement( type, extend );
+		else
+			return document.createElement( type );
 	};
 } else {
-	createElement = function ( type, ns ) {
+	createElement = function ( type, ns, extend ) {
 		if ( !ns || ns === namespaces.html ) {
-			return document.createElement( type );
+			if ( extend )
+				return document.createElement( type, extend );
+			else
+				return document.createElement( type );
 		}
 
-		return document.createElementNS( ns, type );
+		if ( extend )
+			return document.createElementNS( ns, type, extend );
+		else
+			return document.createElementNS( ns, type );
 	};
 }
 

--- a/src/virtualdom/items/Element/prototype/render.js
+++ b/src/virtualdom/items/Element/prototype/render.js
@@ -44,10 +44,11 @@ updateScript = function () {
 };
 
 export default function Element$render () {
-	var root = this.root, namespace, node, transition;
+	var root = this.root, namespace, extend, node, transition;
 
 	namespace = getNamespace( this );
-	node = this.node = createElement( this.name, namespace );
+	extend = this.getAttribute( 'is' );
+	node = this.node = createElement( this.name, namespace, extend );
 
 	// Is this a top-level node of a component? If so, we may need to add
 	// a data-ractive-css attribute, for CSS encapsulation

--- a/test/__tests/elements.js
+++ b/test/__tests/elements.js
@@ -102,3 +102,21 @@ if ( 'draggable' in document.createElement( 'div' ) ) {
 		t.equal( divs[6].draggable, false );
 	});
 }
+
+if ( 'registerElement' in document ) {
+	test( '"is" attribute is handled correctly for custom elements (#2043)', t => {
+		let XFoo = document.registerElement('x-foo', {
+			prototype: Object.create(HTMLParagraphElement.prototype, {
+				testMember: { value: true }
+			}),
+			extends: 'p'
+		});
+		let ractive = new Ractive({
+			el: fixture,
+			template: '<p is="x-foo"></p>'
+		});
+
+		let p = ractive.find( 'p' );
+		t.ok( 'testMember' in p );
+	});
+}


### PR DESCRIPTION
In reference to https://github.com/ractivejs/ractive/issues/2043

This code change assumes the user will put a static string value for the "is" attribute. I don't think it makes sense to allow dynamic mustaches for "is", since the whole node would need to be deleted and a new node created with the different typeExtension. Maybe Attribute$init() could just print an error and treat a dynamic mustache as a static mustache to avoid that complication.

Note: this (https://github.com/ractivejs/ractive/blob/master/CONTRIBUTING.md#pull-requests) says to run `grunt test`, but when I try that I get "Fatal error: Unable to find Gruntfile."