### PR TITLE
Bind functions on init/set

### DIFF
--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -143,15 +143,12 @@ function initialiseProperties ( ractive ) {
 	ractive._liveQueries = [];
 	ractive._liveComponentQueries = [];
 
-	// bound data functions
-	ractive._boundFunctions = [];
-
 	// observers
 	ractive._observers = [];
 
 	if(!ractive.component){
 		ractive.root = ractive;
-		ractive.parent = ractive.container = null; // TODO container still applicable?		
+		ractive.parent = ractive.container = null; // TODO container still applicable?
 	}
 
 }

--- a/src/Ractive/helpers/getComputationSignature.js
+++ b/src/Ractive/helpers/getComputationSignature.js
@@ -1,4 +1,5 @@
 import { fatal } from '../../utils/log';
+import bind from '../../utils/bind';
 
 const pattern = /\$\{([^\}]+)\}/g;
 
@@ -16,10 +17,6 @@ function createFunctionFromString ( ractive, str ) {
 
 	fn = new Function( functionBody );
 	return hasThis ? fn.bind( ractive ) : fn;
-}
-
-function bind ( fn, context ) {
-	return /this/.test( fn.toString() ) ? fn.bind( context ) : fn;
 }
 
 export default function getComputationSignature ( ractive, key, signature ) {

--- a/src/Ractive/prototype/set.js
+++ b/src/Ractive/prototype/set.js
@@ -1,4 +1,5 @@
 import { isObject } from '../../utils/is';
+import bind from '../../utils/bind';
 import { splitKeypath } from '../../shared/keypaths';
 import runloop from '../../global/runloop';
 
@@ -29,6 +30,8 @@ export default function Ractive$set ( keypath, value ) {
 
 
 function set ( ractive, keypath, value ) {
+	if ( typeof value === 'function' ) value = bind( value, ractive );
+
 	if ( /\*/.test( keypath ) ) {
 		ractive.viewmodel.findMatches( splitKeypath( keypath ) ).forEach( model => {
 			model.set( value );

--- a/src/Ractive/prototype/teardown.js
+++ b/src/Ractive/prototype/teardown.js
@@ -25,11 +25,5 @@ export default function Ractive$teardown () {
 
 	teardownHook.fire( this );
 
-	this._boundFunctions.forEach( deleteFunctionCopy );
-
 	return promise;
-}
-
-function deleteFunctionCopy ( bound ) {
-	delete bound.fn[ bound.prop ];
 }

--- a/src/utils/bind.js
+++ b/src/utils/bind.js
@@ -1,0 +1,8 @@
+export default function bind ( fn, context ) {
+	if ( !/this/.test( fn.toString() ) ) return fn;
+
+	let bound = fn.bind( context );
+	for ( let prop in fn ) bound[ prop ] = fn[ prop ];
+
+	return bound;
+}

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -170,8 +170,7 @@ export default class EventDirective {
 						return model.wrapper.value;
 					}
 
-					let value = model.get();
-					return typeof value === 'function' ? value.bind(this.ractive) : value;
+					return model.get();
 				});
 
 				args = this.argsFn.apply( null, values );

--- a/test/__tests/misc.js
+++ b/test/__tests/misc.js
@@ -1548,39 +1548,6 @@ test( 'Ractive.getNodeInfo returns correct keypath, index, and ractive info', t 
 	t.equal( p.keypath, 'baz.bat' );
 });
 
-if ( typeof Object.getOwnPropertyNames === 'function' ) {
-	test( 'Data functions do not retain instance-bound copies of themselves (#1538)', function ( t ) {
-		var foo, Widget, widgets, keys;
-
-		foo = function () {
-			this; // so that it gets wrapped
-			return 'bar';
-		};
-
-		Widget = Ractive.extend({
-			template: '{{foo()}}',
-			data: { foo: foo }
-		});
-
-		widgets = [ new Widget(), new Widget(), new Widget() ];
-		keys = Object.getOwnPropertyNames( foo ).filter( key => /__ractive/.test( key ) );
-
-		t.equal( keys.length, 3 );
-
-		widgets.pop().teardown();
-		keys = Object.getOwnPropertyNames( foo ).filter( key => /__ractive/.test( key ) );
-		t.equal( keys.length, 2 );
-
-		widgets.pop().teardown();
-		keys = Object.getOwnPropertyNames( foo ).filter( key => /__ractive/.test( key ) );
-		t.equal( keys.length, 1 );
-
-		widgets.pop().teardown();
-		keys = Object.getOwnPropertyNames( foo ).filter( key => /__ractive/.test( key ) );
-		t.equal( keys.length, 0 );
-	});
-}
-
 test( 'Boolean attributes are added/removed based on unstringified fragment value', function ( t ) {
 	var ractive, button;
 

--- a/test/testdeps/helpers/Model.js
+++ b/test/testdeps/helpers/Model.js
@@ -5,6 +5,8 @@ var Model = function ( attributes ) {
 };
 
 Model.prototype = {
+	constructor: Model,
+
 	set: function ( attr, newValue ) {
 		var transformer, oldValue = this.attributes[ attr ];
 


### PR DESCRIPTION
This is a follow-up to #2111. Rather than binding functions to the current instance (or reusing existing bound function copies) in situations like `{{foo()}}` and `on-click='set("bar",foo())'` (where `foo` depends on `this`) at the point of *getting* them, we bind them at the point of *setting* them (or upon initialisation). This is cheaper (it only needs to happen once) and cleaner (we don't need to track bound copies and clean them up later).

The only situation where it might be a problem is if someone is using a non-POJO as their root `data` object, which is already strongly discouraged (and warned about in debug mode).