### PR TITLE
First swing at escaping . in keypaths - RFC

### DIFF
--- a/src/Ractive/prototype/shared/makeArrayMethod.js
+++ b/src/Ractive/prototype/shared/makeArrayMethod.js
@@ -1,5 +1,5 @@
 import { isArray } from '../../../utils/is';
-import { normalise } from '../../../shared/keypaths';
+import { splitKeypath } from '../../../shared/keypaths';
 import runloop from '../../../global/runloop';
 import getNewIndices from '../../../shared/getNewIndices';
 
@@ -7,7 +7,7 @@ const arrayProto = Array.prototype;
 
 export default function ( methodName ) {
 	return function ( keypath, ...args ) {
-		const model = this.viewmodel.joinAll( normalise( keypath ).split( '.' ) );
+		const model = this.viewmodel.joinAll( splitKeypath( keypath ) );
 		const array = model.get();
 
 		if ( !isArray( array ) ) {

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -42,7 +42,7 @@ export default class Model {
 		if ( parent ) {
 			this.parent = parent;
 			this.root = parent.root;
-			this.key = key;
+			this.key = unescape( key );
 			this.isReadonly = parent.isReadonly;
 
 			if ( parent.value ) {
@@ -266,7 +266,7 @@ export default class Model {
 
 	getKeyModel () {
 		// TODO... different to IndexModel because key can never change
-		return new KeyModel( this.key );
+		return new KeyModel( escape( this.key ) );
 	}
 
 	getKeypathModel () {
@@ -275,12 +275,12 @@ export default class Model {
 
 	getKeypath () {
 		// TODO keypaths inside components... tricky
-		return this.parent.isRoot ? this.key : this.parent.getKeypath() + '.' + this.key;
+		return this.parent.isRoot ? escape( this.key ) : this.parent.getKeypath() + '.' + escape( this.key );
 	}
 
 	has ( key ) {
 		const value = this.get();
-		return value && hasProp.call( value, key );
+		return value && hasProp.call( value, unescape( key ) );
 	}
 
 	joinKey ( key ) {
@@ -444,4 +444,18 @@ export default class Model {
 		this.children.forEach( updateKeypathDependants );
 		if ( this.keypathModel ) this.keypathModel.handleChange();
 	}
+}
+
+function escape( key ) {
+	if ( typeof key === 'string' ) {
+		return key.replace( '.', '\\.' );
+	}
+	return key;
+}
+
+function unescape( key ) {
+	if ( typeof key === 'string' ) {
+		return key.replace( '\\.', '.' );
+	}
+	return key;
 }

--- a/src/parse/converters/expressions/primary/readReference.js
+++ b/src/parse/converters/expressions/primary/readReference.js
@@ -11,7 +11,7 @@ globals = /^(?:Array|console|Date|RegExp|decodeURIComponent|decodeURI|encodeURIC
 // keywords are not valid references, with the exception of `this`
 keywords = /^(?:break|case|catch|continue|debugger|default|delete|do|else|finally|for|function|if|in|instanceof|new|return|switch|throw|try|typeof|var|void|while|with)$/;
 
-var legalReference = /^[a-zA-Z$_0-9]+(?:(?:\.[a-zA-Z$_0-9]+)|(?:\[[0-9]+\]))*/;
+var legalReference = /^(?:[a-zA-Z$_0-9]|\\\.)+(?:(?:\.(?:[a-zA-Z$_0-9]|\\\.)+)|(?:\[[0-9]+\]))*/;
 var relaxedName = /^[a-zA-Z_$][-\/a-zA-Z_$0-9]*/;
 
 export default function readReference ( parser ) {

--- a/src/shared/keypaths.js
+++ b/src/shared/keypaths.js
@@ -1,9 +1,13 @@
-let refPattern = /\[\s*(\*|[0-9]|[1-9][0-9]+)\s*\]/g;
+const refPattern = /\[\s*(\*|[0-9]|[1-9][0-9]+)\s*\]/g;
 
 export function normalise ( ref ) {
 	return ref ? ref.replace( refPattern, '.$1' ) : '';
 }
 
 export function splitKeypath ( keypath ) {
-	return normalise( keypath ).split( '.' );
+	let parts = normalise( keypath ).replace( '\\.', '$' ).split( '.' );
+	for ( let i = parts.length - 1; i >= 0; i-- ) {
+		parts[i] = parts[i].replace( '$', '\\.' );
+	}
+	return parts;
 }

--- a/src/utils/getPotentialWildcardMatches.js
+++ b/src/utils/getPotentialWildcardMatches.js
@@ -1,3 +1,5 @@
+import { splitKeypath } from '../shared/keypaths';
+
 var starMaps = {};
 
 // This function takes a keypath such as 'foo.bar.baz', and returns
@@ -9,7 +11,7 @@ var starMaps = {};
 export default function getPotentialWildcardMatches ( keypath ) {
 	var keys, starMap, mapper, i, result, wildcardKeypath;
 
-	keys = keypath.split( '.' );
+	keys = splitKeypath( keypath );
 	if( !( starMap = starMaps[ keys.length ]) ) {
 		starMap = getStarMap( keys.length );
 	}

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -5,6 +5,7 @@ import createFunction from '../../../shared/createFunction';
 import { unbind } from '../../../shared/methodCallers';
 import noop from '../../../utils/noop';
 import resolveReference from '../../resolvers/resolveReference';
+import { splitKeypath } from '../../../shared/keypaths';
 
 const eventPattern = /^event(?:\.(.+))?$/;
 const argumentsPattern = /^arguments\.(\d*)$/;
@@ -52,7 +53,7 @@ export default class EventDirective {
 						// on-click="foo(event.node)"
 						return {
 							event: true,
-							keys: ref.length > 5 ? ref.slice( 6 ).split( '.' ) : [],
+							keys: ref.length > 5 ? splitKeypath( ref.slice( 6 ) ) : [],
 							unbind: noop
 						};
 					}

--- a/src/view/resolvers/ReferenceResolver.js
+++ b/src/view/resolvers/ReferenceResolver.js
@@ -1,4 +1,4 @@
-import { normalise } from '../../shared/keypaths';
+import { splitKeypath, normalise } from '../../shared/keypaths';
 import { removeFromArray } from '../../utils/array';
 import resolveAmbiguousReference from './resolveAmbiguousReference';
 
@@ -8,7 +8,7 @@ export default class ReferenceResolver {
 		this.reference = normalise( reference );
 		this.callback = callback;
 
-		this.keys = reference.split( '.' );
+		this.keys = splitKeypath( reference );
 		this.resolved = false;
 
 		// TODO the consumer should take care of addUnresolved

--- a/src/view/resolvers/resolveAmbiguousReference.js
+++ b/src/view/resolvers/resolveAmbiguousReference.js
@@ -1,10 +1,12 @@
+import { splitKeypath } from '../../shared/keypaths';
+
 function badReference ( key ) {
 	throw new Error( `An index or key reference (${key}) cannot have child properties` );
 }
 
 export default function resolveAmbiguousReference ( fragment, ref ) {
 	const localViewmodel = fragment.findContext().root;
-	const keys = ref.split( '.' );
+	const keys = splitKeypath( ref );
 	const key = keys[0];
 
 	let hasContextChain;

--- a/src/view/resolvers/resolveReference.js
+++ b/src/view/resolvers/resolveReference.js
@@ -1,4 +1,5 @@
 import resolveAmbiguousReference from './resolveAmbiguousReference';
+import { splitKeypath } from '../../shared/keypaths';
 
 export default function resolveReference ( fragment, ref ) {
 	let context = fragment.findContext();
@@ -16,7 +17,7 @@ export default function resolveReference ( fragment, ref ) {
 	if ( ref === '@key' ) return fragment.findRepeatingFragment().context.getKeyModel();
 
 	// ancestor references
-	if ( ref[0] === '~' ) return context.root.joinAll( ref.slice( 2 ).split( '.' ) );
+	if ( ref[0] === '~' ) return context.root.joinAll( splitKeypath( ref.slice( 2 ) ) );
 	if ( ref[0] === '.' ) {
 		const parts = ref.split( '/' );
 
@@ -32,7 +33,7 @@ export default function resolveReference ( fragment, ref ) {
 
 		// special case - `{{.foo}}` means the same as `{{./foo}}`
 		if ( ref[0] === '.' ) ref = ref.slice( 1 );
-		return context.joinAll( ref.split( '.' ) );
+		return context.joinAll( splitKeypath( ref ) );
 	}
 
 	return resolveAmbiguousReference( fragment, ref );

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -1172,6 +1172,18 @@ const renderTests = [
 		name: 'No whitespace other than leading/trailing line break is stripped (#1851)',
 		template: '<pre>\r\tfoo\n\t</pre><textarea>\r\n\tfoo\r\t</textarea>',
 		result: '<pre>\tfoo\n\t</pre><textarea>\tfoo\r\t</textarea>'
+	},
+	{
+		name: `Escaped '.'s in keypaths`,
+		template: `{{foo\\.bar}}{{foo.bar\\.baz}}{{foo.bar.baz}}`,
+		data: { 'foo.bar': 1, foo: { 'bar.baz': 2, bar: { baz: 3 } } },
+		result: '123'
+	},
+	{
+		name: `Escaped '.'s in refined keypaths`,
+		template: `{{.['foo.bar']}}{{foo['bar.baz']}}{{foo['bar']['baz']}}`,
+		data: { 'foo.bar': 1, foo: { 'bar.baz': 2, bar: { baz: 3 } } },
+		result: '123'
 	}
 ];
 

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -1184,6 +1184,12 @@ const renderTests = [
 		template: `{{.['foo.bar']}}{{foo['bar.baz']}}{{foo['bar']['baz']}}`,
 		data: { 'foo.bar': 1, foo: { 'bar.baz': 2, bar: { baz: 3 } } },
 		result: '123'
+	},
+	{
+		name: `Escaped '.'s in reference expressions`,
+		template: `{{foo[key]}}`,
+		data: { foo: { 'bar.baz': 'yep' }, key: 'bar.baz' },
+		result: 'yep'
 	}
 ];
 

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -1513,6 +1513,29 @@ test( 'Promise.all works with non-promises (#1642)', t => {
 	});
 });
 
+test( 'Setting an escaped . keypath', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '{{ foo\\.bar }}',
+		data: {}
+	});
+
+	t.htmlEqual( fixture.innerHTML, '' );
+	r.set( 'foo\\.bar', 'yep' );
+	t.htmlEqual( fixture.innerHTML, 'yep' );
+});
+
+test( 'Getting an escaped . keypath', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{ .['foo.bar'] }}`,
+		data: { 'foo.bar': 'yep' }
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'yep' );
+	t.equal( r.get( 'foo\\.bar' ), 'yep' );
+});
+
 if ( hasUsableConsole ) {
 	test( 'Ractive.DEBUG can be changed', t => {
 		t.expect( 0 );


### PR DESCRIPTION
__Probably post 0.8__

This is a fairly requested feature that I believe was present at one point and removed due to complexity. After the massive awesome `Model` changes from @martypdx and @Rich-Harris I think a lot of the complexity has been reduced. I needed a mental break from the day job, so I figured I'd take a swing at this.

All of the tests pass, and the following now works as you'd expect:
```html
{{ foo\.bar }} {{ foo.bar\.baz }} {{ foo.bar.baz }}
{{ .['foo.bar'] }} {{ foo['bar.baz'] }} {{ foo['bar']['baz'] }} {{ foo[key] }}
```
Data:
```js
{
  'foo.bar': 'works1',
  foo: { 'bar.baz': 'works2', bar: { baz: 'still works' } },
  key: 'bar.baz'
}
```
Output:
```
works1 works2 still works
works1 works2 still works works2
```

### So...

If you see anything I missed or screwed up horribly or have some more tests to apply, please feel free to mention them or push them to this branch.