### PR TITLE
Correctly handle a combination of pseudo classes and a pseudo element…

### DIFF
--- a/src/Ractive/config/custom/css/transform.js
+++ b/src/Ractive/config/custom/css/transform.js
@@ -1,6 +1,6 @@
 const selectorsPattern = /(?:^|\})?\s*([^\{\}]+)\s*\{/g;
 const commentsPattern = /\/\*.*?\*\//g;
-const selectorUnitPattern = /((?:(?:\[[^\]+]\])|(?:[^\s\+\>\~:]))+)((?::[^\s\+\>\~\(]+(?:\([^\)]+\))?)?\s*[\s\+\>\~]?)\s*/g;
+const selectorUnitPattern = /((?:(?:\[[^\]+]\])|(?:[^\s\+\>~:]))+)((?::[^\s\+\>\~\(:]+(?:\([^\)]+\))?)*\s*[\s\+\>\~]?)\s*/g;
 const mediaQueryPattern = /^@media/;
 const dataRvcGuidPattern = /\[data-ractive-css~="\{[a-z0-9-]+\}"]/g;
 


### PR DESCRIPTION
… when transforming css (fixes #1964)

Not including the following test because I couldn't get it to work in phantomJS:

```js
test( 'Combination of pseudo classes and a pseudo element works (#1964)', t => {
	const Widget = Ractive.extend({
		template: '<div class="foo"></div>',
		css: '.foo:not(:focus):before { content: "c before" } .foo:first-of-type:after { content: "c after" }'
	});

	const ractive = new Widget({ el: fixture });
	const foo = ractive.find( '.foo' );

	t.equal( getComputedStyle( foo, ':before' ).getPropertyValue( 'content' ), '"c before"' );
	t.equal( getComputedStyle( foo, ':after' ).getPropertyValue( 'content' ), '"c after"' );
});
```