### PR TITLE
Shuffling pattern observers and repeated sections - #2222

### DIFF
--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -824,3 +824,46 @@ test( 'Observer fires on initialisation for computed properties', t => {
 
 	t.deepEqual( observed, { num: 21, doubled: 42 });
 });
+
+test( `observers that cause a shuffle shouldn't throw (#2222)`, t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `-{{#each items}}{{.}}{{/each}}
+			{{#each watches}}{{.}}{{/each}}`,
+		data: {
+			items: [],
+			watches: []
+		},
+		oninit() {
+			this.observe( 'items.*', ( n, o, k ) => {
+				this.push( 'watches', `${n} - ${k} ` );
+			});
+		}
+	});
+
+	r.push( 'items', 1, 2 );
+	t.htmlEqual( fixture.innerHTML, '-12 1 - items.0 2 - items.1' );
+});
+
+test( `a pattern observer that is shuffled with objects should only notify on the new keys`, t => {
+	let count = 0;
+
+	const r = new Ractive({
+		el: fixture,
+		template: '',
+		data: {
+			items: [ { val: 1 } , { val: 2 } ]
+		},
+		oninit() {
+			this.observe( 'items.*', () => {
+				count++;
+			});
+		}
+	});
+
+	t.equal( count, 2 );
+	r.push( 'items', { val: 3 } );
+	t.equal( count, 3 );
+	r.unshift( 'items', { val: 0 } );
+	t.equal( count, 7 );
+});


### PR DESCRIPTION
This is my patch from #2222 with tests added.

First, if an array with object children is shuffled, then the pattern observer will fire for all of the keys. It seems like it should only fire on the observed keys, so this adds shuffle support that does that.

Second, if an observer makes a change that causes a shuffle, and the observer fires more than once, the repeated fragment refuses to shuffle more than once. This also adds support for the multiple shuffles per runloop to repeated sections by mapping the original new indices through the accumulated shuffles.