### PR TITLE
Fix namespaced attributes, like xlink:href

### DIFF
--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -2,6 +2,7 @@ import { INTERPOLATOR } from '../../../config/types';
 import { html } from '../../../config/namespaces';
 import Fragment from '../../Fragment';
 import Item from '../shared/Item';
+import determineNameAndNamespace from './attribute/determineNameAndNamespace';
 import getUpdateDelegate from './attribute/getUpdateDelegate';
 import propertyNames from './attribute/propertyNames';
 import { isArray } from '../../../utils/is';
@@ -12,7 +13,8 @@ export default class Attribute extends Item {
 	constructor ( options ) {
 		super( options );
 
-		this.name = options.name;
+		determineNameAndNamespace( this, options.name );
+
 		this.element = options.element;
 		this.parentFragment = options.element.parentFragment; // shared
 		this.ractive = this.parentFragment.ractive;

--- a/src/view/items/element/attribute/determineNameAndNamespace.js
+++ b/src/view/items/element/attribute/determineNameAndNamespace.js
@@ -1,0 +1,31 @@
+import * as namespaces from '../../../../config/namespaces';
+
+export default function ( attribute, name ) {
+	var colonIndex, namespacePrefix;
+
+	// are we dealing with a namespaced attribute, e.g. xlink:href?
+	colonIndex = name.indexOf( ':' );
+	if ( colonIndex !== -1 ) {
+
+		// looks like we are, yes...
+		namespacePrefix = name.substr( 0, colonIndex );
+
+		// ...unless it's a namespace *declaration*, which we ignore (on the assumption
+		// that only valid namespaces will be used)
+		if ( namespacePrefix !== 'xmlns' ) {
+			name = name.substring( colonIndex + 1 );
+
+			attribute.name = name;
+			attribute.namespace = namespaces[ namespacePrefix.toLowerCase() ];
+			attribute.namespacePrefix = namespacePrefix;
+
+			if ( !attribute.namespace ) {
+				throw 'Unknown namespace ("' + namespacePrefix + '")';
+			}
+
+			return;
+		}
+	}
+
+	attribute.name = name;
+}

--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -5,7 +5,7 @@ import { isArray } from '../../../../utils/is';
 import noop from '../../../../utils/noop';
 
 export default function getUpdateDelegate ( attribute ) {
-	const { element, name } = attribute;
+	const { element, name, namespace } = attribute;
 
 	if ( name === 'id' ) return updateId;
 
@@ -49,6 +49,8 @@ export default function getUpdateDelegate ( attribute ) {
 	if ( name === 'class' && ( !node.namespaceURI || node.namespaceURI === html ) ) return updateClassName;
 
 	if ( attribute.useProperty ) return updateProperty;
+
+	if ( attribute.namespace ) return updateNamespacedAttribute;
 
 	return updateAttribute;
 }
@@ -187,4 +189,8 @@ function updateProperty () {
 
 function updateAttribute () {
 	this.node.setAttribute( this.name, safeToStringValue( this.getString() ) );
+}
+
+function updateNamespacedAttribute () {
+	this.node.setAttributeNS( this.namespace, this.name, safeToStringValue( this.getString() ) );
 }

--- a/test/__tests/render.js
+++ b/test/__tests/render.js
@@ -274,6 +274,16 @@ test( 'Sections survive unrender-render (#1553)', t => {
 	t.htmlEqual( fixture.innerHTML, '<p>1</p><p>2</p><p>3</p>' );
 });
 
+test( 'Namespaced attributes are set correctly', t => {
+	var ractive = new Ractive({
+		template: '<svg><use xlink:href="#yup" /></svg>'
+	});
+
+	ractive.render( fixture );
+
+	t.equal(ractive.find('use').getAttributeNS('http://www.w3.org/1999/xlink', 'href'), '#yup');
+});
+
 if ( typeof Object.create === 'function' ) {
 	test( 'data of type Object.create(null) (#1825)', t => {
 		var ractive, expected;


### PR DESCRIPTION
This somehow got dropped with all the recent refactoring.

I stole the `determineNameAndNamespace` function directly from the 0.7.3 release.