### PR TITLE
clear mappings on component rebind to avoid shuffling issues - fixes #2147

### DIFF
--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -216,6 +216,7 @@ export default class Component extends Item {
 
 		// update relevant mappings
 		const viewmodel = this.instance.viewmodel;
+		viewmodel.mappings = {};
 
 		if ( this.template.a ) {
 			Object.keys( this.template.a ).forEach( localKey => {


### PR DESCRIPTION
The issue here is that the component gets an implicit mapping to a particular model nested on its parent and, on rebind, it finds the old implicit mapping to the now wrong model and rebinds to it. This just empties the mappings on rebind to let the re-resolution happen naturally. This is another one for which I'm not positive that this is the best approach. Is there a better way to handle it?

Thanks to @ISNIT0 and @heavyk for test cases and taking a swing at this. It was deep and interesting spelunk through the internals of shuffling.