### PR TITLE
Template aliasing - RFC

### DIFF
--- a/src/config/types.js
+++ b/src/config/types.js
@@ -14,6 +14,7 @@ export const COMPONENT         = 15;
 export const YIELDER           = 16;
 export const INLINE_PARTIAL    = 17;
 export const DOCTYPE           = 18;
+export const ALIAS             = 19;
 
 export const NUMBER_LITERAL    = 20;
 export const STRING_LITERAL    = 21;

--- a/src/parse/converters/mustache/readAliases.js
+++ b/src/parse/converters/mustache/readAliases.js
@@ -1,0 +1,65 @@
+import readExpression from '../readExpression';
+import refineExpression from '../../utils/refineExpression';
+
+const legalAlias = /^(?:[a-zA-Z$_0-9]|\\\.)+(?:(?:(?:[a-zA-Z$_0-9]|\\\.)+)|(?:\[[0-9]+\]))*/;
+
+export default function readAliases( parser ) {
+	let aliases = [], alias, start = parser.pos;
+
+	parser.allowWhitespace();
+
+	alias = readAlias( parser );
+
+	if ( alias ) {
+		aliases.push( alias );
+
+		parser.allowWhitespace();
+
+		while ( parser.matchString(',') ) {
+			alias = readAlias( parser );
+
+			if ( !alias ) {
+				parser.error( 'Expected another alias.' );
+			}
+
+			aliases.push( alias );
+
+			parser.allowWhitespace();
+		}
+
+		return aliases;
+	}
+
+	parser.pos = start;
+	return null;
+}
+
+function readAlias( parser ) {
+	let expr, alias, start = parser.pos;
+
+	parser.allowWhitespace();
+
+	expr = readExpression( parser, [] );
+
+	if ( !expr ) {
+		parser.pos = start;
+		return null;
+	}
+
+	parser.allowWhitespace();
+
+	if ( !parser.matchPattern( /as/i ) ) {
+		parser.pos = start;
+		return null;
+	}
+
+	parser.allowWhitespace();
+
+	alias = parser.matchPattern( legalAlias );
+
+	if ( !alias ) {
+		parser.error( 'Expected a legal alias name.' );
+	}
+
+	return { n: alias, x: refineExpression( expr, {} ) };
+}

--- a/src/parse/converters/mustache/readAliases.js
+++ b/src/parse/converters/mustache/readAliases.js
@@ -2,8 +2,9 @@ import readExpression from '../readExpression';
 import refineExpression from '../../utils/refineExpression';
 
 const legalAlias = /^(?:[a-zA-Z$_0-9]|\\\.)+(?:(?:(?:[a-zA-Z$_0-9]|\\\.)+)|(?:\[[0-9]+\]))*/;
+const asRE = /^as/i;
 
