### PR TITLE
Computations are models that don't shuffle

### DIFF
--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -62,6 +62,9 @@ export default class Computation extends Model {
 
 		this.boundsSensitive = true;
 		this.dirty = true;
+
+		// computations don't shuffle
+		this.shuffle = undefined;
 	}
 
 	get ( shouldCapture ) {

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -63,7 +63,7 @@ export default class Computation extends Model {
 		this.boundsSensitive = true;
 		this.dirty = true;
 
-		// computations don't shuffle
+		// TODO: computations don't shuffle, but this is a bit hackish
 		this.shuffle = undefined;
 	}
 

--- a/test/browser-tests/shuffling.js
+++ b/test/browser-tests/shuffling.js
@@ -184,6 +184,36 @@ test( 'method event directives with no args should shuffle without throwing', t 
 	r.unshift( 'items', 2 );
 });
 
+test( 'shuffling around a computation with an index ref', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#each items.slice(1)}}{{2 * @index}} {{@index * .}}|{{/each}}`,
+		data: {
+			items: [ 1, 2 ]
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, '0 0|' );
+	r.splice( 'items', 1, 0, 3, 4 );
+	t.htmlEqual( fixture.innerHTML, '0 0|2 4|4 4|' );
+	r.splice( 'items', 0, 1 );
+	t.htmlEqual( fixture.innerHTML, '0 0|2 2|' );
+});
+
+test( 'shuffling a computation should not cause the computation to shuffle (#2267 #2269)', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#each items.slice(1)}}{{.}}{{/each}}`,
+		data: {
+			items: [ 1, 2 ]
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, '2' );
+	r.splice( 'items', 0, 1 );
+	t.htmlEqual( fixture.innerHTML, '' );
+});
+
 // TODO reinstate this in some form. Commented out for purposes of #1740
 // test( `Array shuffling only adjusts context and doesn't tear stuff down to rebuild it`, t => {
 // 	let ractive = new Ractive({


### PR DESCRIPTION
Computations are one of those weird dep/child hybrids that automatically inherit the model shuffle, but since they aren't really shuffle-able, they should not have a shuffle method. This overrides the prototype shuffle property with undefined during construction and fixes #2267 and #2269. Thoughts?