### PR TITLE
Register yield fragments during bubble - fixes #2235

### DIFF
--- a/src/view/items/Yielder.js
+++ b/src/view/items/Yielder.js
@@ -1,6 +1,7 @@
 import Item from './shared/Item';
 import Fragment from '../Fragment';
 import parse from '../../parse/_parse';
+import runloop from '../../global/runloop';
 import { warnIfDebug } from '../../utils/log';
 import { removeFromArray } from '../../utils/array';
 
@@ -40,6 +41,13 @@ export default class Yielder extends Item {
 			ractive: this.container.parent,
 			template
 		}).bind();
+	}
+
+	bubble () {
+		if ( !this.dirty ) {
+			runloop.addFragment( this.fragment );
+			super.bubble();
+		}
 	}
 
 	detach () {

--- a/src/view/items/Yielder.js
+++ b/src/view/items/Yielder.js
@@ -1,7 +1,6 @@
 import Item from './shared/Item';
 import Fragment from '../Fragment';
 import parse from '../../parse/_parse';
-import runloop from '../../global/runloop';
 import { warnIfDebug } from '../../utils/log';
 import { removeFromArray } from '../../utils/array';
 
@@ -45,7 +44,6 @@ export default class Yielder extends Item {
 
 	bubble () {
 		if ( !this.dirty ) {
-			runloop.addFragment( this.fragment );
 			this.containerFragment.bubble();
 			this.dirty = true;
 		}

--- a/src/view/items/Yielder.js
+++ b/src/view/items/Yielder.js
@@ -46,7 +46,8 @@ export default class Yielder extends Item {
 	bubble () {
 		if ( !this.dirty ) {
 			runloop.addFragment( this.fragment );
-			super.bubble();
+			this.containerFragment.bubble();
+			this.dirty = true;
 		}
 	}
 
@@ -107,5 +108,6 @@ export default class Yielder extends Item {
 
 	update () {
 		this.fragment.update();
+		this.dirty = false;
 	}
 }

--- a/test/browser-tests/components/yield.js
+++ b/test/browser-tests/components/yield.js
@@ -226,6 +226,28 @@ test( 'Named yield with Ractive.extend() works as with new Ractive() (#1680)', t
 	t.htmlEqual( fixture.innerHTML, '<p>this is foo</p>' );
 });
 
+test( 'yielded fragments that are updated from an observer should actually update (#2225)', t => {
+	const cmp = Ractive.extend({
+		template: '{{yield}}',
+		onrender() {
+			this.observe( 'bar', v => this.set( 'baz', `${v} yep` ) );
+		}
+	});
+
+	const r = new Ractive({
+		el: fixture,
+		template: '-<cmp bar="{{foo}}" baz="{{bat}}">{{bat}}</cmp>',
+		data: {
+			foo: ''
+		},
+		components: { cmp }
+	});
+
+	t.htmlEqual( fixture.innerHTML, '- yep' );
+	r.set( 'foo', 2 );
+	t.htmlEqual( fixture.innerHTML, '-2 yep' );
+});
+
 test( 'Components inherited from more than one generation off work with named yields', t => {
 	let widget = Ractive.extend({
 		template: '{{yield foo}}'

--- a/test/browser-tests/components/yield.js
+++ b/test/browser-tests/components/yield.js
@@ -253,6 +253,25 @@ test( 'Components inherited from more than one generation off work with named yi
 	t.htmlEqual( fixture.innerHTML, '<p>this is foo</p>' );
 });
 
+test( 'yielders should properly update with their container instance (#2235)', t => {
+	const Foo = Ractive.extend({
+		template: '{{yield}}'
+	});
+
+	const r = new Ractive({
+		el: fixture,
+		template: '<Foo>{{foo}}</Foo>',
+		data: {
+			foo: 'foo'
+		},
+		components: { Foo }
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'foo' );
+	r.set( 'foo', 'bar' );
+	t.htmlEqual( fixture.innerHTML, 'bar' );
+});
+
 if ( hasUsableConsole ) {
 	test( 'Yield with missing partial (#1681)', t => {
 		onWarn( msg => {


### PR DESCRIPTION
It looks like the special component handling during bubble keeps the yield fragment from getting handled in the runloop. This overrides `bubble` on `Yielder` to register the fragment with the runloop so that the fragment updates and isn't left in a dirty state after the update. Does that sound right?