### PR TITLE
Remove non-transition nodes from DOM before calling deferred observers (#1869)

### DIFF
--- a/src/global/TransitionManager.js
+++ b/src/global/TransitionManager.js
@@ -54,11 +54,6 @@ export default class TransitionManager {
 		this.children.forEach( _detachNodes );
 	}
 
-	init () {
-		this.ready = true;
-		check( this );
-	}
-
 	remove ( transition ) {
 		var list = transition.isIntro ? this.intros : this.outros;
 		removeFromArray( list, transition );
@@ -67,6 +62,8 @@ export default class TransitionManager {
 
 	start () {
 		this.intros.concat( this.outros ).forEach( t => t.start() );
+		this.ready = true;
+		check( this );
 	}
 }
 

--- a/src/global/TransitionManager.js
+++ b/src/global/TransitionManager.js
@@ -1,5 +1,4 @@
 import { removeFromArray } from '../utils/array';
-import { teardown } from '../shared/methodCallers';
 
 export default class TransitionManager {
 	constructor ( callback, parent ) {
@@ -13,7 +12,6 @@ export default class TransitionManager {
 		this.totalChildren = this.outroChildren = 0;
 
 		this.detachQueue = [];
-		this.decoratorQueue = [];
 		this.outrosComplete = false;
 
 		if ( parent ) {
@@ -33,11 +31,6 @@ export default class TransitionManager {
 		this.outroChildren += 1;
 	}
 
-	// TODO can we move decorator stuff to element detach() methods?
-	addDecorator ( decorator ) {
-		this.decoratorQueue.push( decorator );
-	}
-
 	decrementOutros () {
 		this.outroChildren -= 1;
 		check( this );
@@ -49,7 +42,6 @@ export default class TransitionManager {
 	}
 
 	detachNodes () {
-		this.decoratorQueue.forEach( teardown );
 		this.detachQueue.forEach( detach );
 		this.children.forEach( _detachNodes );
 	}

--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -46,10 +46,6 @@ const runloop = {
 		batch.transitionManager.add( transition );
 	},
 
-	// registerDecorator ( decorator ) {
-	// 	batch.transitionManager.addDecorator( decorator );
-	// },
-
 	// synchronise node detachments with transition ends
 	detachWhenReady ( thing ) {
 		batch.transitionManager.detachQueue.push( thing );

--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -30,8 +30,6 @@ const runloop = {
 
 	end () {
 		flushChanges();
-
-		batch.transitionManager.init();
 		batch = batch.previousBatch;
 	},
 
@@ -48,9 +46,9 @@ const runloop = {
 		batch.transitionManager.add( transition );
 	},
 
-	registerDecorator ( decorator ) {
-		batch.transitionManager.addDecorator( decorator );
-	},
+	// registerDecorator ( decorator ) {
+	// 	batch.transitionManager.addDecorator( decorator );
+	// },
 
 	// synchronise node detachments with transition ends
 	detachWhenReady ( thing ) {

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -145,7 +145,6 @@ export default class Element extends Item {
 
 	detach () {
 		if ( this.decorator ) this.decorator.unrender();
-
 		return detachNode( this.node );
 	}
 

--- a/src/view/items/element/Decorator.js
+++ b/src/view/items/element/Decorator.js
@@ -87,7 +87,7 @@ export default class Decorator {
 	}
 
 	unrender () {
-		this.intermediary.teardown();
+		if ( this.intermediary ) this.intermediary.teardown();
 	}
 
 	update () {

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -33,6 +33,22 @@ test( 'Observers with { defer: true } fire after the DOM updates', t => {
 	ractive.set( 'foo', true );
 });
 
+test( 'Observers with { defer: true } fire after nodes removed from DOM', t => {
+	t.expect( 1 );
+
+	const ractive = new Ractive({
+		el: fixture,
+		template: '<ul>{{#items}}<li>{{.}}</li>{{/items}}</ul>',
+		data: { items: [ 1, 2, 3 ] }
+	});
+
+	ractive.observe( 'items', function () {
+		t.equal( this.findAll('li').length, this.el.querySelectorAll('li').length );
+	}, { init: false, defer: true });
+
+	ractive.pop( 'items' );
+});
+
 test( 'Observer can be created without an options argument', t => {
 	t.expect( 1 );
 

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -33,7 +33,7 @@ test( 'Observers with { defer: true } fire after the DOM updates', t => {
 	ractive.set( 'foo', true );
 });
 
-test( 'Observers with { defer: true } fire after nodes removed from DOM', t => {
+test( 'Observers with { defer: true } fire after non-transitioned nodes removed from DOM (#1869)', t => {
 	t.expect( 1 );
 
 	const ractive = new Ractive({


### PR DESCRIPTION
Fixes #1869.  (Re)moving the `TransitionManager.init` into `.start` seems to do the trick.

Also pruned some uncalled code and now Transition Manager doesn't need to know about decorators.