### PR TITLE
More robust . escaping

### DIFF
--- a/src/Ractive/static/adaptors/magic.js
+++ b/src/Ractive/static/adaptors/magic.js
@@ -1,3 +1,5 @@
+import { escapeKey } from '../../../shared/keypaths';
+
 let magicAdaptor;
 
 try {
@@ -81,7 +83,7 @@ class MagicWrapper {
 			const originalDescriptor = Object.getOwnPropertyDescriptor( this.value, key );
 			this.originalDescriptors[ key ] = originalDescriptor;
 
-			const childKeypath = keypath ? `${keypath}.${key}` : key;
+			const childKeypath = keypath ? `${keypath}.${escapeKey( key )}` : escapeKey( key );
 
 			const descriptor = createOrWrapDescriptor( originalDescriptor, ractive, childKeypath );
 

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -9,6 +9,8 @@ import { isArray, isObject } from '../utils/is';
 import KeyModel from './specials/KeyModel';
 import KeypathModel from './specials/KeypathModel';
 
+const escapePattern = /\./g;
+const unescapePattern = /\\\./g;
 const hasProp = Object.prototype.hasOwnProperty;
 
 function updateFromBindings ( model ) {
@@ -460,14 +462,14 @@ export default class Model {
 
 function escape( key ) {
 	if ( typeof key === 'string' ) {
-		return key.replace( '.', '\\.' );
+		return key.replace( escapePattern, '\\.' );
 	}
 	return key;
 }
 
 function unescape( key ) {
 	if ( typeof key === 'string' ) {
-		return key.replace( '\\.', '.' );
+		return key.replace( unescapePattern, '.' );
 	}
 	return key;
 }

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -8,9 +8,8 @@ import getPrefixer from './helpers/getPrefixer';
 import { isArray, isObject } from '../utils/is';
 import KeyModel from './specials/KeyModel';
 import KeypathModel from './specials/KeypathModel';
+import { escapeKey, unescapeKey } from '../shared/keypaths';
 
-const escapePattern = /\./g;
-const unescapePattern = /\\\./g;
 const hasProp = Object.prototype.hasOwnProperty;
 
 function updateFromBindings ( model ) {
@@ -44,7 +43,7 @@ export default class Model {
 		if ( parent ) {
 			this.parent = parent;
 			this.root = parent.root;
-			this.key = unescape( key );
+			this.key = unescapeKey( key );
 			this.isReadonly = parent.isReadonly;
 
 			if ( parent.value ) {
@@ -268,7 +267,7 @@ export default class Model {
 
 	getKeyModel () {
 		// TODO... different to IndexModel because key can never change
-		return new KeyModel( escape( this.key ) );
+		return new KeyModel( escapeKey( this.key ) );
 	}
 
 	getKeypathModel () {
@@ -277,14 +276,14 @@ export default class Model {
 
 	getKeypath () {
 		// TODO keypaths inside components... tricky
-		return this.parent.isRoot ? escape( this.key ) : this.parent.getKeypath() + '.' + escape( this.key );
+		return this.parent.isRoot ? escapeKey( this.key ) : this.parent.getKeypath() + '.' + escapeKey( this.key );
 	}
 
 	has ( key ) {
 		const value = this.get();
 		if ( !value ) return false;
 
-		key = unescape( key );
+		key = unescapeKey( key );
 		if ( hasProp.call( value, key ) ) return true;
 
 		// We climb up the constructor chain to find if one of them contains the key
@@ -458,18 +457,4 @@ export default class Model {
 		this.children.forEach( updateKeypathDependants );
 		if ( this.keypathModel ) this.keypathModel.handleChange();
 	}
-}
-
-function escape( key ) {
-	if ( typeof key === 'string' ) {
-		return key.replace( escapePattern, '\\.' );
-	}
-	return key;
-}
-
-function unescape( key ) {
-	if ( typeof key === 'string' ) {
-		return key.replace( unescapePattern, '.' );
-	}
-	return key;
 }

--- a/src/shared/keypaths.js
+++ b/src/shared/keypaths.js
@@ -1,6 +1,5 @@
 const refPattern = /\[\s*(\*|[0-9]|[1-9][0-9]+)\s*\]/g;
-const escapePattern = /\\\./g;
-const unescapePattern = /\$/g;
+const splitPattern = /([^\\](?:\\\\)*)\./;
 const escapeKeyPattern = /\./g;
 const unescapeKeyPattern = /\\\./g;
 
@@ -17,11 +16,14 @@ export function normalise ( ref ) {
 }
 
 export function splitKeypath ( keypath ) {
-	let parts = normalise( keypath ).replace( escapePattern, '$' ).split( '.' );
-	for ( let i = parts.length - 1; i >= 0; i-- ) {
-		parts[i] = parts[i].replace( unescapePattern, '\\.' );
+	let parts = normalise( keypath ).split( splitPattern ),
+		result = [];
+
+	for ( let i = 0; i < parts.length; i += 2 ) {
+		result.push( parts[i] + ( parts[i + 1] || '' ) );
 	}
-	return parts;
+
+	return result;
 }
 
 export function unescapeKey ( key ) {

--- a/src/shared/keypaths.js
+++ b/src/shared/keypaths.js
@@ -1,11 +1,11 @@
 const refPattern = /\[\s*(\*|[0-9]|[1-9][0-9]+)\s*\]/g;
 const splitPattern = /([^\\](?:\\\\)*)\./;
-const escapeKeyPattern = /\./g;
-const unescapeKeyPattern = /\\\./g;
+const escapeKeyPattern = /\\|\./g;
+const unescapeKeyPattern = /((?:\\)+)\1|\\(\.)/g;
 
 export function escapeKey ( key ) {
 	if ( typeof key === 'string' ) {
-		return key.replace( escapeKeyPattern, '\\.' );
+		return key.replace( escapeKeyPattern, '\\$&' );
 	}
 
 	return key;
@@ -28,7 +28,7 @@ export function splitKeypath ( keypath ) {
 
 export function unescapeKey ( key ) {
 	if ( typeof key === 'string' ) {
-		return key.replace( unescapeKeyPattern, '.' );
+		return key.replace( unescapeKeyPattern, '$1$2' );
 	}
 
 	return key;

--- a/src/shared/keypaths.js
+++ b/src/shared/keypaths.js
@@ -1,6 +1,16 @@
 const refPattern = /\[\s*(\*|[0-9]|[1-9][0-9]+)\s*\]/g;
 const escapePattern = /\\\./g;
 const unescapePattern = /\$/g;
+const escapeKeyPattern = /\./g;
+const unescapeKeyPattern = /\\\./g;
+
+export function escapeKey ( key ) {
+	if ( typeof key === 'string' ) {
+		return key.replace( escapeKeyPattern, '\\.' );
+	}
+
+	return key;
+}
 
 export function normalise ( ref ) {
 	return ref ? ref.replace( refPattern, '.$1' ) : '';
@@ -12,4 +22,12 @@ export function splitKeypath ( keypath ) {
 		parts[i] = parts[i].replace( unescapePattern, '\\.' );
 	}
 	return parts;
+}
+
+export function unescapeKey ( key ) {
+	if ( typeof key === 'string' ) {
+		return key.replace( unescapeKeyPattern, '.' );
+	}
+
+	return key;
 }

--- a/src/shared/keypaths.js
+++ b/src/shared/keypaths.js
@@ -1,13 +1,15 @@
 const refPattern = /\[\s*(\*|[0-9]|[1-9][0-9]+)\s*\]/g;
+const escapePattern = /\\\./g;
+const unescapePattern = /\$/g;
 
 export function normalise ( ref ) {
 	return ref ? ref.replace( refPattern, '.$1' ) : '';
 }
 
 export function splitKeypath ( keypath ) {
-	let parts = normalise( keypath ).replace( '\\.', '$' ).split( '.' );
+	let parts = normalise( keypath ).replace( escapePattern, '$' ).split( '.' );
 	for ( let i = parts.length - 1; i >= 0; i-- ) {
-		parts[i] = parts[i].replace( '$', '\\.' );
+		parts[i] = parts[i].replace( unescapePattern, '\\.' );
 	}
 	return parts;
 }

--- a/src/view/resolvers/ReferenceExpressionProxy.js
+++ b/src/view/resolvers/ReferenceExpressionProxy.js
@@ -5,6 +5,7 @@ import resolveReference from './resolveReference';
 import resolve from './resolve';
 import { unbind } from '../../shared/methodCallers';
 import { removeFromArray } from '../../utils/array';
+import { escapeKey } from '../../shared/keypaths';
 
 export default class ReferenceExpressionProxy extends Model {
 	constructor ( fragment, template ) {
@@ -80,7 +81,7 @@ export default class ReferenceExpressionProxy extends Model {
 
 		this.isUnresolved = false;
 
-		const keys = this.members.map( model => model.get() );
+		const keys = this.members.map( model => escapeKey( model.get() ) );
 		const model = this.base.joinAll( keys );
 
 		if ( this.model ) {

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -1206,19 +1206,25 @@ const renderTests = [
 		name: `Escaped '.'s in keypaths`,
 		template: `{{foo\\.bar\\.baz}}{{foo.bar\\.baz}}{{foo.bar.baz}}`,
 		data: { 'foo.bar.baz': 1, foo: { 'bar.baz': 2, bar: { baz: 3 } } },
-		result: '123'
+		result: '123',
+		new_data: { 'foo\\.bar\\.baz': 3 },
+		new_result: '323'
 	},
 	{
 		name: `Escaped '.'s in refined keypaths`,
 		template: `{{.['foo.bar']}}{{foo['bar.baz']}}{{foo['bar']['baz']}}`,
 		data: { 'foo.bar': 1, foo: { 'bar.baz': 2, bar: { baz: 3 } } },
-		result: '123'
+		result: '123',
+		new_data: { 'foo\\.bar': 3 },
+		new_result: '323'
 	},
 	{
 		name: `Escaped '.'s in reference expressions`,
 		template: `{{foo[key]}}`,
 		data: { foo: { 'bar.baz': 'yep' }, key: 'bar.baz' },
-		result: 'yep'
+		result: 'yep',
+		new_data: { 'foo.bar\\.baz': 'nope' },
+		new_result: 'nope'
 	}
 ];
 

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -1204,8 +1204,8 @@ const renderTests = [
 	},
 	{
 		name: `Escaped '.'s in keypaths`,
-		template: `{{foo\\.bar}}{{foo.bar\\.baz}}{{foo.bar.baz}}`,
-		data: { 'foo.bar': 1, foo: { 'bar.baz': 2, bar: { baz: 3 } } },
+		template: `{{foo\\.bar\\.baz}}{{foo.bar\\.baz}}{{foo.bar.baz}}`,
+		data: { 'foo.bar.baz': 1, foo: { 'bar.baz': 2, bar: { baz: 3 } } },
 		result: '123'
 	},
 	{

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -1536,6 +1536,22 @@ test( 'Getting an escaped . keypath', t => {
 	t.equal( r.get( 'foo\\.bar\\.baz' ), 'yep' );
 });
 
+test( '$ can be used in keypaths', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{ $$ }}{{ .['..'] }}`,
+		data: { $$: 'get() works' }
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'get() works' );
+	t.equal( r.get( '$$' ), 'get() works' );
+
+	r.set( '$$', 'set() works as well' );
+
+	t.htmlEqual( fixture.innerHTML, 'set() works as well' );
+	t.equal( r.get( '$$' ), 'set() works as well' );
+});
+
 if ( hasUsableConsole ) {
 	test( 'Ractive.DEBUG can be changed', t => {
 		t.expect( 0 );

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -1516,24 +1516,24 @@ test( 'Promise.all works with non-promises (#1642)', t => {
 test( 'Setting an escaped . keypath', t => {
 	const r = new Ractive({
 		el: fixture,
-		template: '{{ foo\\.bar }}',
+		template: `{{ foo\\.bar\\.baz }}`,
 		data: {}
 	});
 
 	t.htmlEqual( fixture.innerHTML, '' );
-	r.set( 'foo\\.bar', 'yep' );
+	r.set( 'foo\\.bar\\.baz', 'yep' );
 	t.htmlEqual( fixture.innerHTML, 'yep' );
 });
 
 test( 'Getting an escaped . keypath', t => {
 	const r = new Ractive({
 		el: fixture,
-		template: `{{ .['foo.bar'] }}`,
-		data: { 'foo.bar': 'yep' }
+		template: `{{ .['foo.bar.baz'] }}`,
+		data: { 'foo.bar.baz': 'yep' }
 	});
 
 	t.htmlEqual( fixture.innerHTML, 'yep' );
-	t.equal( r.get( 'foo\\.bar' ), 'yep' );
+	t.equal( r.get( 'foo\\.bar\\.baz' ), 'yep' );
 });
 
 if ( hasUsableConsole ) {

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -1552,6 +1552,25 @@ test( '$ can be used in keypaths', t => {
 	t.equal( r.get( '$$' ), 'set() works as well' );
 });
 
+test( '. escapes can be escaped', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{ .['foo\\\\'].bar }}{{ .['foo\\\\.bar'] }}`,
+		data: { 'foo\\': { bar: 1 }, 'foo\\.bar': 2 }
+	});
+
+	t.htmlEqual( fixture.innerHTML, '12' );
+	t.equal( r.get( 'foo\\\\.bar' ), 1 );
+	t.equal( r.get( 'foo\\\\\\.bar' ), 2 );
+
+	r.set( 'foo\\\\.bar', 11 );
+	r.set( 'foo\\\\\\.bar', 12 );console.log(r.get());
+
+	t.htmlEqual( fixture.innerHTML, '1112' );
+	t.equal( r.get( 'foo\\\\.bar' ), 11 );
+	t.equal( r.get( 'foo\\\\\\.bar' ), 12 );
+});
+
 if ( hasUsableConsole ) {
 	test( 'Ractive.DEBUG can be changed', t => {
 		t.expect( 0 );


### PR DESCRIPTION
This PR addresses the following issues:

1. Multiple escapes in a single keypath - `ractive.get('foo\\.bar\\.baz')` now works correctly (was interpreted as `ractive.get('foo\\.bar.baz')` before).

2. `{{foo['bar.baz']}}` updates on `ractive.set('foo.bar\\.baz')`

3. `$`'s in keypaths aren't incorrectly converted to `.`

4. Backslashes can also be escaped, so calling `ractive.set('foo\\\\.bar', 1)` is the same as `ractive.set({ 'foo\\': { bar: 1 } })`