### PR TITLE
Check ref name along with resolved name when resetting partials

### DIFF
--- a/src/Ractive/prototype/resetPartial.js
+++ b/src/Ractive/prototype/resetPartial.js
@@ -5,7 +5,7 @@ import { PARTIAL, COMPONENT, ELEMENT } from '../../config/types';
 function collect( source, name, dest ) {
 	source.forEach( item => {
 		// queue to rerender if the item is a partial and the current name matches
-		if ( item.type === PARTIAL && item.name === name ) {
+		if ( item.type === PARTIAL && ( item.refName ===  name || item.name === name ) ) {
 			dest.push( item );
 			return; // go no further
 		}

--- a/src/view/items/Partial.js
+++ b/src/view/items/Partial.js
@@ -7,14 +7,17 @@ export default class Partial extends Mustache {
 	bind () {
 		super.bind();
 
+		// keep track of the reference name for future resets
+		this.refName = this.template.r;
+
 		// name matches take priority over expressions
-		let template = this.template.r ? getPartialTemplate( this.ractive, this.template.r, this.parentFragment ) || null : null;
+		let template = this.refName ? getPartialTemplate( this.ractive, this.refName, this.parentFragment ) || null : null;
 
 		if ( template ) {
 			this.named = true;
 			this.setTemplate( this.template.r, template );
-		} else if ( ( !this.model || typeof this.model.get() !== 'string' ) && this.template.r ) {
-			this.setTemplate( this.template.r, template );
+		} else if ( ( !this.model || typeof this.model.get() !== 'string' ) && this.refName ) {
+			this.setTemplate( this.refName, template );
 		} else {
 			this.setTemplate( this.model.get() );
 		}
@@ -50,7 +53,17 @@ export default class Partial extends Mustache {
 	}
 
 	forceResetTemplate () {
-		this.partialTemplate = getPartialTemplate( this.ractive, this.name, this.parentFragment );
+		this.partialTemplate = undefined;
+
+		// on reset, check for the reference name first
+		if ( this.refName ) {
+			this.partialTemplate = getPartialTemplate( this.ractive, this.refName, this.parentFragment );
+		}
+
+		// then look for the resolved name
+		if ( !this.partialTemplate ) {
+			this.partialTemplate = getPartialTemplate( this.ractive, this.name, this.parentFragment );
+		}
 
 		if ( !this.partialTemplate ) {
 			warnOnceIfDebug( `Could not find template for partial '${this.name}'` );

--- a/test/browser-tests/partials.js
+++ b/test/browser-tests/partials.js
@@ -813,3 +813,20 @@ test( 'Inline partials can override instance partials if they exist on a node di
 
 	t.htmlEqual( fixture.innerHTML, '<div><span>Something happens one</span></div><div><span>Something happens two</span></div>' );
 });
+
+test( 'resetting a dynamic partial to its reference name should replace the partial (#2185)', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '{{>part1}}{{>part2}}',
+		partials: { part3: 'part3' },
+		data: { part1: 'part3', part2: 'nope' }
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'part3' );
+
+	r.resetPartial( 'part1', 'part1' );
+	t.htmlEqual( fixture.innerHTML, 'part1' );
+
+	r.resetPartial( 'part2', 'part2' );
+	t.htmlEqual( fixture.innerHTML, 'part1part2' );
+});


### PR DESCRIPTION
Partial names should always take precedent over partial name resolutions. I think that should also apply to resetting a partial name that resolved dynamically initially. See #2185, which this should fix.