### PR TITLE
Symlinks for keypaths - RFC

### DIFF
--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -142,6 +142,9 @@ function initialiseProperties ( ractive ) {
 	// observers
 	ractive._observers = [];
 
+	// links
+	ractive._links = {};
+
 	if(!ractive.component){
 		ractive.root = ractive;
 		ractive.parent = ractive.container = null; // TODO container still applicable?

--- a/src/Ractive/prototype.js
+++ b/src/Ractive/prototype.js
@@ -10,6 +10,7 @@ import findParent from './prototype/findParent';
 import fire from './prototype/fire';
 import get from './prototype/get';
 import insert from './prototype/insert';
+import link from './prototype/link';
 import merge from './prototype/merge';
 import observe from './prototype/observe';
 import observeList from './prototype/observeList';
@@ -32,6 +33,7 @@ import subtract from './prototype/subtract';
 import teardown from './prototype/teardown';
 import toggle from './prototype/toggle';
 import toHTML from './prototype/toHTML';
+import unlink from './prototype/unlink';
 import unrender from './prototype/unrender';
 import unshift from './prototype/unshift';
 import update from './prototype/update';
@@ -50,6 +52,7 @@ export default {
 	fire,
 	get,
 	insert,
+	link,
 	merge,
 	observe,
 	observeList,
@@ -75,6 +78,7 @@ export default {
 	toggle,
 	toHTML,
 	toHtml: toHTML,
+	unlink,
 	unrender,
 	unshift,
 	update,

--- a/src/Ractive/prototype/link.js
+++ b/src/Ractive/prototype/link.js
@@ -1,0 +1,72 @@
+import { splitKeypath } from '../../shared/keypaths';
+import runloop from '../../global/runloop';
+import Promise from '../../utils/Promise';
+
+export default function link( there, here ) {
+	if ( here === there || (there + '.').indexOf( here + '.' ) === 0 || (here + '.').indexOf( there + '.' ) === 0 ) {
+		throw new Error( 'A keypath cannot be linked to itself.' );
+	}
+
+	let unlink, run;
+
+	let ln = this._links[ here ];
+
+	if ( ln ) {
+		if ( ln.source.model.str !== there || ln.dest.model.str !== here ) {
+			unlink = this.unlink( here );
+		} else {
+			return Promise.resolve( true );
+		}
+	}
+
+	run = runloop.start();
+
+	ln = new Link( this.viewmodel.joinAll( splitKeypath( there ) ), this.viewmodel.joinAll( splitKeypath( here ) ), this );
+	this._links[ here ] = ln;
+	ln.source.handleChange();
+
+	runloop.end();
+
+	return Promise.all( [ unlink, run ] );
+}
+
+class Link {
+	constructor ( source, dest, ractive ) {
+		this.source = new LinkSide( source, this );
+		this.dest = new LinkSide( dest, this );
+		this.ractive = ractive;
+		this.locked = false;
+		this.initialValue = dest.get();
+	}
+
+	sync ( side ) {
+		if ( !this.locked ) {
+			this.locked = true;
+
+			if ( side === this.dest ) {
+				this.source.model.set( this.dest.model.get() );
+			} else {
+				this.dest.model.set( this.source.model.get() );
+			}
+
+			this.locked = false;
+		}
+	}
+
+	unlink () {
+		this.source.model.unregister( this.source );
+		this.dest.model.unregister( this.dest );
+	}
+}
+
+class LinkSide {
+	constructor ( model, owner ) {
+		this.model = model;
+		this.owner = owner;
+		model.register( this );
+	}
+
+	handleChange () {
+		this.owner.sync( this );
+	}
+}

--- a/src/Ractive/prototype/teardown.js
+++ b/src/Ractive/prototype/teardown.js
@@ -21,6 +21,8 @@ export default function Ractive$teardown () {
 	this.shouldDestroy = true;
 	const promise = ( this.fragment.rendered ? this.unrender() : Promise.resolve() );
 
+	Object.keys( this._links ).forEach( k => this._links[k].unlink() );
+
 	teardownHook.fire( this );
 
 	return promise;

--- a/src/Ractive/prototype/unlink.js
+++ b/src/Ractive/prototype/unlink.js
@@ -1,3 +1,5 @@
+import Promise from '../../utils/Promise';
+
 export default function unlink( here ) {
 	let ln = this._links[ here ];
 
@@ -5,5 +7,7 @@ export default function unlink( here ) {
 		ln.unlink();
 		delete this._links[ here ];
 		return this.set( here, ln.intialValue );
+	} else {
+		return Promise.resolve( true );
 	}
 }

--- a/src/Ractive/prototype/unlink.js
+++ b/src/Ractive/prototype/unlink.js
@@ -1,0 +1,9 @@
+export default function unlink( here ) {
+	let ln = this._links[ here ];
+
+	if ( ln ) {
+		ln.unlink();
+		delete this._links[ here ];
+		return this.set( here, ln.intialValue );
+	}
+}

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -282,6 +282,8 @@ export default class Component extends Item {
 			removeFromArray( instance.el.__ractive_instances__, instance );
 		}
 
+		Object.keys( instance._links ).forEach( k => instance._links[k].unlink() );
+
 		teardownHook.fire( instance );
 	}
 

--- a/test/browser-tests/methods/link.js
+++ b/test/browser-tests/methods/link.js
@@ -1,0 +1,80 @@
+import { test } from 'qunit';
+
+test( 'Keypaths can be linked', t => {
+	let ractive = new Ractive({
+		el: fixture,
+		template: '{{ foo }} {{ bar.baz.bat }}',
+		data: { bar: { baz: { bat: 'linked' } } }
+	});
+
+	t.htmlEqual( fixture.innerHTML, ' linked' );
+	ractive.link( 'bar.baz.bat', 'foo' );
+	t.htmlEqual( fixture.innerHTML, 'linked linked' );
+	ractive.set( 'foo', 'bop' );
+	t.htmlEqual( fixture.innerHTML, 'bop bop' );
+	ractive.set( 'bar.baz.bat', 'bip' );
+	t.htmlEqual( fixture.innerHTML, 'bip bip' );
+});
+
+test( 'Deep references on links should work as expected', t => {
+	let ractive = new Ractive({
+		el: fixture,
+		template: '{{ person.name }} is {{ person.status }}',
+		data: {
+			people: [
+				{ name: 'Rich', status: 'The Man' },
+				{ name: 'Marty', status: 'Awesome&tm;' }
+			]
+		}
+	});
+
+	t.equal( fixture.innerHTML, ' is ' );
+	ractive.link( 'people.0', 'person' );
+	t.htmlEqual( fixture.innerHTML, 'Rich is The Man' );
+	ractive.unlink( 'person' );
+	t.equal( fixture.innerHTML, ' is ' );
+	ractive.link( 'people.1', 'person' );
+	t.htmlEqual( fixture.innerHTML, 'Marty is Awesome&tm;' );
+});
+
+test( 'Re-linking overwrites the existing link', t => {
+	let ractive = new Ractive({
+		el: fixture,
+		template: '{{ dog.name }}',
+		data: { dogs: [ { name: 'Abel' }, { name: 'John' } ] }
+	});
+
+	t.equal( fixture.innerHTML, '' );
+	ractive.link( 'dogs.0', 'dog' );
+	t.equal( fixture.innerHTML, 'Abel' );
+	ractive.link( 'dogs.1', 'dog' );
+	t.equal( fixture.innerHTML, 'John' );
+});
+
+// only for non-mapped links
+test( 'Links can be set to nested paths', t => {
+	let ractive = new Ractive({
+		el: fixture,
+		template: '{{ foo.baz.bar }}',
+		data: { bippy: { boppy: { bar: 1 } } }
+	});
+
+	t.htmlEqual( fixture.innerHTML, '' );
+	ractive.link( 'bippy.boppy', 'foo.baz' );
+	t.htmlEqual( fixture.innerHTML, '1' );
+});
+
+test( 'Links cannot have overlapping paths', t => {
+	let ractive = new Ractive({
+		el: fixture,
+		template: '',
+	});
+
+	t.throws( () => {
+		ractive.link( 'foo.bar.baz', 'foo' );
+	}, /to itself/ );
+
+	t.throws( () => {
+		ractive.link( 'foo', 'foo.bar.baz' );
+	}, /to itself/ );
+});


### PR DESCRIPTION
This is a port of #1722 to the lovely new Model replacement for viewmodel and friends. It basically allows you to create a link between two keypaths that makes them equivalent, which is particularly handy for master-detail type scenarios. For instance:

```html
<ul>
  {{#each items}}
    <li on-click="link(@keypath, 'current')">{{.name}} {{.number}}</li>
  {{/each}}
</ul>
<button on-click="push('items', {})">Add</button>
<div>
  Name: <input value="{{ current.name }}" /><br/>
  Number: <input value="{{ current.number }}" />
</div>
```

This passes the tests that were added with #1722, but there probably need to be a few more. I would greatly appreciate any feedback on concept, construction, or further tests.