### PR TITLE
Component events as first-class citizens

### DIFF
--- a/src/events/fireEvent.js
+++ b/src/events/fireEvent.js
@@ -51,7 +51,7 @@ function fireEventAs  ( ractive, eventNames, event, args, initialFire = false ) 
 			let fullName = ractive.component.name + '.' + eventNames[ eventNames.length-1 ];
 			eventNames = getWildcardNames( fullName );
 
-			if( event ) {
+			if( event && !event.component ) {
 				event.component = ractive;
 			}
 		}

--- a/src/parse/converters/element/processDirective.js
+++ b/src/parse/converters/element/processDirective.js
@@ -33,10 +33,18 @@ export default function processDirective ( tokens, parentParser ) {
 			}
 
 			result = { m: match[1] };
-			args = '[' + tokens.slice( result.m.length + 1, end ) + ']';
+			const sliced = tokens.slice( result.m.length + 1, end )
 
-			parser = new ExpressionParser( args );
-			result.a = flattenExpression( parser.result[0] );
+			if ( sliced === '...arguments' ) {
+				// TODO: what the heck should this be???
+				// maybe ExpressionParser should understand ES6???
+				result.g = true;
+			}
+			else {
+				args = '[' + sliced.replace( /arguments/g, '__args' ) + ']';
+				parser = new ExpressionParser( args );
+				result.a = flattenExpression( parser.result[0] );
+			}
 
 			return result;
 		}

--- a/src/parse/converters/element/processDirective.js
+++ b/src/parse/converters/element/processDirective.js
@@ -41,7 +41,7 @@ export default function processDirective ( tokens, parentParser ) {
 				result.g = true;
 			}
 			else {
-				args = '[' + sliced.replace( /arguments/g, '__args' ) + ']';
+				args = '[' + sliced + ']';
 				parser = new ExpressionParser( args );
 				result.a = flattenExpression( parser.result[0] );
 			}

--- a/src/shared/createFunction.js
+++ b/src/shared/createFunction.js
@@ -1,9 +1,10 @@
 let functionCache = {};
 
-export default function createFunction ( str, i ) {
+export default function createFunction ( str, i, additional ) {
 	if ( functionCache[ str ] ) return functionCache[ str ];
 
-	let args = new Array( i );
+	let args = new Array( i - 1 );
+	if ( additional ) args[ i ] = additional;
 	while ( i-- ) args[i] = `_${i}`;
 
 	const fn = new Function( args.join( ',' ), `return (${str})` );

--- a/src/shared/createFunction.js
+++ b/src/shared/createFunction.js
@@ -3,7 +3,7 @@ let functionCache = {};
 export default function createFunction ( str, i, additional ) {
 	if ( functionCache[ str ] ) return functionCache[ str ];
 
-	let args = new Array( i - 1 );
+	let args = new Array( i );
 	if ( additional ) args[ i ] = additional;
 	while ( i-- ) args[i] = `_${i}`;
 

--- a/src/shared/createFunction.js
+++ b/src/shared/createFunction.js
@@ -1,10 +1,9 @@
 let functionCache = {};
 
-export default function createFunction ( str, i, additional ) {
+export default function createFunction ( str, i ) {
 	if ( functionCache[ str ] ) return functionCache[ str ];
 
 	let args = new Array( i );
-	if ( additional ) args[ i ] = additional;
 	while ( i-- ) args[i] = `_${i}`;
 
 	const fn = new Function( args.join( ',' ), `return (${str})` );

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -46,7 +46,6 @@ export default class Component extends Item {
 		this.name = options.template.e;
 		this.parentFragment = options.parentFragment;
 		this.complexMappings = [];
-		this.eventHandlers = null;
 
 		this.liveQueries = [];
 

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -13,7 +13,7 @@ import { bind, cancel, rebind, render as callRender, unbind, unrender, update } 
 import Hook from '../../events/Hook';
 import Fragment from '../Fragment';
 import parseJSON from '../../utils/parseJSON';
-import EventHandler from './shared/EventHandler';
+import EventDirective from './shared/EventDirective';
 import RactiveEvent from './component/RactiveEvent';
 import fireEvent from '../../events/fireEvent';
 import updateLiveQueries from './component/updateLiveQueries';
@@ -257,7 +257,7 @@ export default class Component extends Item {
 
 			eventNames.forEach( eventName => {
 				const event = new RactiveEvent( this.instance, eventName );
-				handlers.push( new EventHandler( this, event, template ) );
+				handlers.push( new EventDirective( this, event, template ) );
 			});
 		});
 	}

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -5,7 +5,9 @@ import Fragment from '../Fragment';
 import Attribute from './element/Attribute';
 import ConditionalAttribute from './element/ConditionalAttribute';
 import Decorator from './element/Decorator';
-import EventHandler from './element/EventHandler';
+import EventHandler from './shared/EventHandler';
+import { findInViewHierarchy } from '../../shared/registry';
+import { DOMEvent, CustomEvent } from './element/ElementEvents';
 import Transition from './element/Transition';
 import updateLiveQueries from './element/updateLiveQueries';
 import { escapeHtml, voidElementNames } from '../../utils/html';
@@ -85,7 +87,11 @@ export default class Element extends Item {
 				const template = this.template.v[ key ];
 
 				eventNames.forEach( eventName => {
-					this.eventHandlers.push( new EventHandler( this, eventName, template ) );
+					const fn = findInViewHierarchy( 'events', this.ractive, eventName );
+					// we need to pass in "this" in order to get
+					// access to node when it is created.
+					const event = fn ? new CustomEvent( fn, this ) : new DOMEvent( eventName, this );
+					this.eventHandlers.push( new EventHandler( this, event, template ) );
 				});
 			});
 		}

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -82,6 +82,9 @@ export default class Element extends Item {
 		// attach event handlers
 		this.eventHandlers = [];
 		if ( this.template.v ) {
+
+			const handlers = this.eventHandlers = [];
+
 			Object.keys( this.template.v ).forEach( key => {
 				const eventNames = key.split( '-' );
 				const template = this.template.v[ key ];
@@ -91,7 +94,7 @@ export default class Element extends Item {
 					// we need to pass in "this" in order to get
 					// access to node when it is created.
 					const event = fn ? new CustomEvent( fn, this ) : new DOMEvent( eventName, this );
-					this.eventHandlers.push( new EventHandler( this, event, template ) );
+					handlers.push( new EventHandler( this, event, template ) );
 				});
 			});
 		}

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -5,7 +5,7 @@ import Fragment from '../Fragment';
 import Attribute from './element/Attribute';
 import ConditionalAttribute from './element/ConditionalAttribute';
 import Decorator from './element/Decorator';
-import EventHandler from './shared/EventHandler';
+import EventDirective from './shared/EventDirective';
 import { findInViewHierarchy } from '../../shared/registry';
 import { DOMEvent, CustomEvent } from './element/ElementEvents';
 import Transition from './element/Transition';
@@ -94,7 +94,7 @@ export default class Element extends Item {
 					// we need to pass in "this" in order to get
 					// access to node when it is created.
 					const event = fn ? new CustomEvent( fn, this ) : new DOMEvent( eventName, this );
-					handlers.push( new EventHandler( this, event, template ) );
+					handlers.push( new EventDirective( this, event, template ) );
 				});
 			});
 		}

