### PR TITLE
Restore console log of missing decorators and events

### DIFF
--- a/src/view/items/element/Decorator.js
+++ b/src/view/items/element/Decorator.js
@@ -1,4 +1,5 @@
 import { findInViewHierarchy } from '../../../shared/registry';
+import { warnOnce } from '../../../utils/log';
 import { missingPlugin } from '../../../config/errors';
 import Fragment from '../../Fragment';
 import noop from '../../../utils/noop';
@@ -66,7 +67,7 @@ export default class Decorator {
 		const fn = findInViewHierarchy( 'decorators', this.ractive, this.name );
 
 		if ( !fn ) {
-			missingPlugin( this.name, 'decorators' );
+			warnOnce( missingPlugin( this.name, 'decorators' ) );
 			this.intermediary = missingDecorator;
 			return;
 		}

--- a/src/view/items/element/ElementEvents.js
+++ b/src/view/items/element/ElementEvents.js
@@ -1,5 +1,5 @@
 import { missingPlugin } from '../../../config/errors';
-import { fatal } from '../../../utils/log';
+import { fatal, warnOnce } from '../../../utils/log';
 
 class DOMEvent {
 	constructor ( name, owner ) {
@@ -18,7 +18,7 @@ class DOMEvent {
 		const name = this.name;
 
 		if ( !( `on${name}` in node ) ) {
-			missingPlugin( name, 'events' );
+			warnOnce( missingPlugin( name, 'events' ) );
 		}
 
 		node.addEventListener( name, this.handler = function( event ) {

--- a/test/browser-tests/events/custom-proxy-events.js
+++ b/test/browser-tests/events/custom-proxy-events.js
@@ -1,5 +1,6 @@
 import { test } from 'qunit';
 import { fire } from 'simulant';
+import { hasUsableConsole, onWarn } from 'test-config';
 
 test( 'custom event invoked and torndown', t => {
 	t.expect( 3 );
@@ -42,3 +43,18 @@ test( 'custom event invoked and torndown', t => {
 	ractive.unrender();
 	fire( span, 'click' );
 });
+
+if ( hasUsableConsole ) {
+	test( 'Missing event plugin', t => {
+		t.expect( 1 );
+
+	    onWarn( msg => {
+	      t.ok( /Missing "foo" events plugin/.test( msg ) );
+	    });
+
+		new Ractive({
+			el: fixture,
+			template: '<div on-foo="">missing</div>',
+		});
+	});
+}

--- a/test/browser-tests/plugins/decorators.js
+++ b/test/browser-tests/plugins/decorators.js
@@ -1,4 +1,6 @@
 import { test } from 'qunit';
+import { hasUsableConsole, onWarn } from 'test-config';
+
 
 test( 'Basic decorator', t => {
 	new Ractive({
@@ -20,6 +22,21 @@ test( 'Basic decorator', t => {
 
 	t.htmlEqual( fixture.innerHTML, '<div>foo</div>' );
 });
+
+if ( hasUsableConsole ) {
+	test( 'Missing decorator', t => {
+		t.expect( 1 );
+
+	    onWarn( msg => {
+	      t.ok( /Missing "foo" decorators plugin/.test( msg ) );
+	    });
+
+		new Ractive({
+			el: fixture,
+			template: '<div decorator="foo">missing</div>',
+		});
+	});
+}
 
 test( 'Decorator with a static argument', t => {
 	new Ractive({


### PR DESCRIPTION
I went for the middle ground of `warnOnce` on decorator and event plugins. Fixes #2246 

You could make arguments for either `warnOnceIfDebug` and `fatal`. Thoughts?