### PR TITLE
Allow keywords as references

### DIFF
--- a/src/parse/converters/readExpressionOrReference.js
+++ b/src/parse/converters/readExpressionOrReference.js
@@ -1,3 +1,4 @@
+import { REFERENCE } from '../../config/types';
 import readExpression from './readExpression';
 import readReference from './expressions/primary/readReference';
 
@@ -8,6 +9,15 @@ export default function readExpressionOrReference ( parser, expectedFollowers ) 
 	expression = readExpression( parser );
 
 	if ( !expression ) {
+		// valid reference but invalid expression e.g. `{{new}}`?
+		const ref = parser.matchPattern( /^(\w+)/ );
+		if ( ref ) {
+			return {
+				t: REFERENCE,
+				n: ref
+			};
+		}
+
 		return null;
 	}
 

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -1301,6 +1301,12 @@ const renderTests = [
 		template: '{{Object.keys(foo)}} {{Boolean(1)}} {{String(42)[0]}} {{Number("42").toFixed(1)}}',
 		data: { foo: { a: 1, b: 2 } },
 		result: 'a,b true 4 42.0'
+	},
+	{
+		name: 'keyword reference',
+		template: '{{new}}',
+		data: { new: 'old' },
+		result: 'old'
 	}
 ];
 


### PR DESCRIPTION
This makes it possible to have things like `{{new}}`, since sometimes you don't control the shape of your data. Good idea? Bad idea? Would fix #1934 