--- a/src/view/items/component/RactiveEvent.js
+++ b/src/view/items/component/RactiveEvent.js
@@ -1,0 +1,32 @@
+export default class RactiveEvent {
+
+	constructor ( ractive, name ) {
+		this.ractive = ractive;
+		this.name = name;
+		this.handler = null;
+	}
+
+	listen ( directive ) {
+		const ractive = this.ractive;
+
+		this.handler = ractive.on( this.name, function () {
+			let event;
+
+			// semi-weak test, but what else? tag the event obj ._isEvent ?
+			if ( arguments.length && arguments[0] && arguments[0].node ) {
+				event = Array.prototype.shift.call( arguments );
+				event.component = ractive;
+			}
+
+			const args = Array.prototype.slice.call( arguments );
+			directive.fire( event, args );
+
+			// cancel bubbling
+			return false;
+		});
+	}
+
+	unlisten () {
+		this.handler.cancel();
+	}
+}

--- a/src/view/items/element/ElementEvents.js
+++ b/src/view/items/element/ElementEvents.js
@@ -1,0 +1,65 @@
+import { missingPlugin } from '../../../config/errors';
+import { fatal } from '../../../utils/log';
+
+function defaultHandler ( event ) {
+	const handler = this._ractive.events[ event.type ];
+
+	handler.fire({
+		node: this,
+		original: event
+	});
+}
+
+class DOMEvent {
+
+	constructor ( name, owner ) {
+
+		if ( name.indexOf( '*' ) !== -1 ) {
+			fatal( `Only component proxy-events may contain "*" wildcards, <${owner.name} on-${name}="..."/> is not valid` );
+		}
+
+		this.name = name;
+		this.owner = owner;
+		this.node = null;
+	}
+
+	listen ( directive ) {
+		const node = this.node = this.owner.node,
+			  name = this.name;
+
+		if ( !( `on${name}` in node ) ) {
+			missingPlugin( name, 'events' );
+		}
+
+		node._ractive.events[ name ] = directive;
+		node.addEventListener( name, defaultHandler, false );
+	}
+
+	unlisten () {
+		const node = this.node,
+			  name = this.name;
+
+		node.removeEventListener( name, defaultHandler, false );
+		node._ractive.events[ name ] = null;
+	}
+}
+
+class CustomEvent {
+
+	constructor ( eventPlugin, owner ) {
+		this.eventPlugin = eventPlugin;
+		this.owner = owner;
+		this.node = null;
+	}
+
+	listen ( directive ) {
+		const fire = event => directive.fire( event );
+		this.customHandler = this.eventPlugin( this.owner.node, fire );
+	}
+
+	unlisten () {
+		this.customHandler.teardown();
+	}
+}
+
+export { DOMEvent, CustomEvent };

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -88,7 +88,7 @@ export default class EventDirective {
 					return model;
 				});
 
