### PR TITLE
Computed parent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,8 @@ root = true
 
 [*.js]
 indent_style = tab
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -6,6 +6,7 @@ import getPrefixer from './helpers/getPrefixer';
 import { isArray, isObject } from '../utils/is';
 import KeyModel from './specials/KeyModel';
 import KeypathModel from './specials/KeypathModel';
+import Computation from './Computation';
 
 const hasProp = Object.prototype.hasOwnProperty;
 
@@ -166,6 +167,10 @@ export default class Model {
 
 	get ( shouldCapture ) {
 		if ( shouldCapture ) capture( this );
+		if ( this.value === void 0 && this.parent instanceof Computation ) {
+			this.parent.get();
+			return this.retrieve();
+		}
 		return this.value;
 	}
 

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -167,10 +167,23 @@ export default class Model {
 
 	get ( shouldCapture ) {
 		if ( shouldCapture ) capture( this );
-		if ( this.value === void 0 && this.parent instanceof Computation ) {
-			this.parent.get();
-			return this.retrieve();
+		let p = this, stem = []
+		// in the case that one of the model's parents is a computed property,
+		// then we must climb the tree and get its value.
+		// once we have it's value we should return it by going back down the stem.
+		if ( this.value === void 0 && this.parent) {
+			while ( p = p.parent ) {
+				if ( p instanceof Computation ) {
+					let v = p.value || p.getValue()
+					for (var i = 0; i < stem.length; i++) {
+						if ( !( v = v[ stem[ i ].key ] ) ) return
+					}
+					return v[ this.key ]
+				}
+				stem.push( p )
+			}
 		}
+
 		return this.value;
 	}
 
@@ -286,7 +299,24 @@ export default class Model {
 	}
 
 	retrieve () {
-		return this.parent.value ? this.parent.value[ this.key ] : undefined;
+		let p = this
+		let value = this.parent.value ? this.parent.value[ this.key ] : undefined
+		// in the case that the values are deep inside of a computed key, we need
+		// to go up the tree, and compute its value first (before it becomes available)
+		// next, refer to the `get` method to see how we pull the value out and apply
+		// it to the sub-keys on the way back down the tree to the value.
+		if ( value === void 0 ) {
+			while ( p = p.parent ) {
+				if ( p instanceof Computation ) {
+					p.get();
+					break;
+				}
+			}
+
+			return this.parent.value ? this.parent.value[ this.key ] : undefined;
+		} else {
+			return value
+		}
 	}
 
 	set ( value ) {

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -31,7 +31,7 @@ export default class Section extends Mustache {
 
 		// if we managed to bind, we need to create children
 		if ( this.model ) {
-			const value = this.model.value; // TODO should use this.model.get()... but weirdness around root models
+			const value = this.model.parent ? this.model.get() : this.model.value;
 			let fragment;
 
 			if ( !this.sectionType ) this.sectionType = getType( value, this.template.i );

--- a/test/__tests/computations.js
+++ b/test/__tests/computations.js
@@ -372,20 +372,48 @@ test( 'Unresolved computations resolve when parent component data exists', funct
 
 test( 'Computed properties referencing bound parent data', function ( t ) {
 	const List = Ractive.extend({
-		// template: `
-		// 	{{#if limits.sum}}
-		// 		{{limits.sum}}
-		// 	{{else}}
-		// 		x
-		// 	{{/if}}
-		// `,
 		template: `
 			{{limits.sum}}
 		`,
 		computed: {
 			limits: function () {
-				// debugger
-				console.log('computed!')
+				return {sum: this.get('d.opts').reduce((a, b) => a + b)}
+			}
+		}
+	});
+
+	const ractive = new Ractive({
+		el: fixture,
+		template: `
+		{{#each list}}
+			<List d='{{.}}'/>
+		{{/each list}}
+		`,
+		data: {
+			list: [
+				{ opts: [3, 3, 3] },
+				{ opts: [3, 2, 1] },
+				{ opts: [1, 1, 1] },
+			]
+		},
+		components: { List }
+	});
+
+	t.equal( fixture.innerHTML, '963' );
+
+});
+
+test( 'Computed properties referencing bound parent data w/ conditional', function ( t ) {
+	const List = Ractive.extend({
+		template: `
+			{{#if limits.sum}}
+				{{limits.sum}}
+			{{else}}
+				x
+			{{/if}}
+		`,
+		computed: {
+			limits: function () {
 				return {sum: this.get('d.opts').reduce((a, b) => a + b)}
 			}
 		}

--- a/test/__tests/computations.js
+++ b/test/__tests/computations.js
@@ -345,25 +345,25 @@ test( 'Unresolved computations resolve when parent component data exists', funct
 	var ractive, Component;
 
 	Component = Ractive.extend({
-	    template: '{{FOO}} {{BAR}}',
-	    computed: {
-	        FOO: '${foo}.toUpperCase()',
-	        BAR: function () {
-	            return this.get( 'bar' ).toUpperCase();
-	        }
-	    }
+		template: '{{FOO}} {{BAR}}',
+		computed: {
+			FOO: '${foo}.toUpperCase()',
+			BAR: function () {
+				return this.get( 'bar' ).toUpperCase();
+			}
+		}
 	});
 
 	ractive = new Ractive({
-	    el: fixture,
-	    template: '<component/>',
-	    data: {
-	        foo: 'fee fi',
-	        bar: 'fo fum'
-	    },
-	    components: {
-	    	component: Component
-	    }
+		el: fixture,
+		template: '<component/>',
+		data: {
+			foo: 'fee fi',
+			bar: 'fo fum'
+		},
+		components: {
+			component: Component
+		}
 	});
 
 	t.equal( fixture.innerHTML, 'FEE FI FO FUM' );
@@ -375,26 +375,26 @@ test( 'Computations are not order dependent', function ( t ) {
 	var ractive, Component;
 
 	Component = Ractive.extend({
-	    template: '{{foo}}',
-	    data: {
-	        count: 1
-	    },
-	    computed: {
-	        foo: '${bar} + 1',
-	        bar: '${count} + 1'
-	    }
+		template: '{{foo}}',
+		data: {
+			count: 1
+		},
+		computed: {
+			foo: '${bar} + 1',
+			bar: '${count} + 1'
+		}
 	});
 
 	ractive = new Ractive({
-        el: fixture,
-        template: '<component/>',
-        data: {
-            bar: 20
-        },
-        components: {
-            component: Component
-        }
-    });
+el: fixture,
+template: '<component/>',
+data: {
+bar: 20
+},
+components: {
+component: Component
+}
+});
 	t.equal( fixture.innerHTML, '3' );
 
 });
@@ -404,24 +404,24 @@ test( 'Parent extend instance computations are resolved before child computation
 	var ractive, Base, Component;
 
 	Base = Ractive.extend({
-	    computed: {
-	        base: () => 1
-	    }
+		computed: {
+			base: () => 1
+		}
 	});
 
 	Component = Base.extend({
 		template: '{{foo}}',
-	    computed: {
-	        foo: '${base} + 1'
-	    }
+		computed: {
+			foo: '${base} + 1'
+		}
 	});
 
 	ractive = new Ractive({
-	    el: fixture,
-	    template: '<component/>',
-	    components: {
-	    	component: Component
-	    }
+		el: fixture,
+		template: '<component/>',
+		components: {
+			component: Component
+		}
 	});
 
 	t.equal( fixture.innerHTML, '2' );
@@ -526,23 +526,23 @@ test( 'Computations can depend on array values (#1747)', t => {
 
 	Component = Ractive.extend({
 		template: "{{ a }}:{{ b }}",
-	    computed: {
-	        b: function() {
-	            var a = this.get("a");
-	            return a + "bar";
-	        }
-	    }
+		computed: {
+			b: function() {
+				var a = this.get("a");
+				return a + "bar";
+			}
+		}
 	});
 
 	ractive = new Ractive({
-	    el: fixture,
-	    template: '{{ a }}:{{ b }}-<component a="{{ a }}" b="{{ b }}" />',
+		el: fixture,
+		template: '{{ a }}:{{ b }}-<component a="{{ a }}" b="{{ b }}" />',
 		components: {
-	        component: Component
-	    },
-	    data: {
-	        a: "foo"
-	    }
+			component: Component
+		},
+		data: {
+			a: "foo"
+		}
 	});
 
 	t.equal( fixture.innerHTML, 'foo:foobar-foo:foobar' );

--- a/test/__tests/computations.js
+++ b/test/__tests/computations.js
@@ -370,6 +370,48 @@ test( 'Unresolved computations resolve when parent component data exists', funct
 
 });
 
+test( 'Computed properties referencing bound parent data', function ( t ) {
+	const List = Ractive.extend({
+		// template: `
+		// 	{{#if limits.sum}}
+		// 		{{limits.sum}}
+		// 	{{else}}
+		// 		x
+		// 	{{/if}}
+		// `,
+		template: `
+			{{limits.sum}}
+		`,
+		computed: {
+			limits: function () {
+				// debugger
+				console.log('computed!')
+				return {sum: this.get('d.opts').reduce((a, b) => a + b)}
+			}
+		}
+	});
+
+	const ractive = new Ractive({
+		el: fixture,
+		template: `
+		{{#each list}}
+			<List d='{{.}}'/>
+		{{/each list}}
+		`,
+		data: {
+			list: [
+				{ opts: [3, 3, 3] },
+				{ opts: [3, 2, 1] },
+				{ opts: [1, 1, 1] },
+			]
+		},
+		components: { List }
+	});
+
+	t.equal( fixture.innerHTML, '963' );
+
+});
+
 test( 'Computations are not order dependent', function ( t ) {
 
 	var ractive, Component;

--- a/test/__tests/computations.js
+++ b/test/__tests/computations.js
@@ -456,15 +456,15 @@ test( 'Computations are not order dependent', function ( t ) {
 	});
 
 	ractive = new Ractive({
-el: fixture,
-template: '<component/>',
-data: {
-bar: 20
-},
-components: {
-component: Component
-}
-});
+		el: fixture,
+		template: '<component/>',
+		data: {
+			bar: 20
+		},
+		components: {
+			component: Component
+		}
+	});
 	t.equal( fixture.innerHTML, '3' );
 
 });

--- a/test/__tests/computations.js
+++ b/test/__tests/computations.js
@@ -440,6 +440,31 @@ test( 'Computed properties referencing bound parent data w/ conditional', functi
 
 });
 
+test( 'Computed properties referencing deep objects', function ( t ) {
+	let ractive = new Ractive({
+	  el: fixture,
+	  template: '{{one.two.tre}}',
+	  data: {
+	    answer: 42
+	  },
+	  computed: {
+	    one () {
+	      var answer = this.get( 'answer' );
+	      return {
+	        two: {
+	          tre: answer
+	        }
+	      };
+	    }
+	  }
+	});
+
+	t.equal( fixture.innerHTML, '42' );
+	ractive.set( 'answer', 99 );
+	t.equal( fixture.innerHTML, '99' );
+
+});
+
 test( 'Computations are not order dependent', function ( t ) {
 
 	var ractive, Component;


### PR DESCRIPTION
turns out that we have to check if it's a computed property when getting (not on the model.joinPath) and lazily compute the value (not when joining it) - otherwise this.value is always undefined (because it never even computes) ...

this is because the computed property returns an object.

just thought of something: it could potentially not resolve if the computed property returns a deep object (and the template references at least 2 levels inside). I dunno