### PR TITLE
Relative partial context - #1880

### DIFF
--- a/src/parse/converters/expressions/shared/readRefinement.js
+++ b/src/parse/converters/expressions/shared/readRefinement.js
@@ -4,8 +4,8 @@ import { name as namePattern } from './patterns';
 import readExpression from '../../readExpression';
 
 export default function readRefinement ( parser ) {
-	// if names are relaxed, refinement is strict, meaning no space between reference and refinement
-	if ( !parser.relaxedNames ) {
+	// some things call for strict refinement (partial names), meaning no space between reference and refinement
+	if ( !parser.strictRefinement ) {
 		parser.allowWhitespace();
 	}
 

--- a/src/parse/converters/expressions/shared/readRefinement.js
+++ b/src/parse/converters/expressions/shared/readRefinement.js
@@ -4,7 +4,10 @@ import { name as namePattern } from './patterns';
 import readExpression from '../../readExpression';
 
 export default function readRefinement ( parser ) {
-	parser.allowWhitespace();
+	// if names are relaxed, refinement is strict, meaning no space between reference and refinement
+	if ( !parser.relaxedNames ) {
+		parser.allowWhitespace();
+	}
 
 	// "." name
 	if ( parser.matchString( '.' ) ) {

--- a/src/parse/converters/mustache/readPartial.js
+++ b/src/parse/converters/mustache/readPartial.js
@@ -11,9 +11,9 @@ export default function readPartial ( parser, tag ) {
 	// blindly. Instead, we use the `relaxedNames` flag to indicate that
 	// `foo-bar` should be read as a single name, rather than 'subtract
 	// bar from foo'
-	parser.relaxedNames = true;
+	parser.relaxedNames = parser.strictRefinement = true;
 	const expression = readExpression( parser );
-	parser.relaxedNames = false;
+	parser.relaxedNames = parser.strictRefinement = false;
 
 	parser.allowWhitespace();
 	const context = readExpression( parser );

--- a/test/browser-tests/partials.js
+++ b/test/browser-tests/partials.js
@@ -813,3 +813,18 @@ test( 'Inline partials can override instance partials if they exist on a node di
 
 	t.htmlEqual( fixture.innerHTML, '<div><span>Something happens one</span></div><div><span>Something happens two</span></div>' );
 });
+
+test( `Partials can have context that starts with '.' (#1880)`, t => {
+	new Ractive({
+		el: fixture,
+		template: '{{#with foo}}{{>foo .bar}}{{/with}}',
+		data: {
+			foo: { bar: { baz: 'bat' } }
+		},
+		partials: {
+			foo: '{{.baz}}'
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'bat' );
+});


### PR DESCRIPTION
I ran into this in a late night coding session. The fix, more-or-less as suggested by @Crisfole, is to simply not allow whitespace in refinements if the relaxedNames flag is set. Any objections?

For reference in #1880, whitespace is normally allowed in refinements because all of the following are equivalent in js:
```js
const foo = { bar: 'baz' };
foo.bar;
// and
foo  .  bar;
// and
foo.
   bar;
// and
foo
  .bar;
// and
foo    ['bar'];
// and
foo
    [
       'bar'
];
```