### PR TITLE
implement getKeypath on keypath models - fixes #2164

### DIFF
--- a/src/model/specials/KeypathModel.js
+++ b/src/model/specials/KeypathModel.js
@@ -12,6 +12,10 @@ export default class KeypathModel {
 		return this.value;
 	}
 
+	getKeypath () {
+		return this.value;
+	}
+
 	handleChange () {
 		this.value = this.parent.getKeypath();
 		this.dependants.forEach( handleChange );

--- a/test/browser-tests/partials.js
+++ b/test/browser-tests/partials.js
@@ -304,6 +304,18 @@ test( 'Partials with expressions may also have context', function( t ) {
 	t.htmlEqual( fixture.innerHTML, 'inverted - 1 : normal - 2');
 });
 
+test( 'Partials with context should still have access to special refs (#2164)', t => {
+	new Ractive({
+		el: fixture,
+		template: '{{>foo bar.baz}}',
+		partials: {
+			foo: `{{ @keypath + '.bop' }}`
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'bar.baz.bop' );
+});
+
 test( 'Partials .toString() works when not the first child of parent (#1163)', t => {
 	const ractive = new Ractive({
 		template: '<div>Foo {{>foo}}</div>',


### PR DESCRIPTION
This looks a little weird, but it kinda makes sense that keypath models should hand back their value as their keypath. The other route I looked at, using `get()` from `ExpressionProxy`, causes other tangential breakage. Does this look right?