### PR TITLE
Children of computed values

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,8 @@ root = true
 
 [*.js]
 indent_style = tab
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -16,8 +16,6 @@ export default function initialise ( ractive, userOptions, options ) {
 		if ( ractive.viewmodel.value.hasOwnProperty( key ) ) {
 			computation.set( ractive.viewmodel.value[ key ] );
 		}
-
-		computation.init();
 	});
 
 	// init config from Parent and options

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -129,7 +129,7 @@ export default class Computation extends Model {
 
 	set ( value ) {
 		if ( !this.signature.setter ) {
-			throw new Error( `Cannot set read-only computed property '${this.key}'` );
+			throw new Error( `Cannot set read-only computed value '${this.key}'` );
 		}
 
 		this.signature.setter( value );

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -111,9 +111,6 @@ export default class Computation extends Model {
 		this.clearUnresolveds(); // TODO same question as on Model - necessary for primitives?
 	}
 
-	init () {
-	}
-
 	joinKey ( key ) {
 		if ( key === undefined || key === '' ) return this;
 

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -1,12 +1,10 @@
 import { capture, startCapturing, stopCapturing } from '../global/capture';
 import { warnIfDebug } from '../utils/log';
 import Model from './Model';
+import ComputationChild from './ComputationChild';
 import { removeFromArray } from '../utils/array';
 import { isEqual } from '../utils/is';
-import { handleChange, mark as markChild } from '../shared/methodCallers';
-
-// TODO `mark` appears to conflict with method name,
-// hence `markChild` - revert once bundler is fixed
+import { handleChange } from '../shared/methodCallers';
 
 // TODO this is probably a bit anal, maybe we should leave it out
 function prettify ( fnBody ) {
@@ -109,19 +107,27 @@ export default class Computation extends Model {
 		this.dirty = true;
 
 		this.deps.forEach( handleChange );
-		this.children.forEach( markChild ); // TODO rename to mark once bundling glitch fixed
+		this.children.forEach( handleChange );
 		this.clearUnresolveds(); // TODO same question as on Model - necessary for primitives?
 	}
 
 	init () {
 	}
 
-	mark () {
-		this.handleChange();
+	joinKey ( key ) {
+		if ( key === undefined || key === '' ) return this;
+
+		if ( !this.childByKey.hasOwnProperty( key ) ) {
+			const child = new ComputationChild( this, key );
+			this.children.push( child );
+			this.childByKey[ key ] = child;
+		}
+
+		return this.childByKey[ key ];
 	}
 
-	register ( dependant ) {
-		this.deps.push( dependant );
+	mark () {
+		this.handleChange();
 	}
 
 	set ( value ) {
@@ -148,9 +154,5 @@ export default class Computation extends Model {
 		}
 
 		this.dependencies = dependencies;
-	}
-
-	unregister ( dependant ) {
-		removeFromArray( this.deps, dependant );
 	}
 }

--- a/src/model/ComputationChild.js
+++ b/src/model/ComputationChild.js
@@ -1,0 +1,29 @@
+import Model from './Model';
+import { handleChange } from '../shared/methodCallers';
+
+export default class ComputationChild extends Model {
+	get () {
+		const parentValue = this.parent.get();
+		return parentValue ? parentValue[ this.key ] : undefined;
+	}
+
+	handleChange () {
+		this.dirty = true;
+
+		this.deps.forEach( handleChange );
+		this.children.forEach( handleChange ); // TODO rename to mark once bundling glitch fixed
+		this.clearUnresolveds(); // TODO is this necessary?
+	}
+
+	joinKey ( key ) {
+		if ( key === undefined || key === '' ) return this;
+
+		if ( !this.childByKey.hasOwnProperty( key ) ) {
+			const child = new ComputationChild( this, key );
+			this.children.push( child );
+			this.childByKey[ key ] = child;
+		}
+
+		return this.childByKey[ key ];
+	}
+}

--- a/src/model/ComputationChild.js
+++ b/src/model/ComputationChild.js
@@ -26,4 +26,8 @@ export default class ComputationChild extends Model {
 
 		return this.childByKey[ key ];
 	}
+
+	set () {
+		throw new Error( `Cannot set read-only property of computed value (${this.getKeypath()})` );
+	}
 }

--- a/src/model/ComputationChild.js
+++ b/src/model/ComputationChild.js
@@ -11,7 +11,7 @@ export default class ComputationChild extends Model {
 		this.dirty = true;
 
 		this.deps.forEach( handleChange );
-		this.children.forEach( handleChange ); // TODO rename to mark once bundling glitch fixed
+		this.children.forEach( handleChange );
 		this.clearUnresolveds(); // TODO is this necessary?
 	}
 

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -40,6 +40,7 @@ export default class Model {
 			this.parent = parent;
 			this.root = parent.root;
 			this.key = key;
+			this.isComputed = parent.isComputed;
 
 			if ( parent.value ) {
 				this.value = parent.value[ this.key ];
@@ -167,23 +168,6 @@ export default class Model {
 
 	get ( shouldCapture ) {
 		if ( shouldCapture ) capture( this );
-		let p = this, stem = []
-		// in the case that one of the model's parents is a computed property,
-		// then we must climb the tree and get its value.
-		// once we have it's value we should return it by going back down the stem.
-		if ( this.value === void 0 && this.parent) {
-			while ( p = p.parent ) {
-				if ( p instanceof Computation ) {
-					let v = p.value || p.getValue()
-					for (var i = 0; i < stem.length; i++) {
-						if ( !( v = v[ stem[ i ].key ] ) ) return
-					}
-					return v[ this.key ]
-				}
-				stem.push( p )
-			}
-		}
-
 		return this.value;
 	}
 
@@ -299,24 +283,7 @@ export default class Model {
 	}
 
 	retrieve () {
-		let p = this
-		let value = this.parent.value ? this.parent.value[ this.key ] : undefined
-		// in the case that the values are deep inside of a computed key, we need
-		// to go up the tree, and compute its value first (before it becomes available)
-		// next, refer to the `get` method to see how we pull the value out and apply
-		// it to the sub-keys on the way back down the tree to the value.
-		if ( value === void 0 ) {
-			while ( p = p.parent ) {
-				if ( p instanceof Computation ) {
-					p.get();
-					break;
-				}
-			}
-
-			return this.parent.value ? this.parent.value[ this.key ] : undefined;
-		} else {
-			return value
-		}
+		return this.parent.value ? this.parent.value[ this.key ] : undefined;
 	}
 
 	set ( value ) {

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -6,6 +6,7 @@ import getPrefixer from './helpers/getPrefixer';
 import { isArray, isObject } from '../utils/is';
 import KeyModel from './specials/KeyModel';
 import KeypathModel from './specials/KeypathModel';
+import Computation from './Computation';
 
 const hasProp = Object.prototype.hasOwnProperty;
 
@@ -166,6 +167,23 @@ export default class Model {
 
 	get ( shouldCapture ) {
 		if ( shouldCapture ) capture( this );
+		let p = this, stem = []
+		// in the case that one of the model's parents is a computed property,
+		// then we must climb the tree and get its value.
+		// once we have it's value we should return it by going back down the stem.
+		if ( this.value === void 0 && this.parent) {
+			while ( p = p.parent ) {
+				if ( p instanceof Computation ) {
+					let v = p.value || p.getValue()
+					for (var i = 0; i < stem.length; i++) {
+						if ( !( v = v[ stem[ i ].key ] ) ) return
+					}
+					return v[ this.key ]
+				}
+				stem.push( p )
+			}
+		}
+
 		return this.value;
 	}
 
@@ -281,7 +299,24 @@ export default class Model {
 	}
 
 	retrieve () {
-		return this.parent.value ? this.parent.value[ this.key ] : undefined;
+		let p = this
+		let value = this.parent.value ? this.parent.value[ this.key ] : undefined
+		// in the case that the values are deep inside of a computed key, we need
+		// to go up the tree, and compute its value first (before it becomes available)
+		// next, refer to the `get` method to see how we pull the value out and apply
+		// it to the sub-keys on the way back down the tree to the value.
+		if ( value === void 0 ) {
+			while ( p = p.parent ) {
+				if ( p instanceof Computation ) {
+					p.get();
+					break;
+				}
+			}
+
+			return this.parent.value ? this.parent.value[ this.key ] : undefined;
+		} else {
+			return value
+		}
 	}
 
 	set ( value ) {

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -40,7 +40,7 @@ export default class Model {
 			this.parent = parent;
 			this.root = parent.root;
 			this.key = key;
-			this.isComputed = parent.isComputed;
+			this.isReadonly = parent.isReadonly;
 
 			if ( parent.value ) {
 				this.value = parent.value[ this.key ];

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -31,7 +31,7 @@ export default class Section extends Mustache {
 
 		// if we managed to bind, we need to create children
 		if ( this.model ) {
-			const value = this.model.value; // TODO should use this.model.get()... but weirdness around root models
+			const value = this.model.parent ? this.model.get() : this.model.value;
 			let fragment;
 
 			if ( !this.sectionType ) this.sectionType = getType( value, this.template.i );

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -65,7 +65,6 @@ export default class ExpressionProxy extends Model {
 		};
 
 		const computation = ractive.viewmodel.compute( key, signature );
-		computation.init();
 
 		this.value = computation.get(); // TODO should not need this, eventually
 

--- a/test/__tests/computations.js
+++ b/test/__tests/computations.js
@@ -345,28 +345,123 @@ test( 'Unresolved computations resolve when parent component data exists', funct
 	var ractive, Component;
 
 	Component = Ractive.extend({
-	    template: '{{FOO}} {{BAR}}',
-	    computed: {
-	        FOO: '${foo}.toUpperCase()',
-	        BAR: function () {
-	            return this.get( 'bar' ).toUpperCase();
-	        }
-	    }
+		template: '{{FOO}} {{BAR}}',
+		computed: {
+			FOO: '${foo}.toUpperCase()',
+			BAR: function () {
+				return this.get( 'bar' ).toUpperCase();
+			}
+		}
 	});
 
 	ractive = new Ractive({
-	    el: fixture,
-	    template: '<component/>',
-	    data: {
-	        foo: 'fee fi',
-	        bar: 'fo fum'
-	    },
-	    components: {
-	    	component: Component
-	    }
+		el: fixture,
+		template: '<component/>',
+		data: {
+			foo: 'fee fi',
+			bar: 'fo fum'
+		},
+		components: {
+			component: Component
+		}
 	});
 
 	t.equal( fixture.innerHTML, 'FEE FI FO FUM' );
+
+});
+
+test( 'Computed properties referencing bound parent data', function ( t ) {
+	const List = Ractive.extend({
+		template: `
+			{{limits.sum}}
+		`,
+		computed: {
+			limits: function () {
+				return {sum: this.get('d.opts').reduce((a, b) => a + b)}
+			}
+		}
+	});
+
+	const ractive = new Ractive({
+		el: fixture,
+		template: `
+		{{#each list}}
+			<List d='{{.}}'/>
+		{{/each list}}
+		`,
+		data: {
+			list: [
+				{ opts: [3, 3, 3] },
+				{ opts: [3, 2, 1] },
+				{ opts: [1, 1, 1] },
+			]
+		},
+		components: { List }
+	});
+
+	t.equal( fixture.innerHTML, '963' );
+
+});
+
+test( 'Computed properties referencing bound parent data w/ conditional', function ( t ) {
+	const List = Ractive.extend({
+		template: `
+			{{#if limits.sum}}
+				{{limits.sum}}
+			{{else}}
+				x
+			{{/if}}
+		`,
+		computed: {
+			limits: function () {
+				return {sum: this.get('d.opts').reduce((a, b) => a + b)}
+			}
+		}
+	});
+
+	const ractive = new Ractive({
+		el: fixture,
+		template: `
+		{{#each list}}
+			<List d='{{.}}'/>
+		{{/each list}}
+		`,
+		data: {
+			list: [
+				{ opts: [3, 3, 3] },
+				{ opts: [3, 2, 1] },
+				{ opts: [1, 1, 1] },
+			]
+		},
+		components: { List }
+	});
+
+	t.equal( fixture.innerHTML, '963' );
+
+});
+
+test( 'Computed properties referencing deep objects', function ( t ) {
+	let ractive = new Ractive({
+	  el: fixture,
+	  template: '{{one.two.tre}}',
+	  data: {
+	    answer: 42
+	  },
+	  computed: {
+	    one () {
+	      var answer = this.get( 'answer' );
+	      return {
+	        two: {
+	          tre: answer
+	        }
+	      };
+	    }
+	  }
+	});
+
+	t.equal( fixture.innerHTML, '42' );
+	ractive.set( 'answer', 99 );
+	t.equal( fixture.innerHTML, '99' );
 
 });
 
@@ -375,26 +470,26 @@ test( 'Computations are not order dependent', function ( t ) {
 	var ractive, Component;
 
 	Component = Ractive.extend({
-	    template: '{{foo}}',
-	    data: {
-	        count: 1
-	    },
-	    computed: {
-	        foo: '${bar} + 1',
-	        bar: '${count} + 1'
-	    }
+		template: '{{foo}}',
+		data: {
+			count: 1
+		},
+		computed: {
+			foo: '${bar} + 1',
+			bar: '${count} + 1'
+		}
 	});
 
 	ractive = new Ractive({
-        el: fixture,
-        template: '<component/>',
-        data: {
-            bar: 20
-        },
-        components: {
-            component: Component
-        }
-    });
+		el: fixture,
+		template: '<component/>',
+		data: {
+			bar: 20
+		},
+		components: {
+			component: Component
+		}
+	});
 	t.equal( fixture.innerHTML, '3' );
 
 });
@@ -404,24 +499,24 @@ test( 'Parent extend instance computations are resolved before child computation
 	var ractive, Base, Component;
 
 	Base = Ractive.extend({
-	    computed: {
-	        base: () => 1
-	    }
+		computed: {
+			base: () => 1
+		}
 	});
 
 	Component = Base.extend({
 		template: '{{foo}}',
-	    computed: {
-	        foo: '${base} + 1'
-	    }
+		computed: {
+			foo: '${base} + 1'
+		}
 	});
 
 	ractive = new Ractive({
-	    el: fixture,
-	    template: '<component/>',
-	    components: {
-	    	component: Component
-	    }
+		el: fixture,
+		template: '<component/>',
+		components: {
+			component: Component
+		}
 	});
 
 	t.equal( fixture.innerHTML, '2' );
@@ -526,23 +621,23 @@ test( 'Computations can depend on array values (#1747)', t => {
 
 	Component = Ractive.extend({
 		template: "{{ a }}:{{ b }}",
-	    computed: {
-	        b: function() {
-	            var a = this.get("a");
-	            return a + "bar";
-	        }
-	    }
+		computed: {
+			b: function() {
+				var a = this.get("a");
+				return a + "bar";
+			}
+		}
 	});
 
 	ractive = new Ractive({
-	    el: fixture,
-	    template: '{{ a }}:{{ b }}-<component a="{{ a }}" b="{{ b }}" />',
+		el: fixture,
+		template: '{{ a }}:{{ b }}-<component a="{{ a }}" b="{{ b }}" />',
 		components: {
-	        component: Component
-	    },
-	    data: {
-	        a: "foo"
-	    }
+			component: Component
+		},
+		data: {
+			a: "foo"
+		}
 	});
 
 	t.equal( fixture.innerHTML, 'foo:foobar-foo:foobar' );


### PR DESCRIPTION
This follows up @heavyk's work in #2117. From it, I came to realise that `{{foo.bar.baz}}` where `foo` is a computed value is actually a totally different beast to `{{foo.bar.baz}}` where `foo` is a regular value. With regular values, if `foo` is changed but `foo.bar.baz` ends up the same, dependants of `foo.bar.baz` are left alone, meaning that part of the view tree doesn't become 'dirty'. Computed values work the other way round – if their dependencies change, they don't recalculate immediately but instead always notify their dependencies and children of the change, and then *later* (when observers are dispatched, or the view is updated) recalculate *if necessary*.

So given that `foo.bar.baz` and `foo.bar.baz` can do two totally different jobs, depending on what sort of thing `foo` is, it makes sense that the `bar` and `baz` parts should also be different things. This PR introduces the `ComputationChild` class, which is responsible for propagating changes on the same basis as `Computation` nodes themselves. It achieves the same end result as #2117, but allows children of regular values to skip the check for computed parents.

Moreover, it allows us to consider a case that our test suite currently ignores – *setting* child properties of computed values. I'll make a separate issue for that.

Thoughts welcome