-export default function readAliases( parser ) {
+export function readAliases( parser ) {
 	let aliases = [], alias, start = parser.pos;
 
 	parser.allowWhitespace();
@@ -11,6 +12,7 @@ export default function readAliases( parser ) {
 	alias = readAlias( parser );
 
 	if ( alias ) {
+		alias.x = refineExpression( alias.x, {} );
 		aliases.push( alias );
 
 		parser.allowWhitespace();
@@ -22,6 +24,7 @@ export default function readAliases( parser ) {
 				parser.error( 'Expected another alias.' );
 			}
 
+			alias.x = refineExpression( alias.x, {} );
 			aliases.push( alias );
 
 			parser.allowWhitespace();
@@ -34,7 +37,7 @@ export default function readAliases( parser ) {
 	return null;
 }
 
-function readAlias( parser ) {
+export function readAlias( parser ) {
 	let expr, alias, start = parser.pos;
 
 	parser.allowWhitespace();
@@ -48,7 +51,7 @@ function readAlias( parser ) {
 
 	parser.allowWhitespace();
 
-	if ( !parser.matchPattern( /as/i ) ) {
+	if ( !parser.matchPattern( asRE ) ) {
 		parser.pos = start;
 		return null;
 	}
@@ -61,5 +64,5 @@ function readAlias( parser ) {
 		parser.error( 'Expected a legal alias name.' );
 	}
 
-	return { n: alias, x: refineExpression( expr, {} ) };
+	return { n: alias, x: expr };
 }

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -102,6 +102,12 @@ export default class RepeatedFragment {
 		fragment.isIteration = true;
 
 		const model = this.context.joinKey( key );
+
+		// set up an iteration alias if there is one
+		if ( this.owner.template.z ) {
+			fragment.aliases = { [this.owner.template.z[0].n]: model };
+		}
+
 		return fragment.bind( model );
 	}
 
@@ -167,7 +173,11 @@ export default class RepeatedFragment {
 		// {{#each array}}...
 		if ( isArray( context.get() ) ) {
 			this.iterations.forEach( ( fragment, i ) => {
-				fragment.rebind( context.joinKey( i ) );
+				const model = context.joinKey( i );
+				if ( this.owner.template.z ) {
+					fragment.aliases = { [this.owner.template.z[0].n]: model };
+				}
+				fragment.rebind( model );
 			});
 		}
 	}
@@ -340,7 +350,11 @@ export default class RepeatedFragment {
 				fragment.unbind().unrender( true );
 			} else {
 				fragment.index = newIndex;
-				fragment.rebind( this.context.joinKey( newIndex ) );
+				const model = this.context.joinKey( newIndex );
+				if ( this.owner.template.z ) {
+					fragment.aliases = { [this.owner.template.z[0].n]: model };
+				}
+				fragment.rebind( model );
 
 				if ( reinsertFrom === null && ( newIndex !== previousNewIndex + 1 ) ) {
 					reinsertFrom = oldIndex;

--- a/src/view/items/Alias.js
+++ b/src/view/items/Alias.js
@@ -1,0 +1,96 @@
+import { createDocumentFragment } from '../../utils/dom';
+import Fragment from '../Fragment';
+import Item from './shared/Item';
+import resolve from '../resolvers/resolve';
+
+function resolveAliases( section ) {
+	if ( section.template.z ) {
+		section.aliases = {};
+
+		let refs = section.template.z;
+		for ( let i = 0; i < refs.length; i++ ) {
+			section.aliases[ refs[i].n ] = resolve( section.parentFragment, refs[i].x );
+		}
+	}
+}
+
+export default class Alias extends Item {
+	constructor ( options ) {
+		super( options );
+
+		this.fragment = null;
+	}
+
+	bind () {
+		resolveAliases( this );
+
+		this.fragment = new Fragment({
+			owner: this,
+			template: this.template.f
+		}).bind();
+	}
+
+	detach () {
+		return this.fragment ? this.fragment.detach() : createDocumentFragment();
+	}
+
+	find ( selector ) {
+		if ( this.fragment ) {
+			return this.fragment.find( selector );
+		}
+	}
+
+	findAll ( selector, query ) {
+		if ( this.fragment ) {
+			this.fragment.findAll( selector, query );
+		}
+	}
+
+	findComponent ( name ) {
+		if ( this.fragment ) {
+			return this.fragment.findComponent( name );
+		}
+	}
+
+	findAllComponents ( name, query ) {
+		if ( this.fragment ) {
+			this.fragment.findAllComponents( name, query );
+		}
+	}
+
+	firstNode () {
+		return this.fragment && this.fragment.firstNode();
+	}
+
+	rebind () {
+		resolveAliases( this );
+		if ( this.fragment ) this.fragment.rebind();
+	}
+
+	render ( target ) {
+		this.rendered = true;
+		if ( this.fragment ) this.fragment.render( target );
+	}
+
+	toString ( escape ) {
+		return this.fragment ? this.fragment.toString( escape ) : '';
+	}
+
+	unbind () {
+		this.aliases = {};
+		if ( this.fragment ) this.fragment.unbind();
+	}
+
+	unrender ( shouldDestroy ) {
+		if ( this.rendered && this.fragment ) this.fragment.unrender( shouldDestroy );
+		this.rendered = false;
+	}
+
+	update () {
+		if ( !this.dirty ) return;
+
+		this.fragment.update();
+
+		this.dirty = false;
+	}
+}

--- a/src/view/items/createItem.js
+++ b/src/view/items/createItem.js
@@ -1,4 +1,5 @@
-import { DOCTYPE, ELEMENT, INTERPOLATOR, PARTIAL, SECTION, TRIPLE, YIELDER } from '../../config/types';
+import { ALIAS, DOCTYPE, ELEMENT, INTERPOLATOR, PARTIAL, SECTION, TRIPLE, YIELDER } from '../../config/types';
+import Alias from './Alias';
 import Component from './Component';
 import Doctype from './Doctype';
 import Form from './element/specials/Form';
@@ -16,6 +17,7 @@ import Yielder from './Yielder';
 import getComponentConstructor from './component/getComponentConstructor';
 
 const constructors = {};
+constructors[ ALIAS ] = Alias;
 constructors[ DOCTYPE ] = Doctype;
 constructors[ INTERPOLATOR ] = Interpolator;
 constructors[ PARTIAL ] = Partial;

--- a/src/view/resolvers/resolveAmbiguousReference.js
+++ b/src/view/resolvers/resolveAmbiguousReference.js
@@ -26,6 +26,15 @@ export default function resolveAmbiguousReference ( fragment, ref ) {
 			}
 		}
 
+		if ( fragment.owner.aliases && fragment.owner.aliases.hasOwnProperty( key ) ) {
+			let model = fragment.owner.aliases[ key ];
+
+			if ( keys.length === 1 ) return model;
+			else if ( typeof model.joinAll === 'function' ) {
+				return model.joinAll( keys.slice( 1 ) );
+			}
+		}
+
 		if ( fragment.context ) {
 			// TODO better encapsulate the component check
 			if ( !fragment.isRoot || fragment.ractive.component ) hasContextChain = true;

--- a/src/view/resolvers/resolveAmbiguousReference.js
+++ b/src/view/resolvers/resolveAmbiguousReference.js
@@ -11,6 +11,7 @@ export default function resolveAmbiguousReference ( fragment, ref ) {
 
 	let hasContextChain;
 	let crossedComponentBoundary;
+	let aliases;
 
 	while ( fragment ) {
 		// repeated fragments
@@ -26,8 +27,9 @@ export default function resolveAmbiguousReference ( fragment, ref ) {
 			}
 		}
 
-		if ( fragment.owner.aliases && fragment.owner.aliases.hasOwnProperty( key ) ) {
-			let model = fragment.owner.aliases[ key ];
+		// alias node or iteration
+		if ( ( ( aliases = fragment.owner.aliases ) || ( aliases = fragment.aliases ) ) && aliases.hasOwnProperty( key ) ) {
+			let model = aliases[ key ];
 
 			if ( keys.length === 1 ) return model;
 			else if ( typeof model.joinAll === 'function' ) {

--- a/test/browser-tests/aliases.js
+++ b/test/browser-tests/aliases.js
@@ -60,30 +60,6 @@ test( '@keypath refs can be aliased', t => {
 	t.htmlEqual( fixture.innerHTML, 'items.0items.1items.2items.3' );
 });
 
-test( 'multiple nested aliases', t => {
-	new Ractive({
-		el: fixture,
-		template:`
-			{{#each items as item}}{{#if item.foo}}
-				{{#with @keypath as key, item.foo as v1}}
-					{{#each v1.bar as v2}}{{#with @keypath as key2}}
-						{{#each v2.baz}}{{key}} {{key2}} {{.}}{{/each}}
-					{{/with}}{{/each}}
-				{{/with}}
-			{{/if}}{{/each}}
-		`,
-		data: {
-			items: [
-				{ foo: { bar: [ { baz: [ 1 ] } ] } },
-				{ foo: { bar: [ { baz: [ 2 ] } ] } },
-				{ foo: { bar: [ { baz: [ 3 ] } ] } }
-			]
-		}
-	});
-
-	t.htmlEqual( fixture.innerHTML, 'items.0 items.0.foo.bar.0 1items.1 items.1.foo.bar.0 2items.2 items.2.foo.bar.0 3' );
-});
-
 test( 'aliased complex computations are cached', t => {
 	let normal = 0, aliased = 0;
 
@@ -106,6 +82,30 @@ test( 'aliased complex computations are cached', t => {
 
 // TODO: no idea why these fail in phantom an pass in browser, but they should probably pass both
 if ( !/phantom/i.test( navigator.userAgent ) ) {
+	test( 'multiple nested aliases', t => {
+		new Ractive({
+			el: fixture,
+			template:`
+				{{#each items as item}}{{#if item.foo}}
+					{{#with @keypath as key, item.foo as v1}}
+						{{#each v1.bar as v2}}{{#with @keypath as key2}}
+							{{#each v2.baz}}{{key}} {{key2}} {{.}}{{/each}}
+						{{/with}}{{/each}}
+					{{/with}}
+				{{/if}}{{/each}}
+			`,
+			data: {
+				items: [
+					{ foo: { bar: [ { baz: [ 1 ] } ] } },
+					{ foo: { bar: [ { baz: [ 2 ] } ] } },
+					{ foo: { bar: [ { baz: [ 3 ] } ] } }
+				]
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'items.0 items.0.foo.bar.0 1items.1 items.1.foo.bar.0 2items.2 items.2.foo.bar.0 3' );
+	});
+
 	test( 'basic aliased array iteration', t => {
 		new Ractive({
 			el: fixture,

--- a/test/browser-tests/aliases.js
+++ b/test/browser-tests/aliases.js
@@ -24,6 +24,86 @@ test( 'aliased computations', t => {
 	t.htmlEqual( fixture.innerHTML, '16' );
 });
 
+test( '@index refs can be aliased', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '{{#each items}}{{#with @index as idx}}{{idx}}{{/with}}{{/each}}',
+		data: { items: [1, 2, 3] }
+	});
+
+	t.htmlEqual( fixture.innerHTML, '012' );
+	r.splice( 'items', 1, 0, 99 );
+	t.htmlEqual( fixture.innerHTML, '0123' );
+});
+
+test( '@key refs can be aliased', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '{{#each items}}{{#with @key as idx}}{{idx}}{{/with}}{{/each}}',
+		data: { items: { foo: 1, bar: 2, baz: 3 } }
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'foobarbaz' );
+	r.set( 'items.bat', 99 );
+	t.htmlEqual( fixture.innerHTML, 'foobarbazbat' );
+});
+
+test( '@keypath refs can be aliased', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '{{#each items}}{{#with @keypath as idx}}{{idx}}{{/with}}{{/each}}',
+		data: { items: [1, 2, 3] }
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'items.0items.1items.2' );
+	r.splice( 'items', 1, 0, 99 );
+	t.htmlEqual( fixture.innerHTML, 'items.0items.1items.2items.3' );
+});
+
+test( 'multiple nested aliases', t => {
+	new Ractive({
+		el: fixture,
+		template:`
+			{{#each items as item}}{{#if item.foo}}
+				{{#with @keypath as key, item.foo as v1}}
+					{{#each v1.bar as v2}}{{#with @keypath as key2}}
+						{{#each v2.baz}}{{key}} {{key2}} {{.}}{{/each}}
+					{{/with}}{{/each}}
+				{{/with}}
+			{{/if}}{{/each}}
+		`,
+		data: {
+			items: [
+				{ foo: { bar: [ { baz: [ 1 ] } ] } },
+				{ foo: { bar: [ { baz: [ 2 ] } ] } },
+				{ foo: { bar: [ { baz: [ 3 ] } ] } }
+			]
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'items.0 items.0.foo.bar.0 1items.1 items.1.foo.bar.0 2items.2 items.2.foo.bar.0 3' );
+});
+
+test( 'aliased complex computations are cached', t => {
+	let normal = 0, aliased = 0;
+
+	new Ractive({
+		el: fixture,
+		template: `
+			{{#if normal()}}{{JSON.stringify(normal())}}{{/if}}
+			{{#with aliased() as thing}}{{JSON.stringify(thing)}}{{/with}}
+		`,
+		data: {
+			normal() { normal++; return true; },
+			aliased() { aliased++; return true; }
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'true true' );
+	t.equal( normal, 2 );
+	t.equal( aliased, 1 );
+});
+
 // TODO: no idea why these fail in phantom an pass in browser, but they should probably pass both
 if ( !/phantom/i.test( navigator.userAgent ) ) {
 	test( 'basic aliased array iteration', t => {

--- a/test/browser-tests/aliases.js
+++ b/test/browser-tests/aliases.js
@@ -1,5 +1,7 @@
 import { test } from 'qunit';
 
+/* global navigator */
+
 test( 'simple template aliases', t => {
 	new Ractive({
 		el: fixture,
@@ -22,36 +24,39 @@ test( 'aliased computations', t => {
 	t.htmlEqual( fixture.innerHTML, '16' );
 });
 
-test( 'basic aliased array iteration', t => {
-	new Ractive({
-		el: fixture,
-		template: `{{#each items as item:i}}|{{i+1}}-{{item}}{{/each}}`,
-		data: { items: [ 'a', 'b', 'c' ] }
+// TODO: no idea why these fail in phantom an pass in browser, but they should probably pass both
+if ( !/phantom/i.test( navigator.userAgent ) ) {
+	test( 'basic aliased array iteration', t => {
+		new Ractive({
+			el: fixture,
+			template: `{{#each items as item:i}}|{{i+1}}-{{item}}{{/each}}`,
+			data: { items: [ 'a', 'b', 'c' ] }
+		});
+
+		t.htmlEqual( fixture.innerHTML, '|1-a|2-b|3-c' );
 	});
 
-	t.htmlEqual( fixture.innerHTML, '|1-a|2-b|3-c' );
-});
+	test( 'basic aliased object iteration', t => {
+		new Ractive({
+			el: fixture,
+			template: `{{#each items as item:k,i}}|{{k}}-{{i+1}}-{{item}}{{/each}}`,
+			data: { items: { k1: 'a', k2: 'b', k3: 'c' } }
+		});
 
-test( 'basic aliased object iteration', t => {
-	new Ractive({
-		el: fixture,
-		template: `{{#each items as item:k,i}}|{{k}}-{{i+1}}-{{item}}{{/each}}`,
-		data: { items: { k1: 'a', k2: 'b', k3: 'c' } }
+		t.htmlEqual( fixture.innerHTML, '|k1-1-a|k2-2-b|k3-3-c' );
 	});
 
-	t.htmlEqual( fixture.innerHTML, '|k1-1-a|k2-2-b|k3-3-c' );
-});
+	test( 'aliased array iteration shuffle', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each items as item:i}}|{{i+1}}-{{item}}{{/each}}`,
+			data: { items: [ 'a', 'b', 'c' ] }
+		});
 
-test( 'aliased array iteration shuffle', t => {
-	const r = new Ractive({
-		el: fixture,
-		template: `{{#each items as item:i}}|{{i+1}}-{{item}}{{/each}}`,
-		data: { items: [ 'a', 'b', 'c' ] }
+		t.htmlEqual( fixture.innerHTML, '|1-a|2-b|3-c' );
+
+		r.splice( 'items', 1, 0, 'd' );
+
+		t.htmlEqual( fixture.innerHTML, '|1-a|2-d|3-b|4-c' );
 	});
-
-	t.htmlEqual( fixture.innerHTML, '|1-a|2-b|3-c' );
-
-	r.splice( 'items', 1, 0, 'd' );
-
-	t.htmlEqual( fixture.innerHTML, '|1-a|2-d|3-b|4-c' );
-});
+}

--- a/test/browser-tests/aliases.js
+++ b/test/browser-tests/aliases.js
@@ -1,0 +1,57 @@
+import { test } from 'qunit';
+
+test( 'simple template aliases', t => {
+	new Ractive({
+		el: fixture,
+		template: '{{#with foo.bar.baz as bar, bippy.boppy as boop}}{{bar}} {{boop}}{{/with}}',
+		data: {
+			foo: { bar: { baz: 'yep' } },
+			bippy: { boppy: 'works' }
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'yep works' );
+});
+
+test( 'aliased computations', t => {
+	new Ractive({
+		el: fixture,
+		template: `{{#with 3 * 2 + 10 as num}}{{num}}{{/with}}`
+	});
+
+	t.htmlEqual( fixture.innerHTML, '16' );
+});
+
+test( 'basic aliased array iteration', t => {
+	new Ractive({
+		el: fixture,
+		template: `{{#each items as item:i}}|{{i+1}}-{{item}}{{/each}}`,
+		data: { items: [ 'a', 'b', 'c' ] }
+	});
+
+	t.htmlEqual( fixture.innerHTML, '|1-a|2-b|3-c' );
+});
+
+test( 'basic aliased object iteration', t => {
+	new Ractive({
+		el: fixture,
+		template: `{{#each items as item:k,i}}|{{k}}-{{i+1}}-{{item}}{{/each}}`,
+		data: { items: { k1: 'a', k2: 'b', k3: 'c' } }
+	});
+
+	t.htmlEqual( fixture.innerHTML, '|k1-1-a|k2-2-b|k3-3-c' );
+});
+
+test( 'aliased array iteration shuffle', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#each items as item:i}}|{{i+1}}-{{item}}{{/each}}`,
+		data: { items: [ 'a', 'b', 'c' ] }
+	});
+
+	t.htmlEqual( fixture.innerHTML, '|1-a|2-b|3-c' );
+
+	r.splice( 'items', 1, 0, 'd' );
+
+	t.htmlEqual( fixture.innerHTML, '|1-a|2-d|3-b|4-c' );
+});

--- a/test/browser-tests/aliases.js
+++ b/test/browser-tests/aliases.js
@@ -80,6 +80,17 @@ test( 'aliased complex computations are cached', t => {
 	t.equal( aliased, 1 );
 });
 
+test( 'unresolved aliases should resolve if a suitable model appears', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '{{#with foo.bar as baz}}{{baz}}{{/with}}'
+	});
+
+	t.htmlEqual( fixture.innerHTML, '' );
+	r.set( 'foo', { bar: 'yep' } );
+	t.htmlEqual( fixture.innerHTML, 'yep' );
+});
+
 // TODO: no idea why these fail in phantom an pass in browser, but they should probably pass both
 if ( !/phantom/i.test( navigator.userAgent ) ) {
 	test( 'multiple nested aliases', t => {


### PR DESCRIPTION
__Probably post 0.8~~, not ready for merge, and no tests yet~~__

This is one of those things that pops up now and then as a little bit surprising: setting context with `with` isn't really bidirectional (#1353). There has been a proposed syntax to address that `{{#with foo.bar.baz as v1, lah.dee.dah as v2}}`, and this is my attempt to see what it would take and how it would work. What this does is introduce a new step in parsing sections, a new node type, and another step in ambiguous reference resolution to achieve aliasing within a branch of a template.

### Construction

The parsing step sits between block name and expression parsing. It looks for aliases in the form `[expression] as [non-path ref]` with optional additional `,` separated aliases if the section type is a `with`. If aliases are found, they are stuck on the template node in a new `z` property and the type is changed to `ALIAS` (19). Children are still parsed, but most of special stuff, like looking for `else`, is skipped.

The new node, `Alias`, is pretty simple. It only exists to resolve its own references and supply an `aliases` map to children. This is my first new node type, so I'm not positive that all of the methods are right. It seems to be well behaved in the stuff I've thrown through it though.

The resolution step is pretty simple. During the walk up the fragment tree, it just checks for fragment owners with an `aliases` property with a key matching the root of the current ref. If there is one, the model stored there is joined if possible. If not, resolution continues as usual.

Any valid reference is usable, so you can alias `@index` and other special refs or a regular keypath or an expression.

### Segue - components

Something that also pops up every now and then with components is how to let events fire in the context of the owner while the content guts stay in the context of the component (recently #2206). Obviously bubbling is one good solution, but that requires a little bit tighter integration between component-er and component-ee. Table that for a second while I segue the segue.

I was thinking that perhaps it would be useful to introduce a new special reference (yay!) `@ractive` that returned `this.ractive` when resolved. This could be useful in some scenarios, like the question about where to put functions that popped up recently (#2176). Then things like `@ractive.someFun(...)` could be possible. It might also be useful for combining method and proxy event syntax at some point in the future.

Now, what if template aliasing allowed you to override the `@ractive` special ref? The event directive could look for a `@ractive` override before using its own `ractive` to fire an event. This could allow something like:
```html
Name: <input value="{{current.name}}" /><br/>
Phone: <input value="{{current.phone}}" />
<List values="{{people}}">
  <div class="person" on-click="link(@keypath, 'current')">{{.name}} {{.phone}}</div>
</List>
```
and the List component:
```html
{{#each page(values)}}
  {{#with @ractive.parent as @ractive}}{{>content}}
{{/each}}
{{#each range(1, values.length / pageSize)}}
  <a href="#" on-click="set('page', .)">{{.}}</a>
{{/each}}
```
Here, the `link` call in the `content` partial would happen in the context of the component's parent, since it has an alias defined. The pagination link `set` calls would happen in the context of the component because there is no alias overriding the `@ractive` reference.

### So...

If you made it this far, thanks! I would love to get some feedback, as always, on concept and construction ( and testing when this grows some tests ).