### PR TITLE
Fix #2201

### DIFF
--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -78,19 +78,19 @@ export default class Attribute extends Item {
 
 		// should we use direct property access, or setAttribute?
 		if ( !node.namespaceURI || node.namespaceURI === html ) {
-			const propertyName = propertyNames[ this.name ] || this.name;
+			this.propertyName = propertyNames[ this.name ] || this.name;
 
-			if ( node[ propertyName ] !== undefined ) {
-				this.propertyName = propertyName;
+			if ( node[ this.propertyName ] !== undefined ) {
+				this.useProperty = true;
 			}
 
 			// is attribute a boolean attribute or 'value'? If so we're better off doing e.g.
 			// node.selected = true rather than node.setAttribute( 'selected', '' )
 			if ( booleanAttributes.test( this.name ) || this.isTwoway ) {
-				this.useProperty = true;
+				this.isBoolean = true;
 			}
 
-			if ( propertyName === 'value' ) {
+			if ( this.propertyName === 'value' ) {
 				node._ractive.value = this.value;
 			}
 		}

--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -48,7 +48,7 @@ export default function getUpdateDelegate ( attribute ) {
 	// special case - class names. IE fucks things up, again
 	if ( name === 'class' && ( !node.namespaceURI || node.namespaceURI === html ) ) return updateClassName;
 
-	if ( attribute.useProperty ) return updateProperty;
+	if ( attribute.isBoolean ) return updateBoolean;
 
 	if ( attribute.namespace ) return updateNamespacedAttribute;
 
@@ -179,11 +179,19 @@ function updateClassName () {
 	this.node.className = safeToStringValue( this.getValue() );
 }
 
-function updateProperty () {
+function updateBoolean () {
 	// with two-way binding, only update if the change wasn't initiated by the user
 	// otherwise the cursor will often be sent to the wrong place
 	if ( !this.locked ) {
-		this.node[ this.propertyName ] = this.getValue();
+		if ( this.useProperty ) {
+			this.node[ this.propertyName ] = this.getValue();
+		} else {
+			if ( this.getValue() ) {
+				this.node.setAttribute( this.propertyName, '' );
+			} else {
+				this.node.removeAttribute( this.propertyName );
+			}
+		}
 	}
 }
 

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -1249,6 +1249,14 @@ const renderTests = [
 			foo: false
 		},
 		new_result: '<div>xy</div>'
+	},
+	{
+		name: 'Boolean attributes are set using setAttribute() if needed (#2201)',
+		template: `<div itemscope="{{foo}}"></div>`,
+		data: { foo: true },
+		result: '<div itemscope=""></div>',
+		new_data: { foo: false },
+		new_result: '<div></div>'
 	}
 ];
 


### PR DESCRIPTION
@martypdx explained the problem very well in [this comment](https://github.com/ractivejs/ractive/issues/2201#issuecomment-146438758).

The solution is to use a combination of `setAttribute()` and `removeAttribute()`, because if `node.propertyName` isn't defined, setting it won't have any effect.