-				this.argsFn = createFunction( template.a.s, template.a.r.length, '__args' );
+				this.argsFn = createFunction( template.a.s, template.a.r.length );
 			}
 
 		}

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -168,9 +168,6 @@ export default class EventDirective {
 					return model.get();
 				});
 
-				// TODO: include passedArgs interpolation
-				//if ( passedArgs ) args = args.concat( passedArgs );
-
 				args = this.argsFn.apply( null, values );
 			}
 

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -11,7 +11,7 @@ const eventPattern = /^event(?:\.(.+))?$/,
 	  dollarArgsPattern = /^\$(\d*)$/;
 
 
-export default class EventHandler {
+export default class EventDirective {
 	constructor ( owner, event, template ) {
 		this.owner = owner;
 		this.event = event;
@@ -198,7 +198,7 @@ export default class EventHandler {
 	}
 
 	rebind () {
-		throw new Error( 'EventHandler$rebind not yet implemented!' ); // TODO add tests
+		throw new Error( 'EventDirective$rebind not yet implemented!' ); // TODO add tests
 	}
 
 	render () {

--- a/test/__tests/events.js
+++ b/test/__tests/events.js
@@ -1073,7 +1073,9 @@ test( 'component "on-" with ...arguments', t => {
 	component.fire( 'bar', 'bar', 100 );
 });
 
-test( 'component "on-" with arguments[n]', t => {
+
+
+test( 'component "on-" with $n', t => {
 	var Component, component, ractive;
 
 	expect( 5 );
@@ -1084,7 +1086,7 @@ test( 'component "on-" with arguments[n]', t => {
 
 	ractive = new Ractive({
 		el: fixture,
-		template: '<component on-foo="foo(arguments[1], \'qux\', arguments[0])" on-bar="bar(arguments[0], 100)"/>',
+		template: '<component on-foo="foo($3, \'qux\', $1)" on-bar="bar($1, 100)"/>',
 		components: {
 			component: Component
 		},
@@ -1104,10 +1106,10 @@ test( 'component "on-" with arguments[n]', t => {
 	component.fire( 'bar', 'bar' );
 });
 
-test( 'component "on-" supply own arguments', t => {
+test( 'component "on-" supply own event proxy arguments', t => {
 	var Component, component, ractive;
 
-	expect( 6 );
+	expect( 4 );
 
 	Component = Ractive.extend({
 		template: '<span id="test" on-click="foo:\'foo\'">click me</span>'
@@ -1124,17 +1126,15 @@ test( 'component "on-" supply own arguments', t => {
 		}
 	});
 
-	ractive.on( 'foo-reproxy', ( e, num, word ) => {
-		t.equal( e.original.type, 'click' );
-		t.equal( num, 1 );
-		t.equal( word, 'foo' );
+	ractive.on( 'foo-reproxy', ( arg1, arg2 ) => {
+		t.equal( arg1.original.type, 'click' );
+		t.equal( arg2, 1 );
 	});
-	ractive.on( 'bar-reproxy', ( outter, inner ) => {
-		t.equal( outter, 'qux' );
-		t.equal( inner, 'bar' );
+	ractive.on( 'bar-reproxy', ( arg1 ) => {
+		t.equal( arg1, 'qux' );
 	});
-	ractive.on( 'bizz-reproxy', ( arg ) => {
-		t.equal( arg, 'buzz' );
+	ractive.on( 'bizz-reproxy', () => {
+		t.equal( arguments.length, 0 );
 	});
 
 	component = ractive.findComponent( 'component' );
@@ -1161,12 +1161,12 @@ test( 'component "on-" handles reproxy of arguments correctly', t => {
 		}
 	});
 
-	ractive.on( 'foo-reproxy', ( e, arg ) => {
+	ractive.on( 'foo-reproxy', ( e, ...args ) => {
 		t.equal( e.original.type, 'click' );
-		t.equal( arg, 'foo' );
+		t.equal( args.length, 0 );
 	});
-	ractive.on( 'bar-reproxy', ( arg ) => {
-		t.equal( arg, 'bar' );
+	ractive.on( 'bar-reproxy', () => {
+		t.equal( arguments.length, 0 );
 	});
 	ractive.on( 'bizz-reproxy', () => {
 		t.equal( arguments.length, 0 );

--- a/test/__tests/events.js
+++ b/test/__tests/events.js
@@ -1073,7 +1073,36 @@ test( 'component "on-" with ...arguments', t => {
 	component.fire( 'bar', 'bar', 100 );
 });
 
+test( 'component "on-" with arguments[n]', t => {
+	var Component, component, ractive;
 
+	expect( 5 );
+
+	Component = Ractive.extend({
+		template: '<span id="test" on-click="foo:\'foo\', 42">click me</span>'
+	});
+
+	ractive = new Ractive({
+		el: fixture,
+		template: '<component on-foo="foo(arguments[2], \'qux\', arguments[0])" on-bar="bar(arguments[0], 100)"/>',
+		components: {
+			component: Component
+		},
+		foo ( arg1, arg2, arg3 ) {
+			t.equal( arg1, 42 );
+			t.equal( arg2, 'qux' );
+			t.equal( arg3.original.type, 'click' );
+		},
+		bar ( arg1, arg2 ) {
+			t.equal( arg1, 'bar' );
+			t.equal( arg2, 100 );
+		}
+	});
+
+	component = ractive.findComponent( 'component' );
+	simulant.fire( component.nodes.test, 'click' );
+	component.fire( 'bar', 'bar' );
+});
 
 test( 'component "on-" with $n', t => {
 	var Component, component, ractive;

--- a/test/__tests/events.js
+++ b/test/__tests/events.js
@@ -1017,7 +1017,7 @@ module( 'Component events', setup )
 test( 'component "on-" can call methods', t => {
 	var Component, component, ractive;
 
-	expect( 3 );
+	expect( 2 );
 
 	Component = Ractive.extend({
 		template: '<span id="test" on-click="foo:\'foo\'">click me</span>'
@@ -1029,12 +1029,73 @@ test( 'component "on-" can call methods', t => {
 		components: {
 			component: Component
 		},
-		foo ( num, word ) {
+		foo ( num ) {
 			t.equal( num, 1 );
-			t.equal( word, 'foo' );
 		},
 		bar ( num ) {
 			t.equal( num, 2 );
+		}
+	});
+
+	component = ractive.findComponent( 'component' );
+	simulant.fire( component.nodes.test, 'click' );
+	component.fire( 'bar', 'bar' );
+});
+
+test( 'component "on-" with ...arguments', t => {
+	var Component, component, ractive;
+
+	expect( 5 );
+
+	Component = Ractive.extend({
+		template: '<span id="test" on-click="foo:\'foo\', 42">click me</span>'
+	});
+
+	ractive = new Ractive({
+		el: fixture,
+		template: '<component on-foo="foo(...arguments)" on-bar="bar(...arguments)"/>',
+		components: {
+			component: Component
+		},
+		foo ( e, arg1, arg2 ) {
+			t.equal( e.original.type, 'click' );
+			t.equal( arg1, 'foo' );
+			t.equal( arg2, 42 );
+		},
+		bar ( arg1, arg2 ) {
+			t.equal( arg1, 'bar' );
+			t.equal( arg2, 100 );
+		}
+	});
+
+	component = ractive.findComponent( 'component' );
+	simulant.fire( component.nodes.test, 'click' );
+	component.fire( 'bar', 'bar', 100 );
+});
+
+test( 'component "on-" with arguments[n]', t => {
+	var Component, component, ractive;
+
+	expect( 5 );
+
+	Component = Ractive.extend({
+		template: '<span id="test" on-click="foo:\'foo\', 42">click me</span>'
+	});
+
+	ractive = new Ractive({
+		el: fixture,
+		template: '<component on-foo="foo(arguments[1], \'qux\', arguments[0])" on-bar="bar(arguments[0], 100)"/>',
+		components: {
+			component: Component
+		},
+		foo ( arg1, arg2, arg3 ) {
+			t.equal( arg1, 42 );
+			t.equal( arg2, 'qux' );
+			t.equal( arg3.original.type, 'click' );
+		},
+		bar ( arg1, arg2 ) {
+			t.equal( arg1, 'bar' );
+			t.equal( arg2, 100 );
 		}
 	});
 


### PR DESCRIPTION
Refactored out the event source (`DOMEvent`, `CustomEvent`) from `EventHandler` and added a `RactiveEvent` used to proxy the component instance events.

This gives full event handling capability to component events including method calls.

Right now, original instance event args are tacked on after component event arg (but original `event` arg is still first if it exists). Need to implement argument repackaging per [#1172 comment](https://github.com/ractivejs/ractive/issues/1172/#issuecomment-136159638).