### PR TITLE
Better, 'onchange' worthy observers at root/wildcard *

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -58,7 +58,8 @@ function createObserver ( ractive, keypath, callback, options ) {
 	if ( !~wildcardIndex ) {
 		const key = keys[0];
 
-		if ( !viewmodel.has( key ) ) {
+		// if not the root model itself, check if viewmodel has key.
+		if ( key !== '' && !viewmodel.has( key ) ) {
 			// if this is an inline component, we may need to create an implicit mapping
 			if ( ractive.component ) {
 				const model = resolveReference( ractive.component.parentFragment, key );
@@ -160,12 +161,8 @@ class PatternObserver {
 			this.oldValues = this.newValues;
 		}
 
-		if ( baseModel.isRoot && keys.length === 1 && keys[0] === '*' ) {
-			models.forEach( model => model.register( this ) );
-		}
-		else {
-			baseModel.register( this );
-		}
+		baseModel.register( this );
+
 	}
 
 	cancel () {
@@ -182,8 +179,11 @@ class PatternObserver {
 			if ( this.strict && newValue === oldValue ) return;
 			if ( isEqual( newValue, oldValue ) ) return;
 
-			const wildcards = this.pattern.exec( keypath ).slice( 1 );
-			const args = [ newValue, oldValue, keypath ].concat( wildcards );
+			let args = [ newValue, oldValue, keypath ];
+			if ( keypath ) {
+				const wildcards = this.pattern.exec( keypath ).slice( 1 );
+				args = args.concat( wildcards );
+			}
 
 			this.callback.apply( this.context, args );
 		});

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -47,7 +47,9 @@ export default class Computation extends Model {
 
 		this.root = this.parent = viewmodel;
 		this.signature = signature;
+
 		this.key = key; // not actually used, but helps with debugging
+		this.isExpression = key && key[0] === '@'
 
 		this.isReadonly = !this.signature.setter;
 

--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -41,19 +41,29 @@ export default class RootModel extends Model {
 		return computation;
 	}
 
+	extendChildren ( fn ) {
+		const mappings = this.mappings;
+		Object.keys( mappings ).forEach( key => {
+			fn( key, mappings[ key ] );
+		});
+
+		const computations = this.computations;
+		Object.keys( computations ).forEach( key => {
+			const computation = computations[ key ];
+			// exclude template expressions
+			if ( !computation.isExpression ) {
+				fn( key, computation );
+			}
+		});
+	}
+
 	get ( shouldCapture ) {
 		if ( shouldCapture ) capture( this );
 		let result = extend( {}, this.value );
 
-		Object.keys( this.mappings ).forEach( key => {
-			result[ key ] = this.mappings[ key ].value;
-		});
-
-		Object.keys( this.computations ).forEach( key => {
-			if ( key[0] !== '@' ) { // exclude template expressions
-				result[ key ] = this.computations[ key ].value;
-			}
-		});
+		this.extendChildren( ( key, model ) => {
+			result[ key ] = model.value;
+		})
 
 		return result;
 	}
@@ -64,6 +74,20 @@ export default class RootModel extends Model {
 
 	getRactiveModel() {
 		return this.ractiveModel || ( this.ractiveModel = new RactiveModel( this.ractive ) );
+	}
+
+	getValueChildren () {
+		const children = super.getValueChildren( this.value );
+
+		this.extendChildren( ( key, model ) => {
+			children.push( model );
+		})
+
+		return children;
+	}
+
+	handleChange () {
+		this.deps.forEach( handleChange );
 	}
 
 	has ( key ) {

--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -106,6 +106,7 @@ export default class RootModel extends Model {
 	map ( localKey, origin ) {
 		// TODO remapping
 		this.mappings[ localKey ] = origin;
+		origin.register( this );
 	}
 
 	set ( value ) {

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -884,16 +884,23 @@ test( `a pattern observer that is shuffled with objects should only notify on th
 	t.equal( count, 7 );
 });
 
-test( `wildcard * fires in components for mapped data`, t => {
-	t.expect(6);
+test( `wildcard * and root fire in components for mapped and local data`, t => {
+	t.expect(16);
 
-	let expect = 'foo';
+	let wckeypath = 'value';
+	let wcexpect = 'foo';
+	let rootexpect = { value: 'foo' };
 
 	const widget = Ractive.extend({
 		oninit () {
 			this.observe( '*', ( n, o, k ) => {
-				t.equal( n, expect );
-				t.equal( k, 'value' );
+				t.equal( n, wcexpect, 'wildcard value' );
+				t.equal( k, wckeypath, 'wildcard keypath' );
+			});
+
+			this.observe( ( n, o, k ) => {
+				t.deepEqual( n, rootexpect, 'root value' );
+				t.equal( k, '', 'root keypath' );
 			});
 		}
 	});
@@ -907,10 +914,19 @@ test( `wildcard * fires in components for mapped data`, t => {
 		components: { widget }
 	});
 
-	expect = 'bar';
+	wcexpect = 'bar';
+	rootexpect = { value: 'bar' };
 	r.set( 'foo', 'bar' );
-	expect = 'qux';
+
+	wcexpect = 'qux';
+	rootexpect = { value: 'qux' };
 	r.findComponent( 'widget' ).set( 'value', 'qux' );
+
+	wckeypath = 'bizz';
+	wcexpect = 'buzz';
+	rootexpect = { value: 'qux', bizz: 'buzz' };
+	r.findComponent( 'widget' ).set( 'bizz', 'buzz' );
+});
 });
 
 test( 'Pattern observer expects * to only apply to arrays and objects (#1923)', t => {

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -927,6 +927,30 @@ test( `wildcard * and root fire in components for mapped and local data`, t => {
 	rootexpect = { value: 'qux', bizz: 'buzz' };
 	r.findComponent( 'widget' ).set( 'bizz', 'buzz' );
 });
+
+test( 'wildcard * and root include computed but not expressions', t => {
+	let wildcard = 0, root = 0;
+
+	new Ractive({
+		el: fixture,
+		template: `{{ foo + 2 }}`,
+		data: { foo: 1 },
+		computed: { bar: '${foo} + 1'},
+		oninit () {
+			this.observe( '*', ( n, o, k ) => {
+				t.ok( k[0] !== '@' );
+				wildcard++;
+			});
+
+			this.observe( ( n, o, k ) => {
+				t.ok( k[0] !== '@' );
+				root++;
+			});
+		}
+	});
+
+	t.equal( wildcard, 2, 'wildcard count' );
+	t.equal( root, 1, 'root count' );
 });
 
 test( 'Pattern observer expects * to only apply to arrays and objects (#1923)', t => {
@@ -939,4 +963,17 @@ test( 'Pattern observer expects * to only apply to arrays and objects (#1923)', 
 			t.ok( false, 'observer should not fire' );
 		});
 	}, /Cannot get values of msg\.\* as msg is not an array, object or function/ );
+})
+
+test( 'wildcard * fires on new property', t => {
+	t.expect( 2 );
+
+	const ractive = new Ractive({ data: { qux: 'qux' } });
+
+	ractive.observe( '*', ( n, o, k ) => {
+		t.equal( k, 'foo' );
+		t.equal( n, 'bar' );
+	}, { init: false} );
+
+	ractive.set( 'foo', 'bar' );
 });


### PR DESCRIPTION
Follow-on to #2296, I started testing cases around #1990 being able to use observers faithfully for component root and `*` wildcard I found a number of issues around root observers and `'*'` observers:

* Template expressions with internal `@(..` keypaths are no longer included 
* Both `*` and root observers use correct component-relative keypaths
* Adding new properties works correctly