### PR TITLE
Use ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,11 @@
 {
 	"rules": {
-		"indent": [ 2, "tab" ],
+		"indent": [ 2, "tab", { "SwitchCase": 1 }],
 		"quotes": [ 2, "single" ],
 		"linebreak-style": [ 2, "unix" ],
 		"semi": [ 2, "always" ],
 		"no-mixed-spaces-and-tabs": [2, "smart-tabs"],
-		
+
 		"no-cond-assign": 0
 	},
 	"env": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,19 @@
+{
+	"rules": {
+		"indent": [ 2, "tab" ],
+		"quotes": [ 2, "single" ],
+		"linebreak-style": [ 2, "unix" ],
+		"semi": [ 2, "always" ],
+		"no-mixed-spaces-and-tabs": [2, "smart-tabs"],
+		
+		"no-cond-assign": 0
+	},
+	"env": {
+		"es6": true,
+		"browser": true
+	},
+	"extends": "eslint:recommended",
+	"ecmaFeatures": {
+		"modules": true
+	}
+}

--- a/package.json
+++ b/package.json
@@ -67,11 +67,13 @@
     "build": "sh ./scripts/build.sh",
     "release": "sh ./scripts/release.sh",
     "fakebuild": "sh ./scripts/build.sh --fake",
-    "promises-aplus-tests": "./scripts/promises-aplus-tests.js"
+    "promises-aplus-tests": "./scripts/promises-aplus-tests.js",
+    "lint": "node node_modules/eslint/bin/eslint src/ --ext .js"
   },
   "github": "https://github.com/ractivejs/ractive",
   "devDependencies": {
     "cheerio": "^0.18.0",
+    "eslint": "^1.3.1",
     "esperanto": "^0.6.32",
     "gobble": "^0.10.1",
     "gobble-babel": "^5.1.0",

--- a/src/Ractive/config/custom/template/parser.js
+++ b/src/Ractive/config/custom/template/parser.js
@@ -3,7 +3,7 @@ import parse from '../../../../parse/_parse';
 import { create } from '../../../../utils/object';
 
 var parseOptions = [
- 	'preserveWhitespace',
+	'preserveWhitespace',
 	'sanitize',
 	'stripComments',
 	'delimiters',

--- a/src/Ractive/config/registries.js
+++ b/src/Ractive/config/registries.js
@@ -23,7 +23,7 @@ Registry = function ( name, useDefaults ) {
 Registry.prototype = {
 	constructor: Registry,
 
- 	extend: function ( Parent, proto, options ) {
+	extend: function ( Parent, proto, options ) {
 		this.configure(
 			this.useDefaults ? Parent.defaults : Parent,
 			this.useDefaults ? proto : proto.constructor,

--- a/src/Ractive/static/adaptors/array/processWrapper.js
+++ b/src/Ractive/static/adaptors/array/processWrapper.js
@@ -1,7 +1,7 @@
 export default function ( wrapper, array, methodName, newIndices ) {
 	var { __model } = wrapper;
 
-	if ( !!newIndices ) {
+	if ( newIndices ) {
 		__model.shuffle( newIndices );
 	} else {
 		// If this is a sort or reverse, we just do root.set()...

--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -83,22 +83,22 @@ function dispatch ( observer ) {
 }
 
 function flushChanges () {
-	var i, thing, changeHash;
-
 	batch.immediateObservers.forEach( dispatch );
 
 	// Now that changes have been fully propagated, we can update the DOM
 	// and complete other tasks
-	i = batch.fragments.length;
+	let i = batch.fragments.length;
+	let fragment;
+
 	while ( i-- ) {
-		thing = batch.fragments[i];
+		fragment = batch.fragments[i];
 
 		// TODO deprecate this. It's annoying and serves no useful function
-		const ractive = thing.ractive;
+		const ractive = fragment.ractive;
 		changeHook.fire( ractive, ractive.viewmodel.changes );
 		ractive.viewmodel.changes = {};
 
-		thing.update();
+		fragment.update();
 	}
 	batch.fragments.length = 0;
 

--- a/src/legacy.js
+++ b/src/legacy.js
@@ -322,12 +322,10 @@ if ( !win ) {
 		exportedShims.getComputedStyle = (function () {
 			var borderSizes = {};
 
-			function getPixelSize(element, style, property, fontSize) {
-				var
-				sizeWithSuffix = style[property],
-				size = parseFloat(sizeWithSuffix),
-				suffix = sizeWithSuffix.split(/\d/)[0],
-				rootSize;
+			function getPixelSize ( element, style, property, fontSize ) {
+				const sizeWithSuffix = style[property];
+				let size = parseFloat(sizeWithSuffix);
+				let suffix = sizeWithSuffix.split(/\d/)[0];
 
 				if ( isNaN( size ) ) {
 					if ( /^thin|medium|thick$/.test( sizeWithSuffix ) ) {
@@ -341,7 +339,7 @@ if ( !win ) {
 				}
 
 				fontSize = fontSize != null ? fontSize : /%|em/.test(suffix) && element.parentElement ? getPixelSize(element.parentElement, element.parentElement.currentStyle, 'fontSize', null) : 16;
-				rootSize = property == 'fontSize' ? fontSize : /width/i.test(property) ? element.clientWidth : element.clientHeight;
+				const rootSize = property == 'fontSize' ? fontSize : /width/i.test(property) ? element.clientWidth : element.clientHeight;
 
 				return (suffix == 'em') ? size * fontSize : (suffix == 'in') ? size * 96 : (suffix == 'pt') ? size * 96 / 72 : (suffix == '%') ? size / 100 * rootSize : size;
 			}
@@ -367,12 +365,11 @@ if ( !win ) {
 			}
 
 			function setShortStyleProperty(style, property) {
-				var
-				borderSuffix = property == 'border' ? 'Width' : '',
-				t = property + 'Top' + borderSuffix,
-				r = property + 'Right' + borderSuffix,
-				b = property + 'Bottom' + borderSuffix,
-				l = property + 'Left' + borderSuffix;
+				const borderSuffix = property == 'border' ? 'Width' : '';
+				const t = `${property}Top${borderSuffix}`;
+				const r = `${property}Right${borderSuffix}`;
+				const b = `${property}Bottom${borderSuffix}`;
+				const l = `${property}Left${borderSuffix}`;
 
 				style[property] = (style[t] == style[r] == style[b] == style[l] ? [style[t]]
 				: style[t] == style[b] && style[l] == style[r] ? [style[t], style[r]]

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -2,8 +2,6 @@ import { capture, startCapturing, stopCapturing } from '../global/capture';
 import { warnIfDebug } from '../utils/log';
 import Model from './Model';
 import ComputationChild from './ComputationChild';
-import { removeFromArray } from '../utils/array';
-import { isEqual } from '../utils/is';
 import { handleChange } from '../shared/methodCallers';
 
 // TODO this is probably a bit anal, maybe we should leave it out

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -6,7 +6,6 @@ import getPrefixer from './helpers/getPrefixer';
 import { isArray, isObject } from '../utils/is';
 import KeyModel from './specials/KeyModel';
 import KeypathModel from './specials/KeypathModel';
-import Computation from './Computation';
 
 const hasProp = Object.prototype.hasOwnProperty;
 

--- a/src/parse/converters/element/processDirective.js
+++ b/src/parse/converters/element/processDirective.js
@@ -33,7 +33,7 @@ export default function processDirective ( tokens, parentParser ) {
 			}
 
 			result = { m: match[1] };
-			const sliced = tokens.slice( result.m.length + 1, end )
+			const sliced = tokens.slice( result.m.length + 1, end );
 
 			if ( sliced === '...arguments' ) {
 				// TODO: what the heck should this be???

--- a/src/parse/converters/element/readAttribute.js
+++ b/src/parse/converters/element/readAttribute.js
@@ -47,8 +47,8 @@ function readAttributeValue ( parser ) {
 	valueStart = parser.pos;
 	startDepth = parser.sectionDepth;
 
-	value = readQuotedAttributeValue( parser, "'" ) ||
-			readQuotedAttributeValue( parser, '"' ) ||
+	value = readQuotedAttributeValue( parser, `'` ) ||
+			readQuotedAttributeValue( parser, `"` ) ||
 			readUnquotedAttributeValue( parser );
 
 	if ( value === null ) {
@@ -144,15 +144,12 @@ function readQuotedAttributeValue ( parser, quoteMark ) {
 }
 
 function readQuotedStringToken ( parser, quoteMark ) {
-	var start, index, haystack, needles;
+	const haystack = parser.remaining();
 
-	start = parser.pos;
-	haystack = parser.remaining();
-
-	needles = parser.tags.map( t => t.open ); // TODO refactor... we do this in readText.js as well
+	let needles = parser.tags.map( t => t.open ); // TODO refactor... we do this in readText.js as well
 	needles.push( quoteMark );
 
-	index = getLowestIndex( haystack, needles );
+	const index = getLowestIndex( haystack, needles );
 
 	if ( index === -1 ) {
 		parser.error( 'Quoted attribute value must have a closing quote' );

--- a/src/parse/converters/expressions/primary/literal/readStringLiteral.js
+++ b/src/parse/converters/expressions/primary/literal/readStringLiteral.js
@@ -1,8 +1,8 @@
 import { STRING_LITERAL } from '../../../../../config/types';
 import makeQuotedStringMatcher from './stringLiteral/makeQuotedStringMatcher';
 
-var getSingleQuotedString = makeQuotedStringMatcher( '"' );
-var getDoubleQuotedString = makeQuotedStringMatcher( "'" );
+var getSingleQuotedString = makeQuotedStringMatcher( `"` );
+var getDoubleQuotedString = makeQuotedStringMatcher( `'` );
 
 export default function ( parser ) {
 	var start, string;
@@ -23,10 +23,10 @@ export default function ( parser ) {
 		};
 	}
 
-	if ( parser.matchString( "'" ) ) {
+	if ( parser.matchString( `'` ) ) {
 		string = getSingleQuotedString( parser );
 
-		if ( !parser.matchString( "'" ) ) {
+		if ( !parser.matchString( `'` ) ) {
 			parser.pos = start;
 			return null;
 		}

--- a/src/parse/converters/expressions/primary/literal/stringLiteral/makeQuotedStringMatcher.js
+++ b/src/parse/converters/expressions/primary/literal/stringLiteral/makeQuotedStringMatcher.js
@@ -13,20 +13,18 @@ lineContinuationPattern = /^\\(?:\r\n|[\u000A\u000D\u2028\u2029])/;
 // Helper for defining getDoubleQuotedString and getSingleQuotedString.
 export default function ( okQuote ) {
 	return function ( parser ) {
-		var start, literal, done, next;
-
-		start = parser.pos;
-		literal = '"';
-		done = false;
+		let literal = '"';
+		let done = false;
+		let next;
 
 		while ( !done ) {
 			next = ( parser.matchPattern( stringMiddlePattern ) || parser.matchPattern( escapeSequencePattern ) ||
 				parser.matchString( okQuote ) );
 			if ( next ) {
-				if ( next === '"' ) {
-					literal += '\\"';
-				} else if ( next === "\\'" ) {
-					literal += "'";
+				if ( next === `"` ) {
+					literal += `\\"`;
+				} else if ( next === `\\'` ) {
+					literal += `'`;
 				} else {
 					literal += next;
 				}

--- a/src/parse/converters/expressions/primary/readBracketedExpression.js
+++ b/src/parse/converters/expressions/primary/readBracketedExpression.js
@@ -3,26 +3,17 @@ import { expectedExpression, expectedParen } from '../shared/errors';
 import readExpression from '../../readExpression';
 
 export default function readBracketedExpression ( parser ) {
-	var start, expr;
-
-	start = parser.pos;
-
-	if ( !parser.matchString( '(' ) ) {
-		return null;
-	}
+	if ( !parser.matchString( '(' ) ) return null;
 
 	parser.allowWhitespace();
 
-	expr = readExpression( parser );
-	if ( !expr ) {
-		parser.error( expectedExpression );
-	}
+	const expr = readExpression( parser );
+
+	if ( !expr ) parser.error( expectedExpression );
 
 	parser.allowWhitespace();
 
-	if ( !parser.matchString( ')' ) ) {
-		parser.error( expectedParen );
-	}
+	if ( !parser.matchString( ')' ) ) parser.error( expectedParen );
 
 	return {
 		t: BRACKETED,

--- a/src/parse/converters/expressions/readLogicalOr.js
+++ b/src/parse/converters/expressions/readLogicalOr.js
@@ -31,7 +31,7 @@ makeInfixSequenceMatcher = function ( symbol, fallthrough ) {
 				return left;
 			}
 
-		   parser.allowWhitespace();
+			parser.allowWhitespace();
 
 			// right operand must also consist of only higher-precedence operators
 			right = fallthrough( parser );

--- a/src/parse/converters/expressions/readMemberOrInvocation.js
+++ b/src/parse/converters/expressions/readMemberOrInvocation.js
@@ -5,18 +5,13 @@ import readRefinement from './shared/readRefinement';
 import { expectedParen } from './shared/errors';
 
 export default function ( parser ) {
-	var current, expression, refinement, expressionList;
+	let expression = readPrimary( parser );
 
-	expression = readPrimary( parser );
-
-	if ( !expression ) {
-		return null;
-	}
+	if ( !expression ) return null;
 
 	while ( expression ) {
-		current = parser.pos;
-
-		if ( refinement = readRefinement( parser ) ) {
+		const refinement = readRefinement( parser );
+		if ( refinement ) {
 			expression = {
 				t: MEMBER,
 				x: expression,
@@ -26,7 +21,7 @@ export default function ( parser ) {
 
 		else if ( parser.matchString( '(' ) ) {
 			parser.allowWhitespace();
-			expressionList = readExpressionList( parser );
+			const expressionList = readExpressionList( parser );
 
 			parser.allowWhitespace();
 
@@ -39,9 +34,7 @@ export default function ( parser ) {
 				x: expression
 			};
 
-			if ( expressionList ) {
-				expression.o = expressionList;
-			}
+			if ( expressionList ) expression.o = expressionList;
 		}
 
 		else {

--- a/src/parse/converters/expressions/shared/readExpressionList.js
+++ b/src/parse/converters/expressions/shared/readExpressionList.js
@@ -2,34 +2,22 @@ import { expectedExpression } from './errors';
 import readExpression from '../../readExpression';
 
 export default function readExpressionList ( parser ) {
-	var start, expressions, expr, next;
-
-	start = parser.pos;
-
 	parser.allowWhitespace();
 
-	expr = readExpression( parser );
+	const expr = readExpression( parser );
 
-	if ( expr === null ) {
-		return null;
-	}
+	if ( expr === null ) return null;
 
-	expressions = [ expr ];
+	let expressions = [ expr ];
 
 	// allow whitespace between expression and ','
 	parser.allowWhitespace();
 
 	if ( parser.matchString( ',' ) ) {
-		next = readExpressionList( parser );
-		if ( next === null ) {
-			parser.error( expectedExpression );
-		}
+		const next = readExpressionList( parser );
+		if ( next === null ) parser.error( expectedExpression );
 
-		next.forEach( append );
-	}
-
-	function append ( expression ) {
-		expressions.push( expression );
+		expressions.push.apply( expressions, next );
 	}
 
 	return expressions;

--- a/src/parse/converters/expressions/shared/readRefinement.js
+++ b/src/parse/converters/expressions/shared/readRefinement.js
@@ -4,17 +4,14 @@ import { name as namePattern } from './patterns';
 import readExpression from '../../readExpression';
 
 export default function readRefinement ( parser ) {
-	var start, name, expr;
-
-	start = parser.pos;
-
 	parser.allowWhitespace();
 
 	// "." name
 	if ( parser.matchString( '.' ) ) {
 		parser.allowWhitespace();
 
-		if ( name = parser.matchPattern( namePattern ) ) {
+		const name = parser.matchPattern( namePattern );
+		if ( name ) {
 			return {
 				t: REFINEMENT,
 				n: name
@@ -28,16 +25,12 @@ export default function readRefinement ( parser ) {
 	if ( parser.matchString( '[' ) ) {
 		parser.allowWhitespace();
 
-		expr = readExpression( parser );
-		if ( !expr ) {
-			parser.error( expectedExpression );
-		}
+		const expr = readExpression( parser );
+		if ( !expr ) parser.error( expectedExpression );
 
 		parser.allowWhitespace();
 
-		if ( !parser.matchString( ']' ) ) {
-			parser.error( 'Expected \']\'' );
-		}
+		if ( !parser.matchString( ']' ) ) parser.error( `Expected ']'` );
 
 		return {
 			t: REFINEMENT,

--- a/src/parse/converters/mustache/readPartial.js
+++ b/src/parse/converters/mustache/readPartial.js
@@ -3,34 +3,25 @@ import readExpression from '../readExpression';
 import refineExpression from '../../utils/refineExpression';
 
 export default function readPartial ( parser, tag ) {
-	var start, nameStart, expression, context, partial;
-
-	start = parser.pos;
-
-	if ( !parser.matchString( '>' ) ) {
-		return null;
-	}
+	if ( !parser.matchString( '>' ) ) return null;
 
 	parser.allowWhitespace();
-	nameStart = parser.pos;
 
 	// Partial names can include hyphens, so we can't use readExpression
 	// blindly. Instead, we use the `relaxedNames` flag to indicate that
 	// `foo-bar` should be read as a single name, rather than 'subtract
 	// bar from foo'
 	parser.relaxedNames = true;
-	expression = readExpression( parser );
+	const expression = readExpression( parser );
 	parser.relaxedNames = false;
 
 	parser.allowWhitespace();
-	context = readExpression( parser );
+	const context = readExpression( parser );
 	parser.allowWhitespace();
 
-	if ( !expression ) {
-		return null;
-	}
+	if ( !expression ) return null;
 
-	partial = { t: PARTIAL };
+	let partial = { t: PARTIAL };
 	refineExpression( expression, partial ); // TODO...
 
 	parser.allowWhitespace();

--- a/src/parse/converters/mustache/readSection.js
+++ b/src/parse/converters/mustache/readSection.js
@@ -85,7 +85,7 @@ export default function readSection ( parser, tag ) {
 			}
 
 			if ( !unlessBlock ) {
-				unlessBlock = createUnlessBlock( expression, section.n );
+				unlessBlock = createUnlessBlock( expression );
 			}
 
 			unlessBlock.f.push({
@@ -111,7 +111,7 @@ export default function readSection ( parser, tag ) {
 
 			// use an unless block if there's no elseif
 			if ( !unlessBlock ) {
-				unlessBlock = createUnlessBlock( expression, section.n );
+				unlessBlock = createUnlessBlock( expression );
 				children = unlessBlock.f;
 			} else {
 				unlessBlock.f.push({
@@ -159,7 +159,7 @@ export default function readSection ( parser, tag ) {
 	return section;
 }
 
-function createUnlessBlock ( expression, sectionType ) {
+function createUnlessBlock ( expression ) {
 	let unlessBlock = {
 		t: SECTION,
 		n: SECTION_UNLESS,
@@ -167,7 +167,6 @@ function createUnlessBlock ( expression, sectionType ) {
 	};
 
 	refineExpression( expression, unlessBlock );
-
 	return unlessBlock;
 }
 

--- a/src/parse/converters/mustache/readYielder.js
+++ b/src/parse/converters/mustache/readYielder.js
@@ -3,14 +3,9 @@ import { YIELDER } from '../../../config/types';
 var yieldPattern = /^yield\s*/;
 
 export default function readYielder ( parser, tag ) {
-	var start, name, yielder;
+	if ( !parser.matchPattern( yieldPattern ) ) return null;
 
-	if ( !parser.matchPattern( yieldPattern ) ) {
-		return null;
-	}
-
-	start = parser.pos;
-	name = parser.matchPattern( /^[a-zA-Z_$][a-zA-Z_$0-9\-]*/ );
+	const name = parser.matchPattern( /^[a-zA-Z_$][a-zA-Z_$0-9\-]*/ );
 
 	parser.allowWhitespace();
 
@@ -18,11 +13,8 @@ export default function readYielder ( parser, tag ) {
 		parser.error( `expected legal partial name` );
 	}
 
-	yielder = { t: YIELDER };
-
-	if ( name ) {
-		yielder.n = name;
-	}
+	let yielder = { t: YIELDER };
+	if ( name ) yielder.n = name;
 
 	return yielder;
 }

--- a/src/parse/converters/readPartialDefinitionComment.js
+++ b/src/parse/converters/readPartialDefinitionComment.js
@@ -5,20 +5,17 @@ import escapeRegExp from '../../utils/escapeRegExp';
 
 export default readPartialDefinitionComment;
 
-var startPattern = /^<!--\s*/,
-    namePattern = /s*>\s*([a-zA-Z_$][-a-zA-Z_$0-9]*)\s*/,
-    finishPattern = /\s*-->/,
-    child;
+const startPattern = /^<!--\s*/;
+const namePattern = /s*>\s*([a-zA-Z_$][-a-zA-Z_$0-9]*)\s*/;
+const finishPattern = /\s*-->/;
 
 function readPartialDefinitionComment ( parser ) {
-	let firstPos = parser.pos,
-	    open = parser.standardDelimiters[0],
-	    close = parser.standardDelimiters[1],
-	    content,
-	    closed;
+	const start = parser.pos;
+	const open = parser.standardDelimiters[0];
+	const close = parser.standardDelimiters[1];
 
 	if ( !parser.matchPattern( startPattern ) || !parser.matchString( open ) ) {
-		parser.pos = firstPos;
+		parser.pos = start;
 		return null;
 	}
 
@@ -33,11 +30,12 @@ Use this...
 
 	// make sure the rest of the comment is in the correct place
 	if ( !parser.matchString( close ) || !parser.matchPattern( finishPattern ) ) {
-		parser.pos = firstPos;
+		parser.pos = start;
 		return null;
 	}
 
-	content = [];
+	let content = [];
+	let closed;
 
 	let endPattern = new RegExp('^<!--\\s*' + escapeRegExp( open ) + '\\s*\\/\\s*' + name + '\\s*' + escapeRegExp( close ) + '\\s*-->');
 
@@ -47,7 +45,7 @@ Use this...
 		}
 
 		else {
-			child = parser.read( READERS );
+			const child = parser.read( READERS );
 			if ( !child ) {
 				parser.error( `expected closing comment ('<!-- ${open}/${name}${close} -->')` );
 			}

--- a/src/parse/converters/readText.js
+++ b/src/parse/converters/readText.js
@@ -17,7 +17,7 @@ export default function readText ( parser ) {
 		// http://developers.whatwg.org/syntax.html#syntax-attributes
 		if ( parser.inAttribute === true ) {
 			// we're inside an unquoted attribute value
-			disallowed.push( '"', "'", '=', '<', '>', '`' );
+			disallowed.push( `"`, `'`, `=`, `<`, `>`, '`' );
 		} else if ( parser.inAttribute ) {
 			// quoted attribute value
 			disallowed.push( parser.inAttribute );

--- a/src/parse/utils/flattenExpression.js
+++ b/src/parse/utils/flattenExpression.js
@@ -17,46 +17,46 @@ export default function flattenExpression ( expression ) {
 			case GLOBAL:
 			case NUMBER_LITERAL:
 			case REGEXP_LITERAL:
-			return node.v;
+				return node.v;
 
 			case STRING_LITERAL:
-			return JSON.stringify( String( node.v ) );
+				return JSON.stringify( String( node.v ) );
 
 			case ARRAY_LITERAL:
-			return '[' + ( node.m ? node.m.map( stringify ).join( ',' ) : '' ) + ']';
+				return '[' + ( node.m ? node.m.map( stringify ).join( ',' ) : '' ) + ']';
 
 			case OBJECT_LITERAL:
-			return '{' + ( node.m ? node.m.map( stringify ).join( ',' ) : '' ) + '}';
+				return '{' + ( node.m ? node.m.map( stringify ).join( ',' ) : '' ) + '}';
 
 			case KEY_VALUE_PAIR:
-			return node.k + ':' + stringify( node.v );
+				return node.k + ':' + stringify( node.v );
 
 			case PREFIX_OPERATOR:
-			return ( node.s === 'typeof' ? 'typeof ' : node.s ) + stringify( node.o );
+				return ( node.s === 'typeof' ? 'typeof ' : node.s ) + stringify( node.o );
 
 			case INFIX_OPERATOR:
-			return stringify( node.o[0] ) + ( node.s.substr( 0, 2 ) === 'in' ? ' ' + node.s + ' ' : node.s ) + stringify( node.o[1] );
+				return stringify( node.o[0] ) + ( node.s.substr( 0, 2 ) === 'in' ? ' ' + node.s + ' ' : node.s ) + stringify( node.o[1] );
 
 			case INVOCATION:
-			return stringify( node.x ) + '(' + ( node.o ? node.o.map( stringify ).join( ',' ) : '' ) + ')';
+				return stringify( node.x ) + '(' + ( node.o ? node.o.map( stringify ).join( ',' ) : '' ) + ')';
 
 			case BRACKETED:
-			return '(' + stringify( node.x ) + ')';
+				return '(' + stringify( node.x ) + ')';
 
 			case MEMBER:
-			return stringify( node.x ) + stringify( node.r );
+				return stringify( node.x ) + stringify( node.r );
 
 			case REFINEMENT:
-			return ( node.n ? '.' + node.n : '[' + stringify( node.x ) + ']' );
+				return ( node.n ? '.' + node.n : '[' + stringify( node.x ) + ']' );
 
 			case CONDITIONAL:
-			return stringify( node.o[0] ) + '?' + stringify( node.o[1] ) + ':' + stringify( node.o[2] );
+				return stringify( node.o[0] ) + '?' + stringify( node.o[1] ) + ':' + stringify( node.o[2] );
 
 			case REFERENCE:
-			return '_' + refs.indexOf( node.n );
+				return '_' + refs.indexOf( node.n );
 
 			default:
-			throw new Error( 'Expected legal JavaScript' );
+				throw new Error( 'Expected legal JavaScript' );
 		}
 	}
 }
@@ -95,4 +95,3 @@ function extractRefs ( node, refs ) {
 		extractRefs( node.v, refs );
 	}
 }
-

--- a/src/shared/Ticker.js
+++ b/src/shared/Ticker.js
@@ -1,5 +1,3 @@
-import { warnOnceIfDebug } from '../utils/log';
-import { missingPlugin } from '../config/errors';
 import getTime from '../utils/getTime';
 import animations from './animations';
 

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -1,31 +1,5 @@
 import { isArray } from './is';
 
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
-if (!Array.prototype.find) {
-	Array.prototype.find = function(predicate) {
-		if (this == null) {
-		throw new TypeError('Array.prototype.find called on null or undefined');
-		}
-		if (typeof predicate !== 'function') {
-		throw new TypeError('predicate must be a function');
-		}
-		var list = Object(this);
-		var length = list.length >>> 0;
-		var thisArg = arguments[1];
-		var value;
-
-		for (var i = 0; i < length; i++) {
-			if (i in list) {
-				value = list[i];
-				if (predicate.call(thisArg, value, i, list)) {
-				return value;
-				}
-			}
-		}
-		return undefined;
-	};
-}
-
 export function addToArray ( array, value ) {
 	var index = array.indexOf( value );
 
@@ -41,7 +15,7 @@ export function arrayContains ( array, value ) {
 		}
 	}
 
-    return false;
+	return false;
 }
 
 export function arrayContentsMatch ( a, b ) {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -5,8 +5,8 @@ var createElement, matches, div, methodNames, unprefixed, prefixed, i, j, makeFu
 
 // Test for SVG support
 if ( !svg ) {
-	createElement = function ( type, ns, extend ) {
-		if ( ns && ns !== namespaces.html ) {
+	createElement = ( type, ns, extend ) => {
+		if ( ns && ns !== html ) {
 			throw 'This browser does not support namespaces other than http://www.w3.org/1999/xhtml. The most likely cause of this error is that you\'re trying to render SVG in an older browser. See http://docs.ractivejs.org/latest/svg-and-older-browsers for more information';
 		}
 
@@ -15,7 +15,7 @@ if ( !svg ) {
 			doc.createElement( type );
 	};
 } else {
-	createElement = function ( type, ns, extend ) {
+	createElement = ( type, ns, extend ) => {
 		if ( !ns || ns === html ) {
 			return extend ?
 				doc.createElement( type, extend ) :

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -1,5 +1,5 @@
 import runloop from '../../global/runloop';
-import { fatal, warnIfDebug, warnOnceIfDebug } from '../../utils/log';
+import { warnIfDebug, warnOnceIfDebug } from '../../utils/log';
 import { COMPONENT, INTERPOLATOR, YIELDER } from '../../config/types';
 import Item from './shared/Item';
 import construct from '../../Ractive/construct';
@@ -15,7 +15,6 @@ import Fragment from '../Fragment';
 import parseJSON from '../../utils/parseJSON';
 import EventDirective from './shared/EventDirective';
 import RactiveEvent from './component/RactiveEvent';
-import fireEvent from '../../events/fireEvent';
 import updateLiveQueries from './component/updateLiveQueries';
 
 function removeFromLiveComponentQueries ( component ) {

--- a/src/view/items/element/Transition.js
+++ b/src/view/items/element/Transition.js
@@ -100,7 +100,7 @@ export default class Transition {
 		}
 
 		return new Promise( fulfil => {
-			var propertyNames, changedProperties, computedStyle, current, from, i, prop;
+			var propertyNames, changedProperties, computedStyle, current, i, prop;
 
 			// Edge case - if duration is zero, set style synchronously and complete
 			if ( !options.duration ) {
@@ -116,7 +116,6 @@ export default class Transition {
 			// Store the current styles
 			computedStyle = getComputedStyle( this.node );
 
-			from = {};
 			i = propertyNames.length;
 			while ( i-- ) {
 				prop = propertyNames[i];

--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -5,7 +5,7 @@ import { isArray } from '../../../../utils/is';
 import noop from '../../../../utils/noop';
 
 export default function getUpdateDelegate ( attribute ) {
-	const { element, name, namespace } = attribute;
+	const { element, name } = attribute;
 
 	if ( name === 'id' ) return updateId;
 

--- a/src/view/items/element/binding/RadioBinding.js
+++ b/src/view/items/element/binding/RadioBinding.js
@@ -1,7 +1,6 @@
 import runloop from '../../../../global/runloop';
 import { removeFromArray } from '../../../../utils/array';
 import Binding from './Binding';
-import getBindingGroup from './getBindingGroup';
 import handleDomEvent from './handleDomEvent';
 
 let siblings = {};

--- a/src/view/items/element/transitions/createTransitions.js
+++ b/src/view/items/element/transitions/createTransitions.js
@@ -1,5 +1,6 @@
+import { missingPlugin } from '../../../../config/errors';
 import { isClient } from '../../../../config/environment';
-import { warnIfDebug } from '../../../../utils/log';
+import { warnIfDebug, warnOnceIfDebug } from '../../../../utils/log';
 import { createElement } from '../../../../utils/dom';
 import camelCase from '../../../../utils/camelCase';
 import interpolate from '../../../../shared/interpolate';

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -4,7 +4,6 @@ import { handleChange, unbind } from '../../shared/methodCallers';
 import createFunction from '../../shared/createFunction';
 import resolveReference from './resolveReference';
 import { removeFromArray } from '../../utils/array';
-import { defineProperty } from '../../utils/object';
 
 function getValue ( model ) {
 	return model ? model.get( true ) : undefined;


### PR DESCRIPTION
JSHint has served us extremely well for a long time. Recently though, I've been experimenting with [ESLint](http://eslint.org/) on a few projects, and I've come to really like it – it's very flexible, very actively developed and very thorough, and it does a good job of helping you figure out why certain tests failed. This PR adds an `npm run lint` task, and fixes a bunch of lint errors in the codebase.