### PR TITLE
throw if element is created inside an <option>

### DIFF
--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -41,6 +41,10 @@ export default class Element extends Item {
 			fragment = fragment.parent;
 		}
 
+		if ( this.parent && this.parent.name === 'option' ) {
+			throw new Error( `An <option> element cannot contain other elements (encountered <${this.name}>)` );
+		}
+
 		// create attributes
 		this.attributeByName = {};
 		this.attributes = [];

--- a/test/browser-tests/render/elements.js
+++ b/test/browser-tests/render/elements.js
@@ -19,6 +19,15 @@ test( 'option element with custom selected logic works without error and correct
 	t.equal( ractive.find('select').value , 2 );
 });
 
+test( 'element inside option is an error', t => {
+	t.throws( () => {
+		const ractive = new Ractive({
+			el: fixture,
+			template: '<select><option><blink/></option></select>'
+		});
+	}, /An <option> element cannot contain other elements \(encountered <blink>\)/ );
+});
+
 test( 'Input with uppercase tag name binds correctly', t => {
 	const ractive = new Ractive({
 		el: fixture,


### PR DESCRIPTION
It's a special case for `<option>` – don't know how far we want to go down this road. Though it could be extended to other text-only elements easily enough – does anyone know if there are any other than `<option>`?

Fixes #2242 (sort of)