### PR TITLE
fix #2098

### DIFF
--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -35,9 +35,7 @@ export default class EventDirective {
 	}
 
 	bind () {
-		let fragment = this.parentFragment;
-		while ( !fragment.context ) fragment = fragment.parent;
-		this.context = fragment.context;
+		this.context = this.parentFragment.findContext();;
 
 		const template = this.template;
 
@@ -236,5 +234,7 @@ export default class EventDirective {
 		// ugh legacy
 		if ( this.action.update ) this.action.update();
 		if ( this.template.d ) this.args.update();
+
+		this.dirty = false;
 	}
 }

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -35,7 +35,7 @@ export default class EventDirective {
 	}
 
 	bind () {
-		this.context = this.parentFragment.findContext();;
+		this.context = this.parentFragment.findContext();
 
 		const template = this.template;
 

--- a/test/__tests/events.js
+++ b/test/__tests/events.js
@@ -854,6 +854,33 @@ test( 'Current event is available to method handler as this.event (#1403)', t =>
 	simulant.fire( ractive.find( 'button' ), 'click' );
 });
 
+test( 'Proxy event arguments update correctly (#2098)', t => {
+	const one = { number: 1 };
+	const two = { number: 2 };
+
+	const ractive = new Ractive({
+		el: fixture,
+		template: `<button type="button" on-click="checkValue:{{current}}">foo</button>`
+	});
+
+	ractive.set( 'current', one );
+	ractive.set( 'current', two );
+
+	let expected = two;
+
+	ractive.on( 'checkValue', ( event, value ) => {
+		t.strictEqual( value, expected );
+		ractive.set( 'current', one );
+		expected = one;
+	});
+
+	const button = ractive.find( 'button' );
+
+	expect( 2 );
+	simulant.fire( button, 'click' );
+	simulant.fire( button, 'click' );
+});
+
 
 var Component, Middle, View, setup;
 


### PR DESCRIPTION
This fixes #2098. `EventDirective` wasn't resetting `this.dirty` to `false` after updating, causing subsequent changes to not register.