### PR TITLE
Regression from #2269

### DIFF
--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -19,6 +19,10 @@ function getRefs ( ref, value, parent ) {
 	return refs;
 }
 
+function activeIterations( array ) {
+	return array.filter( i => !!i );
+}
+
 export default class RepeatedFragment {
 	constructor ( options ) {
 		this.parent = options.owner.parentFragment;
@@ -114,7 +118,7 @@ export default class RepeatedFragment {
 
 	detach () {
 		const docFrag = createDocumentFragment();
-		this.iterations.forEach( fragment => docFrag.appendChild( fragment.detach() ) );
+		activeIterations( this.iterations ).forEach( fragment => docFrag.appendChild( fragment.detach() ) );
 		return docFrag;
 	}
 
@@ -123,6 +127,7 @@ export default class RepeatedFragment {
 		let i;
 
 		for ( i = 0; i < len; i += 1 ) {
+			if ( !this.iterations[i] ) continue;
 			const found = this.iterations[i].find( selector );
 			if ( found ) return found;
 		}
@@ -133,6 +138,7 @@ export default class RepeatedFragment {
 		let i;
 
 		for ( i = 0; i < len; i += 1 ) {
+			if ( !this.iterations[i] ) continue;
 			this.iterations[i].findAll( selector, query );
 		}
 	}
@@ -142,6 +148,7 @@ export default class RepeatedFragment {
 		let i;
 
 		for ( i = 0; i < len; i += 1 ) {
+			if ( !this.iterations[i] ) continue;
 			const found = this.iterations[i].findComponent( name );
 			if ( found ) return found;
 		}
@@ -152,6 +159,7 @@ export default class RepeatedFragment {
 		let i;
 
 		for ( i = 0; i < len; i += 1 ) {
+			if ( !this.iterations[i] ) continue;
 			this.iterations[i].findAllComponents( name, query );
 		}
 	}
@@ -159,6 +167,7 @@ export default class RepeatedFragment {
 	findNextNode ( iteration ) {
 		if ( iteration.index < this.iterations.length - 1 ) {
 			for ( let i = iteration.index + 1; i < this.iterations.length; i++ ) {
+				if ( !this.iterations[i] ) continue;
 				let node = this.iterations[ i ].firstNode();
 				if ( node ) return node;
 			}
@@ -175,8 +184,8 @@ export default class RepeatedFragment {
 		this.context = context;
 
 		// {{#each array}}...
-		if ( isArray( context.get() ) ) {
-			this.iterations.forEach( ( fragment, i ) => {
+		if ( context && isArray( context.get() ) ) {
+			activeIterations( this.iterations ).forEach( ( fragment, i ) => {
 				const model = context.joinKey( i );
 				if ( this.owner.template.z ) {
 					fragment.aliases = {};
@@ -191,7 +200,7 @@ export default class RepeatedFragment {
 		// TODO use docFrag.cloneNode...
 
 		if ( this.iterations ) {
-			this.iterations.forEach( fragment => fragment.render( target, occupants ) );
+			activeIterations( this.iterations ).forEach( fragment => fragment.render( target, occupants ) );
 		}
 
 		this.rendered = true;
@@ -222,17 +231,17 @@ export default class RepeatedFragment {
 
 	toString ( escape ) {
 		return this.iterations ?
-			this.iterations.map( escape ? toEscapedString : toString ).join( '' ) :
+			activeIterations( this.iterations ).map( escape ? toEscapedString : toString ).join( '' ) :
 			'';
 	}
 
 	unbind () {
-		this.iterations.forEach( unbind );
+		activeIterations( this.iterations ).forEach( unbind );
 		return this;
 	}
 
 	unrender ( shouldDestroy ) {
-		this.iterations.forEach( shouldDestroy ? unrenderAndDestroy : unrender );
+		activeIterations( this.iterations ).forEach( shouldDestroy ? unrenderAndDestroy : unrender );
 		if ( this.pendingNewIndices && this.previousIterations ) {
 			this.previousIterations.forEach( fragment => {
 				if ( fragment.rendered ) shouldDestroy ? unrenderAndDestroy( fragment ) : unrender( fragment );
@@ -381,6 +390,9 @@ export default class RepeatedFragment {
 
 			previousNewIndex = newIndex;
 		});
+		for ( let i = newIndices.length; i < this.previousIterations.length; i++ ) {
+			this.previousIterations[ i ].unbind().unrender( true );
+		}
 
 		// create new iterations
 		const docFrag = this.rendered ? createDocumentFragment() : null;

--- a/src/view/items/element/specials/Select.js
+++ b/src/view/items/element/specials/Select.js
@@ -23,7 +23,7 @@ export default class Select extends Element {
 				runloop.scheduleTask( () => {
 					this.sync();
 					this.dirty = false;
-				});
+				}, true );
 			}
 
 			this.parentFragment.bubble(); // default behaviour


### PR DESCRIPTION
This is the follow-on from the second issue in #2269. The issue is a regression in edge with a number of different components, including a shuffle from and immediate observer, a two-way binding select, and setting a populated array to a different array instance while also shuffling.

In some scenarios, a repeated fragment can be rebound with an undefined context. I wasn't able to pin down exactly how it happened because the template was particularly complex. My attempts at reproducing with a simpler template failed, but adding a check for a truthy context kept from throwing.

After a shuffle and before the runloop completes, observers that cause updates to a repeated fragment may cause some interaction with now-undefined iterations on that fragment. To avoid that, this adds a check that filters out the undefined portions.

Finally, select bindings forcing an update before the end of a runloop can cause some pretty nasty things to happen when the select should be disappearing anyways, so this bumps that to the end of the outermost runloop.

## Alternatively...

I think it may be better to call this a breaking change for 0.8 and recommend deferred observers for anything that will write to a model or cause another dom update. Are we shooting for absolute minimal breaking changes for 0.8?