### PR TITLE
Fix bugs with unless sections and undefined models

### DIFF
--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -76,6 +76,12 @@ export default class Section extends Mustache {
 
 			this.fragment = fragment;
 		}
+		else if (this.sectionType && this.sectionType === SECTION_UNLESS) {
+			this.fragment = new Fragment({
+				owner: this,
+				template: this.template.f
+			}).bind();
+		}
 	}
 
 	detach () {

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -84,6 +84,8 @@ export default class ExpressionProxy extends Model {
 		const signature = {
 			getter: () => {
 				const values = this.models.map( model => {
+					if (!model) return undefined;
+					
 					const value = model.get( true );
 
 					if ( typeof value === 'function' ) {

--- a/test/testdeps/samples/render.js
+++ b/test/testdeps/samples/render.js
@@ -797,6 +797,12 @@ var renderTests = [
 		result: '<div class="falsey"></div>'
 	},
 	{
+		name: '#if/else (multiple) for a class attribute inside an array',
+		template: '{{#items}}<div class="{{#if value}}value{{elseif value2}}value2{{else}}falsey{{/if}}"></div>{{/items}}',
+		data: {items: [1]},
+		result: '<div class="falsey"></div>'
+	},
+	{
 		name: 'Restricting references with `this`',
 		template: '{{#foo}}{{this.bar}}{{/foo}}',
 		data: { foo: {}, bar: 'fail' },

--- a/test/testdeps/samples/render.js
+++ b/test/testdeps/samples/render.js
@@ -791,6 +791,12 @@ var renderTests = [
 		result: 'no'
 	},
 	{
+		name: '#if/else for a class attribute inside an array',
+		template: '{{#items}}<div class="{{#if value}}truthy{{else}}falsey{{/if}}"></div>{{/items}}',
+		data: {items: [1]},
+		result: '<div class="falsey"></div>'
+	},
+	{
 		name: 'Restricting references with `this`',
 		template: '{{#foo}}{{this.bar}}{{/foo}}',
 		data: { foo: {}, bar: 'fail' },


### PR DESCRIPTION
I've fixed a couple of bugs where an undefined unless block won't work. And an undefined model would throw a script error.