### PR TITLE
Remove test warnings

### DIFF
--- a/src/Ractive/prototype/resetTemplate.js
+++ b/src/Ractive/prototype/resetTemplate.js
@@ -1,4 +1,5 @@
 import { default as templateConfigurator } from '../config/custom/template';
+import { createDocumentFragment } from '../../utils/dom';
 import Fragment from '../../view/Fragment';
 
 // TODO should resetTemplate be asynchronous? i.e. should it be a case
@@ -22,15 +23,17 @@ export default function Ractive$resetTemplate ( template ) {
 	if ( component ) component.shouldDestroy = false;
 
 	// remove existing fragment and create new one
-	this.fragment.unbind();
+	this.fragment.unbind().unrender( true );
+
 	this.fragment = new Fragment({
 		template: this.template,
 		root: this,
 		owner: this
 	});
-	this.fragment.bind( this.viewmodel );
 
-	this.render( this.el, this.anchor );
+	const docFrag = createDocumentFragment();
+	this.fragment.bind( this.viewmodel ).render( docFrag );
+	this.el.insertBefore( docFrag, this.anchor );
 
 	this.transitionsEnabled = transitionsEnabled;
 }

--- a/src/view/items/element/Decorator.js
+++ b/src/view/items/element/Decorator.js
@@ -67,7 +67,7 @@ export default class Decorator {
 		const fn = findInViewHierarchy( 'decorators', this.ractive, this.name );
 
 		if ( !fn ) {
-			warnOnce( missingPlugin( this.name, 'decorators' ) );
+			warnOnce( missingPlugin( this.name, 'decorator' ) );
 			this.intermediary = missingDecorator;
 			return;
 		}

--- a/test/browser-tests/components/data-and-mappings.js
+++ b/test/browser-tests/components/data-and-mappings.js
@@ -416,6 +416,7 @@ test( 'foo.bar should stay in sync between <one foo="{{foo}}"/> and <two foo="{{
 test( 'qux.foo.bar should stay in sync between <one foo="{{foo}}"/> and <two foo="{{foo}}"/>', t => {
 	const ractive = new Ractive({
 		el: fixture,
+		data: { qux: { foo: {} } },
 		template: `
 			{{#with qux}}
 				<One foo='{{foo}}'/>
@@ -427,7 +428,6 @@ test( 'qux.foo.bar should stay in sync between <one foo="{{foo}}"/> and <two foo
 		}
 	});
 
-	ractive.set( 'qux.foo', {} );
 	t.htmlEqual( fixture.innerHTML, '<p></p><p></p>' );
 
 	ractive.findComponent( 'One' ).set( 'foo.bar', 'baz' );
@@ -635,6 +635,7 @@ test( 'Insane variable shadowing bug doesn\'t appear (#710)', t => {
 		el: fixture,
 		template: '<List items="{{sorted_items}}"/>',
 		components: { List },
+		data: () => ({ items: [] }),
 		computed: {
 			sorted_items () {
 				return this.get( 'items' ).slice().sort( ( a, b ) => a.rank - b.rank );

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -512,8 +512,7 @@ test( 'Double teardown is handled gracefully (#1218)', t => {
 });
 
 test( 'component.teardown() causes component to be removed from the DOM (#1223)', t => {
-	// TODO we get an incorrect console warning here:
-	// ractive.unrender() was called on a Ractive instance that was not rendered
+	onWarn( () => {} ); // suppress
 
 	const Widget = Ractive.extend({
 		template: '<p>I am here!</p>'

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -489,6 +489,8 @@ test( 'oninit() only fires once on a component (#943 #927), oncomplete fires eac
 test( 'Double teardown is handled gracefully (#1218)', t => {
 	t.expect( 0 );
 
+	onWarn( () => {} ); // suppress
+
 	const Widget = Ractive.extend({
 		template: '<p>foo: {{foo}}</p>'
 	});
@@ -510,6 +512,9 @@ test( 'Double teardown is handled gracefully (#1218)', t => {
 });
 
 test( 'component.teardown() causes component to be removed from the DOM (#1223)', t => {
+	// TODO we get an incorrect console warning here:
+	// ractive.unrender() was called on a Ractive instance that was not rendered
+
 	const Widget = Ractive.extend({
 		template: '<p>I am here!</p>'
 	});
@@ -567,6 +572,8 @@ test( 'Decorators and transitions are only initialised post-render, when compone
 });
 
 test( 'Data is synced as soon as an unresolved mapping is resolved', t => {
+	onWarn( () => {} ); // suppress
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: '<Outer/>',
@@ -689,6 +696,8 @@ test( 'Multiple components two-way binding', t => {
 });
 
 test( 'Explicit mappings with uninitialised data', t => {
+	onWarn( () => {} ); // suppress
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: '<Foo/>',
@@ -719,6 +728,8 @@ test( 'Implicit mappings with uninitialised data', t => {
 });
 
 test( 'Two-way bindings on an unresolved key can force resolution', t => {
+	onWarn( () => {} ); // suppress
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: '{{#context}}<Foo value="{{value}}" />{{/}}',
@@ -733,6 +744,8 @@ test( 'Two-way bindings on an unresolved key can force resolution', t => {
 });
 
 test( 'Component mappings used in computations resolve correctly with the mapping (#1645)', t => {
+	onWarn( () => {} ); // suppress
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: '<C1/>',
@@ -770,6 +783,8 @@ test( 'Component attributes with an empty string come back with an empty string'
 
 test( 'Unresolved keypath can be safely torn down', t => {
 	t.expect( 0 );
+
+	onWarn( () => {} ); // suppress
 
 	const ractive = new Ractive({
 		el: fixture,

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -197,6 +197,8 @@ test( 'Computed values with mix of computed and non-computed dependencies update
 });
 
 test( 'Computations that cause errors are considered undefined', t => {
+	onWarn( () => {} ); // suppress
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: '{{uppercaseBar}}',

--- a/test/browser-tests/events/touch-events.js
+++ b/test/browser-tests/events/touch-events.js
@@ -1,8 +1,11 @@
 import { test } from 'qunit';
 import { fire } from 'simulant';
+import { onWarn } from 'test-config';
 
 test( 'touch events safe to include when they don\'t exist in browser', t => {
 	t.expect( 1 );
+
+	onWarn( () => {} ); // suppress
 
 	const ractive = new Ractive({
 		el: fixture,

--- a/test/browser-tests/methods/reset.js
+++ b/test/browser-tests/methods/reset.js
@@ -189,9 +189,7 @@ test( 'resetTemplate removes an inline component from the DOM (#928)', t => {
 		},
 		components: {
 			Widget: Ractive.extend({
-				template ( data ) {
-					return data.type === 1 ? 'ONE' : 'TWO';
-				},
+				template: 'ONE',
 				oninit () {
 					this.observe( 'type', type => {
 						this.resetTemplate( type === 1 ? 'ONE' : 'TWO' );
@@ -201,6 +199,7 @@ test( 'resetTemplate removes an inline component from the DOM (#928)', t => {
 		}
 	});
 
+	t.htmlEqual( fixture.innerHTML, 'ONE' );
 	ractive.set( 'type', 2 );
 	t.htmlEqual( fixture.innerHTML, 'TWO' );
 });

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -175,6 +175,8 @@ test( 'Setting nested properties with a keypath correctly updates value of inter
 test( 'Functions are called with the ractive instance as context', t => {
 	t.expect( 1 );
 
+	onWarn( () => {} ); // suppress
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: '{{ foo() }}'
@@ -188,21 +190,16 @@ test( 'Functions are called with the ractive instance as context', t => {
 test( 'Methods are called with their object as context', t => {
 	t.expect( 1 );
 
+	onWarn( () => {} ); // suppress
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: '{{ foo.bar() }}'
 	});
 
-	let ran;
-
 	const foo = {
 		bar () {
-			// TODO why is this running twice?
-			if ( !ran ) {
-				t.equal( this, foo );
-			}
-
-			ran = true;
+			t.equal( this, foo );
 		}
 	};
 
@@ -249,6 +246,8 @@ test( 'Bindings without explicit keypaths can survive a splice operation', t => 
 	t.expect( 1 );
 
 	let items = new Array( 3 );
+
+	onWarn( () => {} ); // suppress
 
 	const ractive = new Ractive({
 		el: fixture,
@@ -605,6 +604,8 @@ try {
 	});
 
 	test( 'Implicit iterators work in magic mode', t => {
+		onWarn( msg => t.ok( /should be a plain JavaScript object/.test( msg ) ) );
+
 		let items = [
 			{ name: 'one' },
 			{ name: 'two' },

--- a/test/browser-tests/partials.js
+++ b/test/browser-tests/partials.js
@@ -109,6 +109,7 @@ test( 'partial function has access to parser helper', t => {
 		partials: {
 			foo ( parser ) {
 				t.ok( parser.fromId );
+				return 'x';
 			}
 		}
 	});
@@ -350,6 +351,8 @@ test( 'Dynamic partial works with merge (#1313)', t => {
 });
 
 test( 'Nameless expressions with no matching partial don\'t throw', t => {
+	onWarn( msg => t.ok( /Could not find template for partial 'missing'/.test( msg ) ) );
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: `{{> 'miss' + 'ing' }}`
@@ -373,6 +376,8 @@ test( 'Partials can be changed with resetPartial', t => {
 });
 
 test( 'Partials with variable names can be changed with resetPartial', t => {
+	onWarn( msg => /Could not find template for partial 'partial'/.test( msg ) );
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: 'wrapped {{>partial}} around',
@@ -394,6 +399,8 @@ test( 'Partials with variable names can be changed with resetPartial', t => {
 });
 
 test( 'Partials with expression names can be changed with resetPartial', t => {
+	onWarn( msg => /Could not find template for partial 'undefinedPartial'/.test( msg ) );
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: `wrapped {{>foo + 'Partial'}} around`,
@@ -600,6 +607,8 @@ test( 'Inline partials may be defined with a partial section', t => {
 });
 
 test( '(Only) inline partials can be yielded', t => {
+	onWarn( msg => /Could not find template for partial 'foo'/.test( msg ) );
+
 	const Widget = Ractive.extend({
 		template: '{{yield foo}}',
 		partials: { foo: 'bar' }
@@ -754,6 +763,8 @@ test( 'Several inline partials containing elements can be defined (#1736)', t =>
 test( 'Removing a missing partial (#1808)', t => {
 	t.expect( 0 );
 
+	onWarn( msg => /Could not find template for partial 'item'/.test( msg ) );
+
 	const ractive = new Ractive({
 		template: '{{#items}}{{>item}}{{/}}',
 		el: 'main',
@@ -815,6 +826,8 @@ test( 'Inline partials can override instance partials if they exist on a node di
 });
 
 test( 'resetting a dynamic partial to its reference name should replace the partial (#2185)', t => {
+	onWarn( msg => /Could not find template for partial 'nope'/.test( msg ) );
+
 	const r = new Ractive({
 		el: fixture,
 		template: '{{>part1}}{{>part2}}',

--- a/test/browser-tests/partials.js
+++ b/test/browser-tests/partials.js
@@ -376,7 +376,7 @@ test( 'Partials can be changed with resetPartial', t => {
 });
 
 test( 'Partials with variable names can be changed with resetPartial', t => {
-	onWarn( msg => /Could not find template for partial 'partial'/.test( msg ) );
+	onWarn( msg => t.ok( /Could not find template for partial 'partial'/.test( msg ) ) );
 
 	const ractive = new Ractive({
 		el: fixture,
@@ -399,7 +399,7 @@ test( 'Partials with variable names can be changed with resetPartial', t => {
 });
 
 test( 'Partials with expression names can be changed with resetPartial', t => {
-	onWarn( msg => /Could not find template for partial 'undefinedPartial'/.test( msg ) );
+	onWarn( msg => t.ok( /Could not find template for partial 'undefinedPartial'/.test( msg ) ) );
 
 	const ractive = new Ractive({
 		el: fixture,
@@ -607,7 +607,7 @@ test( 'Inline partials may be defined with a partial section', t => {
 });
 
 test( '(Only) inline partials can be yielded', t => {
-	onWarn( msg => /Could not find template for partial 'foo'/.test( msg ) );
+	onWarn( msg => t.ok( /Could not find template for partial "foo"/.test( msg ) ) );
 
 	const Widget = Ractive.extend({
 		template: '{{yield foo}}',
@@ -761,9 +761,9 @@ test( 'Several inline partials containing elements can be defined (#1736)', t =>
 });
 
 test( 'Removing a missing partial (#1808)', t => {
-	t.expect( 0 );
+	t.expect( 1 );
 
-	onWarn( msg => /Could not find template for partial 'item'/.test( msg ) );
+	onWarn( msg => t.ok( /Could not find template for partial 'item'/.test( msg ) ) );
 
 	const ractive = new Ractive({
 		template: '{{#items}}{{>item}}{{/}}',
@@ -826,7 +826,7 @@ test( 'Inline partials can override instance partials if they exist on a node di
 });
 
 test( 'resetting a dynamic partial to its reference name should replace the partial (#2185)', t => {
-	onWarn( msg => /Could not find template for partial 'nope'/.test( msg ) );
+	onWarn( msg => t.ok( /Could not find template for partial 'nope'/.test( msg ) ) );
 
 	const r = new Ractive({
 		el: fixture,

--- a/test/browser-tests/plugins/adaptors/basic.js
+++ b/test/browser-tests/plugins/adaptors/basic.js
@@ -1,6 +1,7 @@
 import { test } from 'qunit';
 import { fire } from 'simulant';
 import Model from 'helpers/Model';
+import { onWarn } from 'test-config';
 
 const adaptor = Model.adaptor;
 
@@ -59,6 +60,8 @@ test( 'Adaptors can change data as it is .set() (#442)', t => {
 });
 
 test( 'ractive.reset() calls are forwarded to wrappers if the root data object is wrapped', t => {
+	onWarn( msg => t.ok( /plain JavaScript object/.test( msg ) ) );
+
 	let model = new Model({
 		foo: 'BAR',
 		unwanted: 'here'

--- a/test/browser-tests/plugins/decorators.js
+++ b/test/browser-tests/plugins/decorators.js
@@ -27,9 +27,9 @@ if ( hasUsableConsole ) {
 	test( 'Missing decorator', t => {
 		t.expect( 1 );
 
-	    onWarn( msg => {
-	      t.ok( /Missing "foo" decorators plugin/.test( msg ) );
-	    });
+		onWarn( msg => {
+			t.ok( /Missing "foo" decorator plugin/.test( msg ) );
+		});
 
 		new Ractive({
 			el: fixture,
@@ -276,6 +276,8 @@ test( 'Teardown before init should work', t => {
 
 
 test( 'Dynamic and empty dynamic decorator and empty', t => {
+	onWarn( msg => t.ok( /Missing "" decorator plugin/.test( msg ) ) );
+
 	const ractive = new Ractive({
 		el: fixture,
 		debug: true,
@@ -357,13 +359,11 @@ test( 'Decorator teardown should happen after outros have completed (#1481)', t 
 test( 'Decorators can have their parameters change before they are rendered (#2278)', t => {
 	t.expect( 0 );
 
-	const dec = function() {
-		return { teardown() {} };
-	};
+	const dec = () => ({ teardown() {} });
 
 	new Ractive({
 		el: fixture,
-		decorator: { dec },
+		decorators: { dec },
 		template: '<div decorator="dec:{{foo}}" />',
 		data: {
 			foo: 1

--- a/test/browser-tests/render/mustache-compliance/all.js
+++ b/test/browser-tests/render/mustache-compliance/all.js
@@ -1,4 +1,5 @@
 import { test } from 'qunit';
+import { onWarn } from 'test-config';
 
 // MUSTACHE SPEC COMPLIANCE TESTS
 // ==============================
@@ -1191,6 +1192,10 @@ testModules.forEach( theModule => {
 		if ( theTest.unpassable || ( isOldIe && theTest.oldIe ) ) return;
 
 		test( `[${theModule.name}] ${theTest.name}`, t => {
+			onWarn( msg => {
+				t.ok( /Could not find template/.test( msg ) ); // only warning that should appear
+			});
+
 			new Ractive({
 				el: fixture,
 				template: theTest.template,

--- a/test/browser-tests/render/output.js
+++ b/test/browser-tests/render/output.js
@@ -2,6 +2,7 @@ import { test } from 'qunit';
 import 'legacy';
 import { svg } from 'config/environment';
 import tests from 'samples/render';
+import { onWarn } from 'test-config';
 
 function getData ( data ) {
 	return typeof data === 'function' ? data() : deepClone( data );
@@ -13,6 +14,9 @@ tests.forEach( theTest => {
 
 	test( theTest.name, t => {
 		const data = getData( theTest.data );
+
+		// suppress warnings about non-POJOs
+		onWarn( msg => t.ok( /plain JavaScript object/.test( msg ) ) );
 
 		const ractive = new Ractive({
 			el: fixture,

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -466,6 +466,8 @@ test( 'Reference expression radio bindings rebind correctly inside reference exp
 });
 
 test( 'Ambiguous reference expressions in two-way bindings attach to correct context', t => {
+	onWarn( () => {} ); // suppress
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: `
@@ -588,6 +590,9 @@ test( 'input[type="checkbox"] works with array mutated on init (#1305)', t => {
 });
 
 test( 'Downstream expression objects in two-way bindings do not trigger a warning (#1421)', t => {
+	// TODO what exactly is being tested here...?
+	onWarn( () => {} ); // suppress
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: '{{#foo()}}<input value="{{.}}">{{/}}',
@@ -643,6 +648,8 @@ test( 'Changes made after render to unresolved', t => {
 });
 
 test( 'If there happen to be unresolved references next to binding resolved references, the unresolveds should not be evicted by mistake (#1608)', t => {
+	onWarn( () => {} ); // suppress
+
 	const ractive = new Ractive({
 		el: fixture,
 		template: `
@@ -982,7 +989,9 @@ test( 'textarea with a single static interpolator as content should not set up a
 	t.equal( r.get( 'foo' ), 'baz' );
 });
 
-test( 'teaxtareas with non-model context should still bind correctly (#2099)', t => {
+test( 'textareas with non-model context should still bind correctly (#2099)', t => {
+	onWarn( () => {} ); // suppress
+
 	const r = new Ractive({
 		el: fixture,
 		template: `{{#with { foo: 'bar' }}}<textarea>{{.foo}}</textarea><button on-click="set(@keypath + '.foo', 'baz')">click me</button>{{/with}}`


### PR DESCRIPTION
When running the test suite you get a console full of warnings. It's annoying. They should either be suppressed, or considered part of the test. This PR does that