### PR TITLE
Skip iterations without nodes when looking for next node in repeated sections - #2234

### DIFF
--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -151,7 +151,10 @@ export default class RepeatedFragment {
 
 	findNextNode ( iteration ) {
 		if ( iteration.index < this.iterations.length - 1 ) {
-			return this.iterations[ iteration.index + 1 ].firstNode();
+			for ( let i = iteration.index + 1; i < this.iterations.length; i++ ) {
+				let node = this.iterations[ i ].firstNode();
+				if ( node ) return node;
+			}
 		}
 
 		return this.owner.findNextNode();

--- a/test/browser-tests/render/misc.js
+++ b/test/browser-tests/render/misc.js
@@ -219,6 +219,23 @@ test( 'iteration special refs outside of an iteration should not error', t => {
 	t.ok( true, 'hey, it didn\'t throw' );
 });
 
+test( 'a repeated section should skip empty iterations when looking for a next node for insertion (#2234)', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '{{#each items}}{{#if .bool}}{{.val}}{{/if}}{{/each}}',
+		data: {
+			items: [ { bool: true, val: 1 }, { bool: true, val: 2 }, { bool: true, val: 3 } ]
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, '123' );
+	r.set( 'items.0.bool', false );
+	r.set( 'items.1.bool', false );
+	t.htmlEqual( fixture.innerHTML, '3' );
+	r.set( 'items.0.bool', true );
+	t.htmlEqual( fixture.innerHTML, '13' );
+});
+
 if ( typeof Object.create === 'function' ) {
 	test( 'data of type Object.create(null) (#1825)', t => {
 		const ractive = new Ractive({


### PR DESCRIPTION
This looks for the next iteration after the target index that actually has a node. The behavior in edge now makes fragments looking for the next node append instead of inserting if the next iteration doesn't actually have a node.