### PR TITLE
Root refs in components should use component viewmodel not context

### DIFF
--- a/src/view/resolvers/resolveReference.js
+++ b/src/view/resolvers/resolveReference.js
@@ -17,7 +17,7 @@ export default function resolveReference ( fragment, ref ) {
 	if ( ref === '@key' ) return fragment.findRepeatingFragment().context.getKeyModel();
 
 	// ancestor references
-	if ( ref[0] === '~' ) return context.root.joinAll( splitKeypath( ref.slice( 2 ) ) );
+	if ( ref[0] === '~' ) return fragment.ractive.viewmodel.joinAll( splitKeypath( ref.slice( 2 ) ) );
 	if ( ref[0] === '.' ) {
 		const parts = ref.split( '/' );
 

--- a/test/browser-tests/components/data-and-mappings.js
+++ b/test/browser-tests/components/data-and-mappings.js
@@ -1118,3 +1118,23 @@ test( 'Interpolators based on computed mappings update correctly #2261)', t => {
 	ractive.set( 'tab', 'bar' );
 	t.htmlEqual( fixture.innerHTML, 'inactive active' );
 });
+
+test( 'root references inside a component should resolve to the component', t => {
+	const cmp = Ractive.extend({
+		template: '{{#with foo.bar}}{{~/test}}{{/with}}',
+		data: function() {
+			return { test: 'yep' };
+		}
+	});
+
+	new Ractive({
+		el: fixture,
+		template: '<cmp foo="{{baz.bat}}" />',
+		components: { cmp },
+		data: {
+			baz: { bat: 'nope' }
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'yep' );
+});


### PR DESCRIPTION
In a component, in `{{#with some.mapped.path}}{{~/local}}{{/with}}`, `local` is trying to resolve using the mapped context root instead of the component root. I believe the correct behavior would be to use the component root instead, right?