### PR TITLE
@global and @ractive special refs - RFC

### DIFF
--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -3,6 +3,8 @@ import { extend } from '../utils/object';
 import Computation from './Computation';
 import Model from './Model';
 import { handleChange, mark } from '../shared/methodCallers';
+import RactiveModel from './specials/RactiveModel';
+import GlobalModel from './specials/GlobalModel';
 
 export default class RootModel extends Model {
 	constructor ( options ) {
@@ -60,11 +62,18 @@ export default class RootModel extends Model {
 		return '';
 	}
 
+	getRactiveModel() {
+		return this.ractiveModel || ( this.ractiveModel = new RactiveModel( this.ractive ) );
+	}
+
 	has ( key ) {
 		return ( key in this.mappings ) || ( key in this.computations ) || super.has( key );
 	}
 
 	joinKey ( key ) {
+		if ( key === '@global' ) return GlobalModel;
+		if ( key === '@ractive' ) return this.getRactiveModel();
+
 		return this.mappings.hasOwnProperty( key ) ? this.mappings[ key ] :
 		       this.computations.hasOwnProperty( key ) ? this.computations[ key ] :
 		       super.joinKey( key );

--- a/src/model/specials/GlobalModel.js
+++ b/src/model/specials/GlobalModel.js
@@ -10,6 +10,10 @@ class GlobalModel extends Model {
 		this.adaptors = [];
 		this.changes = {};
 	}
+
+	getKeypath() {
+		return '@global';
+	}
 }
 
 export default new GlobalModel();

--- a/src/model/specials/GlobalModel.js
+++ b/src/model/specials/GlobalModel.js
@@ -1,0 +1,15 @@
+/* global global */
+import Model from '../Model';
+
+class GlobalModel extends Model {
+	constructor ( ) {
+		super( null, '@global' );
+		this.value = typeof global !== 'undefined' ? global : window;
+		this.isRoot = true;
+		this.root = this;
+		this.adaptors = [];
+		this.changes = {};
+	}
+}
+
+export default new GlobalModel();

--- a/src/model/specials/RactiveModel.js
+++ b/src/model/specials/RactiveModel.js
@@ -1,0 +1,13 @@
+import Model from '../Model';
+
+export default class RactiveModel extends Model {
+	constructor ( ractive ) {
+		super( null, '' );
+		this.value = ractive;
+		this.isRoot = true;
+		this.root = this;
+		this.adaptors = [];
+		this.ractive = ractive;
+		this.changes = {};
+	}
+}

--- a/src/model/specials/RactiveModel.js
+++ b/src/model/specials/RactiveModel.js
@@ -10,4 +10,8 @@ export default class RactiveModel extends Model {
 		this.ractive = ractive;
 		this.changes = {};
 	}
+
+	getKeypath() {
+		return '@ractive';
+	}
 }

--- a/src/parse/converters/expressions/primary/readReference.js
+++ b/src/parse/converters/expressions/primary/readReference.js
@@ -19,7 +19,7 @@ export default function readReference ( parser ) {
 
 	startPos = parser.pos;
 
-	name = parser.matchPattern( /^@(?:keypath|index|key)/ );
+	name = parser.matchPattern( /^@(?:keypath|index|key|ractive|global)/ );
 
 	if ( !name ) {
 		prefix = parser.matchPattern( prefixPattern ) || '';

--- a/src/view/resolvers/resolveReference.js
+++ b/src/view/resolvers/resolveReference.js
@@ -1,5 +1,6 @@
 import resolveAmbiguousReference from './resolveAmbiguousReference';
 import { splitKeypath } from '../../shared/keypaths';
+import GlobalModel from '../../model/specials/GlobalModel';
 
 export default function resolveReference ( fragment, ref ) {
 	let context = fragment.findContext();
@@ -15,6 +16,12 @@ export default function resolveReference ( fragment, ref ) {
 		return repeater.context.getIndexModel( repeater.index );
 	}
 	if ( ref === '@key' ) return fragment.findRepeatingFragment().context.getKeyModel();
+	if ( ref === '@ractive' ) {
+		return fragment.ractive.viewmodel.getRactiveModel();
+	}
+	if ( ref === '@global' ) {
+		return GlobalModel;
+	}
 
 	// ancestor references
 	if ( ref[0] === '~' ) return context.root.joinAll( splitKeypath( ref.slice( 2 ) ) );


### PR DESCRIPTION
__Post 0.8__

This adds two new special refs, `@ractive` and `@global`, that give access to the current Ractive instance and the global object (`window` in a browser environment). Unlike other special refs, these support accessing child paths.

### Why?

Well, for `@global`, it's an outstanding feature request from #1997. Anything in global scope can now be used in the template, which is particularly handy for using external libraries. It's also nice for integration into pages that aren't controlled entirely by Ractive. Two-way binding for child paths also works nicely. There is a single shared model that controls access to the global from within Ractive.

For `@ractive`, as mentioned in several issues recently, it's nice to be able to use functions that are added directly to the Ractive instance in a template. It's also convenient, at times, to track other things as properties on a particular Ractive instance, like, for instance, a shared Ace Editor instance for an edit decorator. For fiddle and development fun, you can also do things like `<input type="checkbox" value="{{@ractive.constructor.DEBUG}}" />` and `{{@ractive.constructor.VERSION}}`. Two-way binding is also supported for child paths on `@ractive` refs. Each `RootModel` creates a single `RactiveModel` instance when needed, and the resolution process pulls it from the fragment Ractive instance.

In addition to being accessible from the template, both `@ractive` and `@global` are accessible in keypaths from the API e.g. `ractive.set('@global.some.value', 42)` so that they can be used in method events and more easily keep template refs in sync with outside state.