### PR TITLE
prevent babel generating iifes in hot code paths, etc

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -6,9 +6,10 @@ import resolveReference from '../../view/resolvers/resolveReference';
 
 export default function observe ( keypath, callback, options ) {
 	let observers = [];
+	let map;
 
 	if ( isObject( keypath ) ) {
-		const map = keypath;
+		map = keypath;
 		options = callback || {};
 
 		Object.keys( map ).forEach( keypath => {

--- a/src/Ractive/prototype/shared/add.js
+++ b/src/Ractive/prototype/shared/add.js
@@ -8,8 +8,10 @@ export default function add ( ractive, keypath, d ) {
 		throw new Error( 'Bad arguments' );
 	}
 
+	let changes;
+
 	if ( /\*/.test( keypath ) ) {
-		let changes = {};
+		changes = {};
 
 		ractive.viewmodel.findMatches( splitKeypath( keypath ) ).forEach( model => {
 			const value = model.get();

--- a/src/global/TransitionManager.js
+++ b/src/global/TransitionManager.js
@@ -51,7 +51,7 @@ export default class TransitionManager {
 	detachNodes () {
 		this.decoratorQueue.forEach( teardown );
 		this.detachQueue.forEach( detach );
-		this.children.forEach( detachNodes );
+		this.children.forEach( _detachNodes );
 	}
 
 	init () {
@@ -74,7 +74,7 @@ function detach ( element ) {
 	element.detach();
 }
 
-function detachNodes ( tm ) {
+function _detachNodes ( tm ) { // _ to avoid transpiler quirk
 	tm.detachNodes();
 }
 

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -55,9 +55,9 @@ export default class RepeatedFragment {
 		else if ( isObject( value ) ) {
 			// TODO this is a dreadful hack. There must be a neater way
 			if ( this.indexRef ) {
-				const [ keyRef, indexRef ] = this.indexRef.split( ',' );
-				this.keyRef = keyRef;
-				this.indexRef = indexRef;
+				const refs = this.indexRef.split( ',' );
+				this.keyRef = refs[0];
+				this.indexRef = refs[1];
 			}
 
 			this.indexByKey = {};
@@ -224,6 +224,7 @@ export default class RepeatedFragment {
 
 		let toRemove;
 		let oldKeys;
+		let i;
 
 		if ( isArray( value ) ) {
 			if ( this.iterations.length > value.length ) {
@@ -232,7 +233,7 @@ export default class RepeatedFragment {
 		} else if ( isObject( value ) ) {
 			toRemove = [];
 			oldKeys = {};
-			let i = this.iterations.length;
+			i = this.iterations.length;
 
 			while ( i-- ) {
 				const fragment = this.iterations[i];
@@ -265,13 +266,16 @@ export default class RepeatedFragment {
 				Object.keys( value ).length :
 				0;
 
+		let docFrag;
+		let fragment;
+
 		if ( newLength > this.iterations.length ) {
-			const docFrag = this.rendered ? createDocumentFragment() : null;
-			let i = this.iterations.length;
+			docFrag = this.rendered ? createDocumentFragment() : null;
+			i = this.iterations.length;
 
 			if ( isArray( value ) ) {
 				while ( i < value.length ) {
-					const fragment = this.createIteration( i, i );
+					fragment = this.createIteration( i, i );
 
 					this.iterations.push( fragment );
 					if ( this.rendered ) fragment.render( docFrag );
@@ -283,7 +287,7 @@ export default class RepeatedFragment {
 			else if ( isObject( value ) ) {
 				Object.keys( value ).forEach( key => {
 					if ( !( key in oldKeys ) ) {
-						const fragment = this.createIteration( key, i );
+						fragment = this.createIteration( key, i );
 
 						this.iterations.push( fragment );
 						if ( this.rendered ) fragment.render( docFrag );

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -96,6 +96,8 @@ export default class Component extends Item {
 		if ( this.template.a ) {
 			Object.keys( this.template.a ).forEach( localKey => {
 				const template = this.template.a[ localKey ];
+				let model;
+				let fragment;
 
 				if ( template === 0 ) {
 					// empty attributes are `true`
@@ -109,7 +111,7 @@ export default class Component extends Item {
 
 				else if ( isArray( template ) ) {
 					if ( template.length === 1 && template[0].t === INTERPOLATOR ) {
-						let model = resolve( this.parentFragment, template[0] );
+						model = resolve( this.parentFragment, template[0] );
 
 						if ( !model ) {
 							warnOnceIfDebug( `The ${localKey}='{{${template[0].r}}}' mapping is ambiguous, and may cause unexpected results. Consider initialising your data to eliminate the ambiguity`, { ractive: this.instance }); // TODO add docs page explaining this
@@ -125,12 +127,12 @@ export default class Component extends Item {
 					}
 
 					else {
-						const fragment = new Fragment({
+						fragment = new Fragment({
 							owner: this,
 							template
 						}).bind();
 
-						const model = viewmodel.joinKey( localKey );
+						model = viewmodel.joinKey( localKey );
 						model.set( fragment.valueOf() );
 
 						// this is a *bit* of a hack
@@ -214,11 +216,12 @@ export default class Component extends Item {
 		this.liveQueries.forEach( makeDirty );
 
 		// update relevant mappings
-		if ( this.template.a ) {
-			const viewmodel = this.instance.viewmodel;
+		const viewmodel = this.instance.viewmodel;
 
+		if ( this.template.a ) {
 			Object.keys( this.template.a ).forEach( localKey => {
 				const template = this.template.a[ localKey ];
+				let model;
 
 				if ( isArray( template ) && template.length === 1 && template[0].t === INTERPOLATOR ) {
 					let model = resolve( this.parentFragment, template[0] );
@@ -235,7 +238,7 @@ export default class Component extends Item {
 			});
 		}
 
-		this.instance.fragment.rebind( this.instance.viewmodel );
+		this.instance.fragment.rebind( viewmodel );
 	}
 
 	render ( target ) {

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -82,9 +82,6 @@ export default class Element extends Item {
 		// attach event handlers
 		this.eventHandlers = [];
 		if ( this.template.v ) {
-
-			const handlers = this.eventHandlers = [];
-
 			Object.keys( this.template.v ).forEach( key => {
 				const eventNames = key.split( '-' );
 				const template = this.template.v[ key ];
@@ -94,7 +91,7 @@ export default class Element extends Item {
 					// we need to pass in "this" in order to get
 					// access to node when it is created.
 					const event = fn ? new CustomEvent( fn, this ) : new DOMEvent( eventName, this );
-					handlers.push( new EventDirective( this, event, template ) );
+					this.eventHandlers.push( new EventDirective( this, event, template ) );
 				});
 			});
 		}

--- a/src/view/items/element/ConditionalAttribute.js
+++ b/src/view/items/element/ConditionalAttribute.js
@@ -61,12 +61,15 @@ export default class ConditionalAttribute extends Item {
 	}
 
 	update () {
+		let str;
+		let attrs;
+
 		if ( this.dirty ) {
 			this.fragment.update();
 
 			if ( this.rendered ) {
-				const str = this.fragment.toString();
-				const attrs = parseAttributes( str, this.isSvg );
+				str = this.fragment.toString();
+				attrs = parseAttributes( str, this.isSvg );
 
 				// any attributes that previously existed but no longer do
 				// must be removed

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -78,9 +78,11 @@ export default class EventDirective {
 						};
 					}
 
+					let resolver;
+
 					const model = resolveReference( this.parentFragment, ref );
 					if ( !model ) {
-						const resolver = this.parentFragment.resolve( ref, model => {
+						resolver = this.parentFragment.resolve( ref, model => {
 							this.models[i] = model;
 							removeFromArray( this.resolvers, resolver );
 						});

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -50,9 +50,10 @@ export default class ExpressionProxy extends Model {
 		this.resolvers = [];
 		this.models = template.r.map( ( ref, index ) => {
 			const model = resolveReference( fragment, ref );
+			let resolver;
 
 			if ( !model ) {
-				const resolver = fragment.resolve( ref, model => {
+				resolver = fragment.resolve( ref, model => {
 					removeFromArray( this.resolvers, resolver );
 					this.models[ index ] = model;
 					this.bubble();
@@ -85,7 +86,7 @@ export default class ExpressionProxy extends Model {
 			getter: () => {
 				const values = this.models.map( model => {
 					if (!model) return undefined;
-					
+
 					const value = model.get( true );
 
 					if ( typeof value === 'function' ) {

--- a/src/view/resolvers/ReferenceExpressionProxy.js
+++ b/src/view/resolvers/ReferenceExpressionProxy.js
@@ -14,16 +14,17 @@ export default class ReferenceExpressionProxy extends Model {
 		this.resolvers = [];
 
 		this.base = resolve( fragment, template );
+		let baseResolver;
 
 		if ( !this.base ) {
-			const resolver = fragment.resolve( template.r, model => {
+			baseResolver = fragment.resolve( template.r, model => {
 				this.base = model;
 				this.bubble();
 
-				removeFromArray( this.resolvers, resolver );
+				removeFromArray( this.resolvers, baseResolver );
 			});
 
-			this.resolvers.push( resolver );
+			this.resolvers.push( baseResolver );
 		}
 
 		const intermediary = {
@@ -36,6 +37,7 @@ export default class ReferenceExpressionProxy extends Model {
 			}
 
 			let model;
+			let resolver;
 
 			if ( template.t === REFERENCE ) {
 				model = resolveReference( fragment, template.n );
@@ -43,7 +45,7 @@ export default class ReferenceExpressionProxy extends Model {
 				if ( model ) {
 					model.register( intermediary );
 				} else {
-					const resolver = fragment.resolve( template.n, model => {
+					resolver = fragment.resolve( template.n, model => {
 						this.members[i] = model;
 
 						model.register( intermediary );


### PR DESCRIPTION
One of the unfortunate consequences of transpiling from ES6 is that Babel will sometimes create IIFEs inside (e.g.) for loops to simulate block scoping. I *think* this PR catches all of those cases. Not sure how best to prevent them creeping back in.

Also, it removes a case where a destructured array was causing a helper to be included unnecessarily.