### PR TITLE
Prevent mappings leapfrogging local contexts

### DIFF
--- a/src/view/resolvers/resolveAmbiguousReference.js
+++ b/src/view/resolvers/resolveAmbiguousReference.js
@@ -7,19 +7,6 @@ export default function resolveAmbiguousReference ( fragment, ref ) {
 	const keys = ref.split( '.' );
 	const key = keys[0];
 
-	// TODO what if there are two component boundaries to cross - does this still work?
-	const base = localViewmodel.mappings.hasOwnProperty( key ) ?
-		localViewmodel.mappings[ key ] :
-		localViewmodel.computations.hasOwnProperty( key ) ?
-			localViewmodel.computations[ key ] :
-			null;
-
-	if ( base ) {
-		return keys.length > 1 ?
-			base.joinAll( keys.slice( 1 ) ) :
-			base;
-	}
-
 	let hasContextChain;
 	let crossedComponentBoundary;
 

--- a/test/__tests/components.js
+++ b/test/__tests/components.js
@@ -875,7 +875,6 @@ test( 'Component attributes with an empty string come back with an empty string'
 });
 
 test( 'Unresolved keypath can be safely torn down', t => {
-
 	expect(0);
 
 	var ractive = new Ractive({
@@ -891,5 +890,34 @@ test( 'Unresolved keypath can be safely torn down', t => {
 	});
 
 	ractive.set('show', false);
+});
 
+test( 'Mappings resolve correctly where references are shadowed (#2108)', assert => {
+	const names = [ 'alice', 'amy', 'andrew', 'bob', 'beatrice', 'brenda', 'charles', 'colin', 'camilla' ];
+
+	const Group = Ractive.extend({
+		template: `{{names.length}}`
+	});
+
+	const List = Ractive.extend({
+		template: `
+			{{#each groups}}
+				<Group names='{{names}}'/>
+			{{/each}}`,
+		data: () => ({
+			groups: [ 'a', 'b', 'c' ].map( letter => {
+				return { names: names.filter( name => name[0] === letter ) };
+			})
+		}),
+		components: { Group }
+	});
+
+	const ractive = new Ractive({
+		el: fixture,
+		template: `<List names='{{names}}'/>`,
+		data: { names },
+		components: { List }
+	});
+
+	assert.equal( fixture.innerHTML, '333' );
 });


### PR DESCRIPTION
Remarkably, simply deleting a few lines of code fixes #2108 without breaking any other tests