### PR TITLE
Allow components to get a special alternate context via 'this' mapping - RFC

### DIFF
--- a/src/Ractive/prototype/get.js
+++ b/src/Ractive/prototype/get.js
@@ -13,10 +13,14 @@ export default function Ractive$get ( keypath ) {
 		// if this is an inline component, we may need to create
 		// an implicit mapping
 		if ( this.component ) {
-			model = resolveReference( this.component.parentFragment, key );
+			if ( this.viewmodel.has( 'this' ) && this.viewmodel.joinKey( 'this' ).has( key ) ) {
+				keys.unshift( 'this' );
+			} else {
+				model = resolveReference( this.component.parentFragment, key );
 
-			if ( model ) {
-				this.viewmodel.map( key, model );
+				if ( model ) {
+					this.viewmodel.map( key, model );
+				}
 			}
 		}
 	}

--- a/src/Ractive/prototype/get.js
+++ b/src/Ractive/prototype/get.js
@@ -2,7 +2,21 @@ import { splitKeypath } from '../../shared/keypaths';
 import resolveReference from '../../view/resolvers/resolveReference';
 
 export default function Ractive$get ( keypath ) {
-	if ( !keypath ) return this.viewmodel.get( true );
+	if ( !keypath ) {
+		const result = this.viewmodel.get( true );
+
+		// merge in alt context if available
+		if ( this.component && result.hasOwnProperty( 'this' ) ) {
+			for ( let k in result.this ) {
+				if ( !result.hasOwnProperty( k ) ) {
+					result[k] = result.this[k];
+				}
+			}
+			delete result.this;
+		}
+
+		return result;
+	}
 
 	const keys = splitKeypath( keypath );
 	const key = keys[0];

--- a/src/Ractive/prototype/set.js
+++ b/src/Ractive/prototype/set.js
@@ -28,14 +28,22 @@ export default function Ractive$set ( keypath, value ) {
 
 
 function set ( ractive, keypath, value ) {
+	const keys = splitKeypath( keypath );
+	const model = ractive.viewmodel;
+
 	if ( typeof value === 'function' ) value = bind( value, ractive );
 
 	if ( /\*/.test( keypath ) ) {
-		ractive.viewmodel.findMatches( splitKeypath( keypath ) ).forEach( model => {
+		model.findMatches( keys ).forEach( model => {
 			model.set( value );
 		});
 	} else {
-		const model = ractive.viewmodel.joinAll( splitKeypath( keypath ) );
-		model.set( value );
+		// prefer component alternate context to data
+		if ( ractive.component && !model.has( keys[0] ) && model.has( 'this' ) ) {
+			keys.unshift( 'this' );
+			ractive.viewmodel.joinAll( keys ).set( value );
+		} else {
+			ractive.viewmodel.joinAll( keys ).set( value );
+		}
 	}
 }

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -135,6 +135,17 @@ export default class EventDirective {
 			event.index = this.parentFragment.indexRefs;
 
 			if ( passedArgs ) passedArgs.unshift( event );
+
+			// check to see if we need to adjust the keypath
+			if ( this.ractive.component ) {
+				const mappings = this.ractive.viewmodel.mappings;
+				for ( let k in mappings ) {
+					if ( event.keypath.indexOf( mappings[k].getKeypath() ) === 0 ) {
+						event.keypath = event.keypath.replace( mappings[k].getKeypath(), k );
+						break;
+					}
+				}
+			}
 		}
 
 		if ( this.method ) {

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -142,6 +142,9 @@ export default class EventDirective {
 				for ( let k in mappings ) {
 					if ( event.keypath.indexOf( mappings[k].getKeypath() ) === 0 ) {
 						event.keypath = event.keypath.replace( mappings[k].getKeypath(), k );
+						if ( k === 'this' ) {
+							event.keypath = event.keypath.replace( 'this.', '' );
+						}
 						break;
 					}
 				}

--- a/src/view/resolvers/resolveAmbiguousReference.js
+++ b/src/view/resolvers/resolveAmbiguousReference.js
@@ -35,6 +35,12 @@ export default function resolveAmbiguousReference ( fragment, ref ) {
 
 				return fragment.context.joinAll( keys );
 			}
+
+			// check special 'this' mapping to see if we can resolve there
+			if ( fragment.ractive.component && fragment.context.has( 'this' ) ) {
+				const altContext = fragment.context.joinKey( 'this' );
+				if ( altContext.has( key ) ) return altContext.joinAll( keys );
+			}
 		}
 
 		if ( fragment.componentParent && !fragment.ractive.isolated ) {

--- a/test/browser-tests/components/data-and-mappings.js
+++ b/test/browser-tests/components/data-and-mappings.js
@@ -1189,3 +1189,44 @@ test( 'Components with alt context should merge context for data get', t => {
 	t.equal( data.lap, 10 );
 	t.equal( data.biz, 'buzz' );
 });
+
+test( 'Alt context should work in a loop', t => {
+	const Foo = Ractive.extend({
+		template: '',
+		data() { return { dogGoes: 'woof' }; }
+	});
+
+	const r = new Ractive({
+		el: fixture,
+		template: `
+			{{#things}}
+				<Foo this='{{this}}'/>
+			{{/}}
+		`,
+		components: { Foo },
+		data: {
+			things: [
+				{ bar: true, zip: true},
+				{ qux: true, zap: true },
+			]
+		}
+	});
+
+	const comps = r.findAllComponents();
+
+	// ensure model is being passed
+	t.equal( comps[0].get('bar'), true);
+	t.equal( comps[0].get('zip'), true);
+
+	t.equal( comps[1].get('qux'), true);
+	t.equal( comps[1].get('zap'), true);
+
+	// and ensure other object's properties in `things` aren't being shared
+	t.strictEqual( comps[0].get('qux'), undefined);
+	t.strictEqual( comps[0].get('zap'), undefined);
+	t.equal( comps[0].get('dogGoes'), 'woof');
+
+	t.strictEqual( comps[1].get('bar'), undefined);
+	t.strictEqual( comps[1].get('zip'), undefined);
+	t.equal( comps[1].get('dogGoes'), 'woof');
+});

--- a/test/browser-tests/components/data-and-mappings.js
+++ b/test/browser-tests/components/data-and-mappings.js
@@ -1164,3 +1164,28 @@ test( 'Components with alt context should have correct event context', t => {
 	t.equal( btns.length, 3 );
 	btns.forEach( b => b.click() );
 });
+
+test( 'Components with alt context should merge context for data get', t => {
+	const Foo = Ractive.extend({
+		template: '',
+		data() { return { bar: 'bop', biz: 'buzz', lap: 10 }; }
+	});
+
+	const r = new Ractive({
+		el: fixture,
+		components: { Foo },
+		template: '<Foo this="{{.}}" bar="what" />',
+		data: {
+			foo: 'bar',
+			bar: 'baz',
+			lap: 22
+		}
+	});
+
+	const f = r.findComponent( 'Foo' );
+	const data = f.get();
+	t.equal( data.foo, 'bar' );
+	t.equal( data.bar, 'what' );
+	t.equal( data.lap, 10 );
+	t.equal( data.biz, 'buzz' );
+});

--- a/test/browser-tests/events/misc.js
+++ b/test/browser-tests/events/misc.js
@@ -260,6 +260,40 @@ try {
 			});
 		}, /invalid input/i );
 	});
+
+	test( 'component events in a mapped context have their keypath adjusted to the mapping', t => {
+		const Foo = Ractive.extend({
+			template: `
+				{{#with mapped}}<button on-click="test1(event)">Click Me</button>{{/with}}
+				{{#with mapped.foo}}<button on-click="test2(event)">Click Me</button>{{/with}}
+				{{#with foo.bar}}<button on-click="test3(event)">Click Me</button>{{/with}}
+			`,
+			data() { return { foo: { bar: 'yep' } }; },
+			test1(event) {
+				t.equal( event.keypath, 'mapped' );
+				t.equal( event.context.foo, 'bar' );
+			},
+			test2(event) {
+				t.equal( event.keypath, 'mapped.foo' );
+				t.equal( event.context, 'bar' );
+			},
+			test3(event) {
+				t.equal( event.keypath, 'foo.bar' );
+				t.equal( event.context, 'yep' );
+			}
+		});
+
+		const r = new Ractive({
+			el: fixture,
+			components: { Foo },
+			template: '<Foo mapped="{{some.deep.key.path}}" />',
+			data: { some: { deep: { key: { path: { foo: 'bar' } } } } }
+		});
+
+		let btns = r.findAll( 'button' );
+		t.equal( btns.length, 3 );
+		btns.forEach( b => b.click() );
+	});
 } catch ( err ) {
 	// do nothing
 }

--- a/test/browser-tests/render/components.js
+++ b/test/browser-tests/render/components.js
@@ -68,3 +68,35 @@ test( 'Top-level list sections in components do not cause elements to be out of 
 
 	t.htmlEqual( fixture.innerHTML, '<h1>Names</h1><p>one</p><p>two</p><p>three</p><p>four</p>' );
 });
