### PR TITLE
Update text input types with safe string value

### DIFF
--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -4,6 +4,8 @@ import { arrayContains } from '../../../../utils/array';
 import { isArray } from '../../../../utils/is';
 import noop from '../../../../utils/noop';
 
+const textTypes = [ undefined, 'text', 'search', 'url', 'email', 'hidden', 'password', 'search', 'reset', 'submit' ];
+
 export default function getUpdateDelegate ( attribute ) {
 	const { element, name } = attribute;
 
@@ -15,7 +17,7 @@ export default function getUpdateDelegate ( attribute ) {
 			return element.getAttribute( 'multiple' ) ? updateMultipleSelectValue : updateSelectValue;
 		}
 
-		if ( element.name === 'textarea' ) return updateValue;
+		if ( element.name === 'textarea' ) return updateStringValue;
 
 		// special case - contenteditable
 		if ( element.getAttribute( 'contenteditable' ) != null ) return updateContentEditableValue;
@@ -29,6 +31,8 @@ export default function getUpdateDelegate ( attribute ) {
 
 			// type='radio' name='{{twoway}}'
 			if ( type === 'radio' && element.binding && element.binding.attribute.name === 'name' ) return updateRadioValue;
+
+			if ( ~textTypes.indexOf( type ) ) return updateStringValue;
 		}
 
 		return updateValue;
@@ -143,6 +147,17 @@ function updateValue () {
 
 		this.node.value = this.node._ractive.value = value;
 		this.node.setAttribute( 'value', value );
+	}
+}
+
+function updateStringValue () {
+	if ( !this.locked ) {
+		const value = this.getValue();
+
+		this.node._ractive.value = value;
+
+		this.node.value = safeToStringValue( value );
+		this.node.setAttribute( 'value', safeToStringValue( value ) );
 	}
 }
 

--- a/test/browser-tests/forms.js
+++ b/test/browser-tests/forms.js
@@ -125,3 +125,14 @@ test( 'textareas without binding allow any template content (#2063)', t => {
 	r.set( 'baz', '<strong>change3</strong>' );
 	t.equal( fixture.querySelector( 'textarea' ).value, '<i>change1</i>change2 <strong>change3</strong>' );
 });
+
+test( 'input that has binding change to undefined should be blank (#2279)', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '<input value="{{foo}}" />'
+	});
+
+	t.equal( r.find( 'input' ).value, '' );
+	r.set( 'foo', undefined );
+	t.equal( r.find( 'input' ).value, '' );
+});


### PR DESCRIPTION
This adds a check for text inputs so that they don't get set to `undefined` but get a "safe" string instead. Thoughts?