### PR TITLE
Adding error catch to component Hooks

### DIFF
--- a/src/Ractive/prototype/shared/hooks/Hook.js
+++ b/src/Ractive/prototype/shared/hooks/Hook.js
@@ -32,7 +32,12 @@ export default class Hook {
 	fire ( ractive, arg ) {
 		function call ( method ) {
 			if ( ractive[ method ] ) {
-				arg ? ractive[ method ]( arg ) : ractive[ method ]();
+				try {
+          arg ? ractive[ method ]( arg ) : ractive[ method ]();
+        } catch (e) {
+          ractive.fire('error', e);
+          console.error(e);
+        };
 				return true;
 			}
 		}


### PR DESCRIPTION
See:https://github.com/ractivejs/ractive/issues/1919
This will fire an error event to a component that fails to execute oninit, oncomplete, etc.

It also allows for the rest of the component to continue functioning, instead of breaking completely.

This may not be the best place to put the change, but here at least it will stop components dying.

Thoughts?
