### PR TITLE
ES2015 object literal property shorthand

### DIFF
--- a/src/parse/converters/expressions/primary/literal/objectLiteral/keyValuePair.js
+++ b/src/parse/converters/expressions/primary/literal/objectLiteral/keyValuePair.js
@@ -1,4 +1,4 @@
-import { KEY_VALUE_PAIR } from '../../../../../../config/types';
+import { KEY_VALUE_PAIR, REFERENCE } from '../../../../../../config/types';
 import readKey from '../../../shared/readKey';
 import readExpression from '../../../../readExpression';
 
@@ -10,6 +10,8 @@ export default function readKeyValuePair ( parser ) {
 	// allow whitespace between '{' and key
 	parser.allowWhitespace();
 
+	const refKey = parser.nextChar() !== '\'' && parser.nextChar() !== '"';
+
 	key = readKey( parser );
 	if ( key === null ) {
 		parser.pos = start;
@@ -18,6 +20,18 @@ export default function readKeyValuePair ( parser ) {
 
 	// allow whitespace between key and ':'
 	parser.allowWhitespace();
+
+	// es2015 shorthand property
+	if ( refKey && ( parser.nextChar() === ',' || parser.nextChar() === '}' ) ) {
+		return {
+			t: KEY_VALUE_PAIR,
+			k: key,
+			v: {
+				t: REFERENCE,
+				n: key
+			}
+		};
+	}
 
 	// next character must be ':'
 	if ( !parser.matchString( ':' ) ) {

--- a/src/parse/converters/expressions/primary/literal/objectLiteral/keyValuePair.js
+++ b/src/parse/converters/expressions/primary/literal/objectLiteral/keyValuePair.js
@@ -1,6 +1,7 @@
 import { KEY_VALUE_PAIR, REFERENCE } from '../../../../../../config/types';
 import readKey from '../../../shared/readKey';
 import readExpression from '../../../../readExpression';
+import { name as namePattern } from '../../../shared/patterns';
 
 export default function readKeyValuePair ( parser ) {
 	var start, key, value;
@@ -23,6 +24,10 @@ export default function readKeyValuePair ( parser ) {
 
 	// es2015 shorthand property
 	if ( refKey && ( parser.nextChar() === ',' || parser.nextChar() === '}' ) ) {
+		if ( !namePattern.test( key ) ) {
+			parser.error( `Expected a valid reference, but found '${key}' instead.` );
+		}
+
 		return {
 			t: KEY_VALUE_PAIR,
 			k: key,

--- a/src/parse/converters/expressions/shared/readKey.js
+++ b/src/parse/converters/expressions/shared/readKey.js
@@ -20,4 +20,6 @@ export default function readKey ( parser ) {
 	if ( token = parser.matchPattern( namePattern ) ) {
 		return token;
 	}
+
+	return null;
 }

--- a/test/__support/js/samples/parse.js
+++ b/test/__support/js/samples/parse.js
@@ -806,6 +806,18 @@ const parseTests = [
 		error: `Partial definitions can only be at the top level of the template, or immediately inside components at line 1 character 17:
 {{#if whatever}}{{#partial nope}}...{{/partial}}{{/if}}
                 ^----`
+	},
+	{
+		name: 'es2015 object literal property shorthand',
+		template: `{{ { foo, bar } }}`,
+		parsed: {v:3,t:[{t:2,x:{r:['foo','bar'],s:'{foo:_0,bar:_1}'}}]}
+	},
+	{
+		name: 'es2015 object literal shorthand reference only',
+		template: `{{ { 'foo' } }}`,
+		error: `Expected closing delimiter '}}' after reference at line 1 character 4:
+{{ { 'foo' } }}
+   ^----`
 	}
 ];
 

--- a/test/__support/js/samples/parse.js
+++ b/test/__support/js/samples/parse.js
@@ -818,6 +818,13 @@ const parseTests = [
 		error: `Expected closing delimiter '}}' after reference at line 1 character 4:
 {{ { 'foo' } }}
    ^----`
+	},
+	{
+		name: 'es2015 object literal shorthand no numbers',
+		template: `{{ { 4 } }}`,
+		error: `Expected a valid reference, but found '4' instead. at line 1 character 8:
+{{ { 4 } }}
+       ^----`
 	}
 ];
 


### PR DESCRIPTION
`{ foo, bar, baz: 'bat' }` because I'm used to doing it everywhere else now. Opinions?