### PR TITLE
Append arguments automatically on re-fired events, more robust arguments spread in method calls

### DIFF
--- a/src/parse/converters/element/processDirective.js
+++ b/src/parse/converters/element/processDirective.js
@@ -5,6 +5,7 @@ import parseJSON from '../../../utils/parseJSON';
 
 var methodCallPattern = /^([a-zA-Z_$][a-zA-Z_$0-9]*)\(/,
 	methodCallExcessPattern = /\)\s*$/,
+	spreadPattern = /(\s*,{0,1}\s*\.{3}arguments\s*)$/,
 	ExpressionParser;
 
 ExpressionParser = Parser.extend({
@@ -15,8 +16,6 @@ ExpressionParser = Parser.extend({
 export default function processDirective ( tokens, parentParser ) {
 	var result,
 		match,
-		parser,
-		args,
 		token,
 		colonIndex,
 		directiveName,
@@ -35,14 +34,16 @@ export default function processDirective ( tokens, parentParser ) {
 			result = { m: match[1] };
 			const sliced = tokens.slice( result.m.length + 1, end );
 
-			if ( sliced === '...arguments' ) {
-				// TODO: what the heck should this be???
-				// maybe ExpressionParser should understand ES6???
+			// does the method include spread of ...arguments?
+			const args = sliced.replace( spreadPattern, '' );
+
+			// if so, other arguments should be appended to end of method arguments
+			if ( sliced !== args ) {
 				result.g = true;
 			}
-			else {
-				args = '[' + sliced + ']';
-				parser = new ExpressionParser( args );
+
+			if ( args ) {
+				const parser = new ExpressionParser( '[' + args + ']' );
 				result.a = flattenExpression( parser.result[0] );
 			}
 

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -42,13 +42,13 @@ export default class EventDirective {
 		if ( template.m ) {
 			this.method = template.m;
 
-			if ( this.passthru = template.g ) {
-				// on-click="foo(...arguments)"
-				// no models or args, just pass thru values
-			}
-			else {
+			// pass-thru "...arguments"
+			this.passthru = !!template.g;
+
+			if ( template.a ) {
 				this.resolvers = [];
 				this.models = template.a.r.map( ( ref, i ) => {
+
 					if ( eventPattern.test( ref ) ) {
 						// on-click="foo(event.node)"
 						return {
@@ -128,14 +128,13 @@ export default class EventDirective {
 		}
 	}
 
-	fire ( event, passedArgs ) {
+	fire ( event, passedArgs = [] ) {
+
 		// augment event object
 		if ( event ) {
 			event.keypath = this.context.getKeypath();
 			event.context = this.context.get();
 			event.index = this.parentFragment.indexRefs;
-
-			if ( passedArgs ) passedArgs.unshift( event );
 		}
 
 		if ( this.method ) {
@@ -145,10 +144,9 @@ export default class EventDirective {
 
 			let args;
 
-			if ( this.passthru ) {
-				args = passedArgs;
-			}
-			else {
+			if ( event ) passedArgs.unshift( event );
+
+			if ( this.models ) {
 				const values = this.models.map( model => {
 					if ( !model ) return undefined;
 
@@ -174,6 +172,9 @@ export default class EventDirective {
 				args = this.argsFn.apply( null, values );
 			}
 
+			if ( this.passthru ) {
+				args = args ? args.concat( passedArgs ) : passedArgs;
+			}
 
 			// make event available as `this.event`
 			const ractive = this.ractive;
@@ -187,6 +188,8 @@ export default class EventDirective {
 		else {
 			const action = this.action.toString();
 			let args = this.template.d ? this.args.getArgsList() : this.args;
+
+			if ( passedArgs.length ) args = args.concat( passedArgs );
 
 			if ( event ) event.name = action;
 

--- a/test/browser-tests/events/dom-proxy-events.js
+++ b/test/browser-tests/events/dom-proxy-events.js
@@ -551,8 +551,8 @@ test( 'Proxy event arguments update correctly (#2098)', t => {
 	fire( button, 'click' );
 });
 
-test( 'component "on-" supply own event proxy arguments', t => {
-	t.expect( 4 );
+test( 'component "on-" supply own event proxy arguments (but original args are tacked on)', t => {
+	t.expect( 5 );
 
 	const Component = Ractive.extend({
 		template: '<span id="test" on-click="foo:\'foo\'">click me</span>'
@@ -575,7 +575,9 @@ test( 'component "on-" supply own event proxy arguments', t => {
 		t.equal( arg1, 'qux' );
 	});
 	ractive.on( 'bizz-reproxy', function () {
-		t.equal( arguments.length, 0 );
+		// original args are implicitly included...
+		t.equal( arguments.length, 1 );
+		t.equal( arguments[0], 'buzz' );
 	});
 
 	const component = ractive.findComponent( 'Component' );
@@ -585,7 +587,7 @@ test( 'component "on-" supply own event proxy arguments', t => {
 });
 
 test( 'component "on-" handles reproxy of arguments correctly', t => {
-	t.expect( 4 );
+	t.expect( 5 );
 
 	const Component = Ractive.extend({
 		template: '<span id="test" on-click="foo:\'foo\'">click me</span>'
@@ -599,10 +601,12 @@ test( 'component "on-" handles reproxy of arguments correctly', t => {
 
 	ractive.on( 'foo-reproxy', ( e, ...args ) => {
 		t.equal( e.original.type, 'click' );
-		t.equal( args.length, 0 );
+		t.equal( args.length, 1 );
 	});
 	ractive.on( 'bar-reproxy', function () {
-		t.equal( arguments.length, 0 );
+		t.equal( arguments.length, 1 );
+		// implicitly included
+		t.equal( arguments[0], 'bar' );
 	});
 	ractive.on( 'bizz-reproxy', function () {
 		t.equal( arguments.length, 0 );

--- a/test/browser-tests/events/method-calls.js
+++ b/test/browser-tests/events/method-calls.js
@@ -183,7 +183,7 @@ test( 'component "on-" with additive ...arguments', t => {
 
 	const ractive = new Ractive({
 		el: fixture,
-		template: '<Component on-foo="foo(\'fooarg\', ...arguments)" on-bar="bar(\'bararg\', ...arguments)"/>',
+		template: `<Component on-foo="foo('fooarg', ...arguments)" on-bar="bar('bararg', ...arguments)"/>`,
 		components: { Component },
 		foo ( arg1, e, arg2, arg3 ) {
 			t.equal( arg1, 'fooarg' );
@@ -212,7 +212,7 @@ test( 'component "on-" with arguments[n]', t => {
 
 	const ractive = new Ractive({
 		el: fixture,
-		template: '<Component on-foo="foo(arguments[2], \'qux\', arguments[0])" on-bar="bar(arguments[0], 100)"/>',
+		template: `<Component on-foo="foo(arguments[2], 'qux', arguments[0])" on-bar="bar(arguments[0], 100)"/>`,
 		components: { Component },
 		foo ( arg1, arg2, arg3 ) {
 			t.equal( arg1, 42 );

--- a/test/browser-tests/events/method-calls.js
+++ b/test/browser-tests/events/method-calls.js
@@ -174,6 +174,35 @@ test( 'component "on-" with ...arguments', t => {
 	component.fire( 'bar', 'bar', 100 );
 });
 
+test( 'component "on-" with additive ...arguments', t => {
+	t.expect( 7 );
+
+	const Component = Ractive.extend({
+		template: `<span id="test" on-click="foo:'foo', 42">click me</span>`
+	});
+
+	const ractive = new Ractive({
+		el: fixture,
+		template: '<Component on-foo="foo(\'fooarg\', ...arguments)" on-bar="bar(\'bararg\', ...arguments)"/>',
+		components: { Component },
+		foo ( arg1, e, arg2, arg3 ) {
+			t.equal( arg1, 'fooarg' );
+			t.equal( e.original.type, 'click' );
+			t.equal( arg2, 'foo' );
+			t.equal( arg3, 42 );
+		},
+		bar ( arg1, arg2, arg3 ) {
+			t.equal( arg1, 'bararg' );
+			t.equal( arg2, 'bar' );
+			t.equal( arg3, 100 );
+		}
+	});
+
+	const component = ractive.findComponent( 'Component' );
+	fire( component.nodes.test, 'click' );
+	component.fire( 'bar', 'bar', 100 );
+});
+
 test( 'component "on-" with arguments[n]', t => {
 	t.expect( 5 );
 

--- a/test/browser-tests/events/method-calls.js
+++ b/test/browser-tests/events/method-calls.js
@@ -174,6 +174,16 @@ test( 'component "on-" with ...arguments', t => {
 	component.fire( 'bar', 'bar', 100 );
 });
 
+test( 'component ...arguments must be last argument', t => {
+	t.throws( () => {
+		new Ractive({
+			template: `<c on-foo="foo(...arguments, 'arg after spread')"/>`
+		});
+	}, /Expected a property name/);
+
+
+});
+
 test( 'component "on-" with additive ...arguments', t => {
 	t.expect( 7 );
 


### PR DESCRIPTION
Fixes #2253. Component event directives now append existing arguments by default:

`<widget on-foo='bar' on-qux:'bizz:{{buzz}}'/>`

will now fire `bar` and `bizz` with original arguments from `foo` and `qux` appended to any supplied arguments (added to value of `{{buzz}}` in `on-qux` firing of `bizz`).

Also makes `...argument` in method calls more robust by allowing inclusion of spread at end of method allowing other arguments to be included:

`<widget on-foo='bar( "foo", ...arguments )'/>`