+
+test( 'Components can be provided an alternate context with a "this" mapping (#2166)', t => {
+	const Foo = Ractive.extend({
+		template: '{{foo.bop}} {{bar.baz}}'
+	});
+	const Bar = Ractive.extend({
+		template: '{{bar.baz}} {{bat + 10}}'
+	});
+
+	const r = new Ractive({
+		el: fixture,
+		template: '<Foo this="{{.}}" /> <Bar this="{{foo}}" />',
+		components: { Foo, Bar },
+		data: {
+			foo: {
+				bop: 'infoo',
+				bar: {
+					baz: 'foobaz'
+				},
+				bat: 32
+			},
+			bar: {
+				baz: 'inbar'
+			}
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'infoo inbar foobaz 42' );
+	r.set( 'foo.bop', 'stillinfoo' );
+	r.add( 'foo.bat', 4200 );
+	t.htmlEqual( fixture.innerHTML, 'stillinfoo inbar foobaz 4242' );
+});

--- a/test/browser-tests/render/components.js
+++ b/test/browser-tests/render/components.js
@@ -68,35 +68,3 @@ test( 'Top-level list sections in components do not cause elements to be out of 
 
 	t.htmlEqual( fixture.innerHTML, '<h1>Names</h1><p>one</p><p>two</p><p>three</p><p>four</p>' );
 });
-
-test( 'Components can be provided an alternate context with a "this" mapping (#2166)', t => {
-	const Foo = Ractive.extend({
-		template: '{{foo.bop}} {{bar.baz}}'
-	});
-	const Bar = Ractive.extend({
-		template: '{{bar.baz}} {{bat + 10}}'
-	});
-
-	const r = new Ractive({
-		el: fixture,
-		template: '<Foo this="{{.}}" /> <Bar this="{{foo}}" />',
-		components: { Foo, Bar },
-		data: {
-			foo: {
-				bop: 'infoo',
-				bar: {
-					baz: 'foobaz'
-				},
-				bat: 32
-			},
-			bar: {
-				baz: 'inbar'
-			}
-		}
-	});
-
-	t.htmlEqual( fixture.innerHTML, 'infoo inbar foobaz 42' );
-	r.set( 'foo.bop', 'stillinfoo' );
-	r.add( 'foo.bat', 4200 );
-	t.htmlEqual( fixture.innerHTML, 'stillinfoo inbar foobaz 4242' );
-});


### PR DESCRIPTION
Per @Rich-Harris' plan in #2166, I was wondering what this would entail, and basic support appears to be super simple.

Should components with an alternate context have `this` resolution applied to `get`, `set`, and other non-template contexts? My gut says yes, but I could see where you may want to use `'this.whatever'` so that you don't have an overly broad external context interfere with internal properties. I'm on the fence. I guess it depends on how we expect component authors to use this, so please, component authors, throw in your two `LC_LITTLEST_CURRENCY`.

@martypdx suggested `@context` as the attribute name. Any opinions? I personally prefer `this` from an aesthetic standpoint, because all bike sheds should be green with blue trim.