### PR TITLE
use locally-defined namespaces where applicable

### DIFF
--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -6,6 +6,7 @@ import Attribute from './element/Attribute';
 import ConditionalAttribute from './element/ConditionalAttribute';
 import Decorator from './element/Decorator';
 import EventDirective from './shared/EventDirective';
+import lookupNamespace from './shared/lookupNamespace';
 import { findInViewHierarchy } from '../../shared/registry';
 import { DOMEvent, CustomEvent } from './element/ElementEvents';
 import Transition from './element/Transition';
@@ -22,13 +23,18 @@ function makeDirty ( query ) {
 	query.makeDirty();
 }
 
+const pattern = /(?:(\w+):)?([\w\-]+)/;
+
 export default class Element extends Item {
 	constructor ( options ) {
 		super( options );
 
 		this.liveQueries = []; // TODO rare case. can we handle differently?
 
-		this.name = options.template.e.toLowerCase();
+		const match = pattern.exec( options.template.e.toLowerCase() );
+
+		this.namespacePrefix = match[1];
+		this.name = match[2];
 		this.isVoid = voidElementNames.test( this.name );
 
 		// find parent element
@@ -436,6 +442,9 @@ function getNamespace ( element ) {
 	// Use specified namespace...
 	const xmlns = element.getAttribute( 'xmlns' );
 	if ( xmlns ) return xmlns;
+
+	const locallyDefined = lookupNamespace( element, element.namespacePrefix );
+	if ( locallyDefined ) return locallyDefined;
 
 	// ...or SVG namespace, if this is an <svg> element
 	if ( element.name === 'svg' ) return svg;

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -13,11 +13,11 @@ export default class Attribute extends Item {
 	constructor ( options ) {
 		super( options );
 
-		determineNameAndNamespace( this, options.name );
-
 		this.element = options.element;
 		this.parentFragment = options.element.parentFragment; // shared
 		this.ractive = this.parentFragment.ractive;
+
+		determineNameAndNamespace( this, options.name );
 
 		this.rendered = false;
 		this.updateDelegate = null;

--- a/src/view/items/element/attribute/determineNameAndNamespace.js
+++ b/src/view/items/element/attribute/determineNameAndNamespace.js
@@ -1,11 +1,12 @@
 import * as namespaces from '../../../../config/namespaces';
+import lookupNamespace from '../../shared/lookupNamespace';
 
 export default function ( attribute, name ) {
 	// are we dealing with a namespaced attribute, e.g. xlink:href?
 	const colonIndex = name.indexOf( ':' );
 	if ( colonIndex !== -1 ) {
 		// looks like we are, yes...
-		const namespacePrefix = name.substr( 0, colonIndex );
+		const namespacePrefix = name.substr( 0, colonIndex ).toLowerCase();
 
 		// ...unless it's a namespace *declaration*, which we ignore (on the assumption
 		// that only valid namespaces will be used)
@@ -13,11 +14,11 @@ export default function ( attribute, name ) {
 			name = name.substring( colonIndex + 1 );
 
 			attribute.name = name;
-			attribute.namespace = namespaces[ namespacePrefix.toLowerCase() ];
+			attribute.namespace = lookupNamespace( attribute.element, namespacePrefix ) || namespaces[ namespacePrefix ];
 			attribute.namespacePrefix = namespacePrefix;
 
 			if ( !attribute.namespace ) {
-				throw 'Unknown namespace ("' + namespacePrefix + '")';
+				throw new Error( `Unknown namespace ("${namespacePrefix}")` );
 			}
 
 			return;

--- a/src/view/items/shared/lookupNamespace.js
+++ b/src/view/items/shared/lookupNamespace.js
@@ -1,0 +1,13 @@
+export default function lookupNamespace ( element, prefix ) {
+	const qualified = `xmlns:${prefix}`;
+	let namespace;
+
+	while ( element ) {
+		namespace = element.getAttribute( qualified );
+		if ( namespace ) return namespace;
+
+		element = element.parent;
+	}
+
+	return null;
+}

--- a/test/browser-tests/render/namespaceURI.js
+++ b/test/browser-tests/render/namespaceURI.js
@@ -73,4 +73,17 @@ if ( svg ) {
 		t.equal( ractive.find( 'text' ).namespaceURI, svg );
 		t.htmlEqual( fixture.innerHTML, '<svg><text>yup</text></svg>' );
 	});
+
+	test( 'Custom namespaces are supported (#2038)', t => {
+		const ractive = new Ractive({
+			el: fixture,
+			template: `
+				<svg xmlns='http://www.w3.org/2000/svg' xmlns:v='http://schemas.microsoft.com/visio/2003/SVGExtensions/' >
+					<v:documentProperties v:langID='2057' v:viewMarkup='false'></v:documentProperties>
+				</svg>`
+		});
+
+		const documentProperties = ractive.find( 'documentProperties' );
+		t.equal( documentProperties.namespaceURI, 'http://schemas.microsoft.com/visio/2003/SVGExtensions/' );
+	});
 }


### PR DESCRIPTION
See #2038. This allows the use of funky namespaces in tags like `<v:documentProperties>`.

I'm not *certain* that it's the correct solution. If you have a tag like that in normal HTML it seems to just inherit the parent `namespaceURI`, and the element name has the prefix contained within it: http://jsfiddle.net/vmsegykr/ Does that mean we should also just ignore the namespace prefix?