### PR TITLE
Various textarea content changes: binding, updates, etc - RFC

### DIFF
--- a/src/parse/_parse.js
+++ b/src/parse/_parse.js
@@ -54,7 +54,8 @@ StandardParser = Parser.extend({
 
 		this.interpolate = {
 			script: !options.interpolate || options.interpolate.script !== false,
-			style: !options.interpolate || options.interpolate.style !== false
+			style: !options.interpolate || options.interpolate.style !== false,
+			textarea: true
 		};
 
 		if ( options.sanitize === true ) {

--- a/src/parse/converters/readElement.js
+++ b/src/parse/converters/readElement.js
@@ -166,7 +166,7 @@ function readElement ( parser ) {
 
 		// Special case - if we open a script element, further tags should
 		// be ignored unless they're a closing script element
-		if ( lowerCaseName === 'script' || lowerCaseName === 'style' ) {
+		if ( lowerCaseName === 'script' || lowerCaseName === 'style' || lowerCaseName === 'textarea' ) {
 			parser.inside = lowerCaseName;
 		}
 

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -16,6 +16,7 @@ import { createElement, matches } from '../../utils/dom';
 import { html, svg } from '../../config/namespaces';
 import { defineProperty } from '../../utils/object';
 import selectBinding from './element/binding/selectBinding';
+import { detachNode } from '../../utils/dom';
 
 function makeDirty ( query ) {
 	query.makeDirty();
@@ -145,10 +146,7 @@ export default class Element extends Item {
 	detach () {
 		if ( this.decorator ) this.decorator.unrender();
 
-		const parentNode = this.node.parentNode;
-		if ( parentNode ) parentNode.removeChild( this.node );
-
-		return this.node;
+		return detachNode( this.node );
 	}
 
 	find ( selector ) {

--- a/src/view/items/Interpolator.js
+++ b/src/view/items/Interpolator.js
@@ -2,10 +2,11 @@ import { doc } from '../../config/environment';
 import { escapeHtml } from '../../utils/html';
 import { safeToStringValue } from '../../utils/dom';
 import Mustache from './shared/Mustache';
+import { detachNode } from '../../utils/dom';
 
 export default class Interpolator extends Mustache {
 	detach () {
-		return this.node.parentNode.removeChild( this.node );
+		return detachNode( this.node );
 	}
 
 	firstNode () {

--- a/src/view/items/Text.js
+++ b/src/view/items/Text.js
@@ -2,6 +2,7 @@ import { doc } from '../../config/environment';
 import { TEXT } from '../../config/types';
 import { escapeHtml } from '../../utils/html';
 import Item from './shared/Item';
+import { detachNode } from '../../utils/dom';
 
 export default class Text extends Item {
 	constructor ( options ) {
@@ -14,10 +15,7 @@ export default class Text extends Item {
 	}
 
 	detach () {
-		if ( !this.node.parentNode ) {
-			throw new Error( 'TODO an unexpected situation arose' );
-		}
-		return this.node.parentNode.removeChild( this.node );
+		return detachNode( this.node );
 	}
 
 	firstNode () {

--- a/src/view/items/Triple.js
+++ b/src/view/items/Triple.js
@@ -2,6 +2,7 @@ import { createDocumentFragment, matches } from '../../utils/dom';
 import Mustache from './shared/Mustache';
 import insertHtml from './triple/insertHtml';
 import { decodeCharacterReferences } from '../../utils/html';
+import { detachNode } from '../../utils/dom';
 
 export default class Triple extends Mustache {
 	constructor ( options ) {
@@ -74,7 +75,7 @@ export default class Triple extends Mustache {
 	}
 
 	unrender () {
-		if ( this.nodes ) this.nodes.forEach( node => node.parentNode.removeChild( node ) );
+		if ( this.nodes ) this.nodes.forEach( node => detachNode( node ) );
 		this.rendered = false;
 	}
 

--- a/src/view/items/createItem.js
+++ b/src/view/items/createItem.js
@@ -9,6 +9,7 @@ import Option from './element/specials/Option';
 import Partial from './Partial';
 import Section from './Section';
 import Select from './element/specials/Select';
+import Textarea from './element/specials/Textarea';
 import Text from './Text';
 import Triple from './Triple';
 import Yielder from './Yielder';
@@ -28,7 +29,7 @@ const specialElements = {
 	input: Input,
 	option: Option,
 	select: Select,
-	textarea: Input // it may turn out we need a separate Textarea class, but until then...
+	textarea: Textarea
 };
 
 export default function createItem ( options ) {

--- a/src/view/items/element/binding/selectBinding.js
+++ b/src/view/items/element/binding/selectBinding.js
@@ -11,7 +11,7 @@ import RadioBinding from './RadioBinding';
 import RadioNameBinding from './RadioNameBinding';
 import SingleSelectBinding from './SingleSelectBinding';
 
-function isBindable ( attribute ) {
+export function isBindable ( attribute ) {
 	return attribute &&
 	       attribute.template.length === 1 &&
 	       attribute.template[0].t === INTERPOLATOR &&

--- a/src/view/items/element/specials/Textarea.js
+++ b/src/view/items/element/specials/Textarea.js
@@ -1,0 +1,32 @@
+import Input from './Input';
+import { isBindable } from '../binding/selectBinding';
+import runloop from '../../../../global/runloop';
+
+export default class Textarea extends Input {
+	constructor( options ) {
+		const template = options.template;
+
+		if ( template.f && (!template.a || !template.a.value) && isBindable( { template: template.f } ) ) {
+			if ( !template.a ) template.a = {};
+			template.a.value = template.f;
+			template.f = [];
+		}
+
+		super( options );
+	}
+
+	bubble () {
+		if ( !this.dirty ) {
+			this.dirty = true;
+
+			if ( this.rendered && !this.binding && this.fragment ) {
+				runloop.scheduleTask( () => {
+					this.dirty = false;
+					this.node.value = this.fragment.toString();
+				});
+			}
+
+			this.parentFragment.bubble(); // default behaviour
+		}
+	}
+}

--- a/test/browser-tests/forms.js
+++ b/test/browser-tests/forms.js
@@ -100,3 +100,28 @@ test( 'Resetting a form resets widgets with no bindings', t => {
 	t.equal( nodes.select.value, 'b' );
 	t.equal( nodes.textarea.value, 'qwert' );
 });
+
+test( 'textarea with html content and no bindings should render the html text as a normal textarea would (#2198)', t => {
+	new Ractive({
+		el: fixture,
+		template: '<textarea><div class="foo"><strong>bar</strong></div><p>WAT</p></textarea>'
+	});
+
+	t.equal( fixture.querySelector( 'textarea' ).value, '<div class="foo"><strong>bar</strong></div><p>WAT</p>' );
+});
+
+test( 'textareas without binding allow any template content (#2063)', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '<textarea><i>{{foo}}</i>{{bar}} {{{baz}}}</textarea>',
+		data: { foo: 'part1', bar: 'part2', baz: '<div>hello</div>' }
+	});
+
+	t.equal( fixture.querySelector( 'textarea' ).value, '<i>part1</i>part2 <div>hello</div>' );
+	r.set( 'foo', 'change1' );
+	t.equal( fixture.querySelector( 'textarea' ).value, '<i>change1</i>part2 <div>hello</div>' );
+	r.set( 'bar', 'change2' );
+	t.equal( fixture.querySelector( 'textarea' ).value, '<i>change1</i>change2 <div>hello</div>' );
+	r.set( 'baz', '<strong>change3</strong>' );
+	t.equal( fixture.querySelector( 'textarea' ).value, '<i>change1</i>change2 <strong>change3</strong>' );
+});

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -888,3 +888,33 @@ test( '`twoway=0` is not mistaken for `twoway`', t => {
 	fire( input, 'change' );
 	t.equal( ractive.get( 'foo' ), undefined );
 });
+
+test( 'textarea with a single interpolator as content should set up a twoway binding (#2197)', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '<textarea>{{foo}}</textarea>',
+		data: { foo: 'bar' }
+	});
+
+	t.equal( r.find( 'textarea' ).value, 'bar' );
+	r.set( 'foo', 'baz' );
+	t.equal( r.find( 'textarea' ).value, 'baz' );
+	r.find( 'textarea' ).value = 'bop';
+	r.updateModel( 'foo' );
+	t.equal( r.get( 'foo' ), 'bop' );
+});
+
+test( 'textarea with a single static interpolator as content should not set up a twoway binding', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '<textarea>[[foo]]</textarea>',
+		data: { foo: 'bar' }
+	});
+
+	t.equal( r.find( 'textarea' ).value, 'bar' );
+	r.set( 'foo', 'baz' );
+	t.equal( r.find( 'textarea' ).value, 'bar' );
+	r.find( 'textarea' ).value = 'bop';
+	r.updateModel( 'foo' );
+	t.equal( r.get( 'foo' ), 'baz' );
+});


### PR DESCRIPTION
There are a number of textarea issues outstanding, and I think this addresses them all in a fairly sane manner. #2011 #2063 #2099 #2197 #2198

* `textarea`s are treated like interpolated script tags by the parser, so content html is rendered as-is if there are no bindings.
* `textarea`s with a single non-static interpolator as content and that don't also have a value attribute are bound as if the content interpolator was the value binding
* `textarea`s with template content that updates (`bubble`s) will set their node value to their fragment `toString` after the runloop turn