### PR TITLE
Name bound checkboxes with duplicate values and crossing component boundaries - #2163

### DIFF
--- a/src/view/items/element/binding/RadioBinding.js
+++ b/src/view/items/element/binding/RadioBinding.js
@@ -13,7 +13,6 @@ export default class RadioBinding extends Binding {
 	constructor ( element ) {
 		super( element, 'checked' );
 
-		// TODO this should use getBindingGroup
 		this.siblings = getSiblings( this.ractive._guid + this.element.getAttribute( 'name' ) );
 		this.siblings.push( this );
 	}

--- a/src/view/items/element/binding/RadioNameBinding.js
+++ b/src/view/items/element/binding/RadioNameBinding.js
@@ -2,11 +2,10 @@ import Binding from './Binding';
 import getBindingGroup from './getBindingGroup';
 import handleDomEvent from './handleDomEvent';
 
-function getGroupValue () {
-	let i = this.bindings.length;
-	while ( i-- ) {
-		const binding = this.bindings[i];
-		if ( binding.node.checked ) return binding.element.getAttribute( 'value' );
+function getValue() {
+	const checked = this.bindings.filter( b => b.node.checked );
+	if ( checked.length > 0 ) {
+		return checked[0].element.getAttribute( 'value' );
 	}
 }
 
@@ -14,8 +13,12 @@ export default class RadioNameBinding extends Binding {
 	constructor ( element ) {
 		super( element, 'name' );
 
-		this.group = getBindingGroup( this.ractive._guid, 'radioname', this.model, getGroupValue );
+		this.group = getBindingGroup( 'radioname', this.model, getValue );
 		this.group.add( this );
+
+		if ( element.checked ) {
+			this.group.value = this.getValue();
+		}
 	}
 
 	bind () {
@@ -45,6 +48,7 @@ export default class RadioNameBinding extends Binding {
 		// If this <input> is the one that's checked, then the value of its
 		// `name` model gets set to its value
 		if ( this.node.checked ) {
+			this.group.value = this.getValue();
 			super.handleChange();
 		}
 	}

--- a/src/view/items/element/binding/getBindingGroup.js
+++ b/src/view/items/element/binding/getBindingGroup.js
@@ -1,16 +1,18 @@
 import { removeFromArray } from '../../../../utils/array';
 
-let groups = {};
-
-export default function getBindingGroup ( id, group, model, getValue ) {
-	const hash = id + group + model.getKeypath();
-	return groups[ hash ] || ( groups[ hash ] = new BindingGroup( model, getValue ) );
+export default function getBindingGroup ( group, model, getValue ) {
+	const hash = `${group}-bindingGroup`;
+	return model[hash] || ( model[ hash ] = new BindingGroup( hash, model, getValue ) );
 }
 
 class BindingGroup {
-	constructor ( model, getValue ) {
+	constructor ( hash, model, getValue ) {
 		this.model = model;
-		this.getValue = getValue;
+		this.hash = hash;
+		this.getValue = () => {
+			this.value = getValue.call(this);
+			return this.value;
+		};
 
 		this.bindings = [];
 	}
@@ -20,6 +22,7 @@ class BindingGroup {
 	}
 
 	bind () {
+		this.value = this.model.get();
 		this.model.registerTwowayBinding( this );
 		this.bound = true;
 	}
@@ -34,5 +37,6 @@ class BindingGroup {
 	unbind () {
 		this.model.unregisterTwowayBinding( this );
 		this.bound = false;
+		delete this.model[this.hash];
 	}
 }

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -245,7 +245,7 @@ test( 'Named checkbox bindings are kept in sync with data changes (#1610)', t =>
 	t.deepEqual( ractive.get( 'colors' ), [ 'green' ] );
 
 	fire( ractive.find( 'input' ), 'click' );
-	t.deepEqual( ractive.get( 'colors' ), [ 'red', 'green' ]);
+	t.deepEqual( ractive.get( 'colors' ), [ 'green', 'red' ]);
 });
 
 test( 'The model updates to reflect which radio input is checked at render time', t => {
@@ -887,4 +887,25 @@ test( '`twoway=0` is not mistaken for `twoway`', t => {
 
 	fire( input, 'change' );
 	t.equal( ractive.get( 'foo' ), undefined );
+});
+
+test( 'checkbox name binding with the same value on multiple boxes still works (#2163)', t => {
+	const common = {};
+	const r = new Ractive({
+		el: fixture,
+		template: '{{#each items}}<input type="checkbox" name="{{list}}" value="{{.}}" />{{/each}}',
+		data: { list: [ common ], items: [ common, common, {} ] }
+	});
+
+	const inputs = r.findAll( 'input' );
+	t.ok( inputs[0].checked && inputs[1].checked && !inputs[2].checked );
+
+	fire( inputs[0], 'click' );
+	t.ok( !( inputs[0].checked || inputs[1].checked || inputs[2].checked ) );
+
+	fire( inputs[2], 'click' );
+	t.ok( !inputs[0].checked && !inputs[1].checked && inputs[2].checked );
+
+	fire( inputs[1], 'click' );
+	t.ok( inputs[0].checked && inputs[1].checked && inputs[2].checked );
 });


### PR DESCRIPTION
Named checkbox bindings where more than one checkbox shared a value were not handled. This adds support for them. It also moves the group registry from a private object in binding group onto a property of the model so that components are guaranteed to get the same group if they share a model even if mappings or some other factor make the hash not equal. This should fix #2163.

I'm 99% sure this is correct, but I would like a sanity check on both functionality and construction.

I removed the RadioBinding TODO to move to binding group because they have no model in which to store the group.