### PR TITLE
Simplify event code and perf test events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ ractive.js
 !src/Ractive.js
 .gobble-build
 perf/control/*
+perf/control/1740
 !perf/control/.empty
 npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,6 @@ ractive.js
 !src/Ractive.js
 .gobble-build
 perf/control/*
-perf/control/1740
+perf/1740
 !perf/control/.empty
 npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,5 @@ ractive.js
 !src/Ractive.js
 .gobble-build
 perf/control/*
-perf/1740
 !perf/control/.empty
 npm-debug.log

--- a/perf/tests/events.js
+++ b/perf/tests/events.js
@@ -1,0 +1,44 @@
+/*global Ractive, MouseEvent, console */
+
+var setup = function(){
+	var items = new Array( 1000 );
+
+	for (var i = 0, l = items.length; i < l; i++) {
+		items[i] = 'hello';
+	}
+	window.items = items;
+};
+
+var tests = [
+	{
+		name: 'subscribe events',
+		setup: setup,
+		test: () => {
+			window.ractive = new Ractive({
+				el: 'body',
+				template: `
+					<ul>
+					{{#each items }}
+						<li on-click='foo()'>{{this}} world</li>
+					{{/each}}
+					<ul>`,
+				data: {
+					items: window.items
+				},
+				foo: function () {
+
+				}
+			});
+
+			var nodes = window.ractive.findAll( 'li' );
+
+			for( var i = 0, l = nodes.length; i < l; i++ ) {
+				nodes[i].dispatchEvent( new MouseEvent('click', {
+					'view': window,
+					'bubbles': true,
+					'cancelable': true
+				}));
+			}
+		}
+	}
+];

--- a/src/view/items/element/ElementEvents.js
+++ b/src/view/items/element/ElementEvents.js
@@ -45,8 +45,7 @@ class CustomEvent {
 	}
 
 	listen ( directive ) {
-		const node = this.owner.node,
-			  fire = directive.fire.bind( directive );
+		const node = this.owner.node;
 
 		this.handler = this.eventPlugin( node, function( event = {} ) {
 			event.node = event.node || node;

--- a/src/view/items/element/ElementEvents.js
+++ b/src/view/items/element/ElementEvents.js
@@ -1,15 +1,6 @@
 import { missingPlugin } from '../../../config/errors';
 import { fatal } from '../../../utils/log';
 
-function defaultHandler ( event ) {
-	const handler = this._ractive.events[ event.type ];
-
-	handler.fire({
-		node: this,
-		original: event
-	});
-}
-
 class DOMEvent {
 
 	constructor ( name, owner ) {
@@ -21,6 +12,7 @@ class DOMEvent {
 		this.name = name;
 		this.owner = owner;
 		this.node = null;
+		this.handler = null;
 	}
 
 	listen ( directive ) {
@@ -31,16 +23,16 @@ class DOMEvent {
 			missingPlugin( name, 'events' );
 		}
 
-		node._ractive.events[ name ] = directive;
-		node.addEventListener( name, defaultHandler, false );
+		node.addEventListener( name, this.handler = function( event ) {
+			directive.fire({
+				node: node,
+				original: event
+			});
+		}, false );
 	}
 
 	unlisten () {
-		const node = this.node,
-			  name = this.name;
-
-		node.removeEventListener( name, defaultHandler, false );
-		node._ractive.events[ name ] = null;
+		this.node.removeEventListener( this.name, this.handler, false );
 	}
 }
 
@@ -49,16 +41,21 @@ class CustomEvent {
 	constructor ( eventPlugin, owner ) {
 		this.eventPlugin = eventPlugin;
 		this.owner = owner;
-		this.node = null;
+		this.handler = null;
 	}
 
 	listen ( directive ) {
-		const fire = event => directive.fire( event );
-		this.customHandler = this.eventPlugin( this.owner.node, fire );
+		const node = this.owner.node,
+			  fire = directive.fire.bind( directive );
+
+		this.handler = this.eventPlugin( node, function( event = {} ) {
+			event.node = event.node || node;
+			directive.fire( event );
+		});
 	}
 
 	unlisten () {
-		this.customHandler.teardown();
+		this.handler.teardown();
 	}
 }
 


### PR DESCRIPTION
I had a chance to investigate something I was curious about: the existing use of routing of DOM event handling through a common function and then calling a handler stored on the event node. 

Via the perf tests it didn't seem to make a difference, though @Rich-Harris  maybe you know something I don't, or it's an IE thing, or something like that? (Side note: Our perf tests don't run on firefox, due to number of interaction issues between iframe and main window)  

Removing it simplifies the code and we don't have to store state on the DOM nodes for events.

For event plugins, we have a closure anyway, so I added default inclusion of the `node` so plugin authors don't need to add it. Even if we need to keep the common `defaultHandler` we should keep this.