### PR TITLE
Prevent isolated components from accessing ancestor data via API - #2335

### DIFF
--- a/src/Ractive/prototype/get.js
+++ b/src/Ractive/prototype/get.js
@@ -12,7 +12,7 @@ export default function Ractive$get ( keypath ) {
 	if ( !this.viewmodel.has( key ) ) {
 		// if this is an inline component, we may need to create
 		// an implicit mapping
-		if ( this.component ) {
+		if ( this.component && !this.isolated ) {
 			model = resolveReference( this.component.parentFragment, key );
 
 			if ( model ) {

--- a/test/browser-tests/components/data-and-mappings.js
+++ b/test/browser-tests/components/data-and-mappings.js
@@ -341,6 +341,25 @@ test( 'Isolated components do not interact with ancestor viewmodels', t => {
 	t.htmlEqual( fixture.innerHTML, 'you should see me.' );
 });
 
+test( 'isolated components do not interact with ancestor viewmodels via API (#2335)', t => {
+	const cmp = Ractive.extend({
+		template: '{{foo}}',
+		oninit() {
+			this.set( 'foo', this.get( 'bar' ) ? 'nope' : 'yep' );
+		},
+		isolated: true
+	});
+
+	Ractive({
+		el: fixture,
+		data: { bar: true },
+		template: '<cmp />',
+		components: { cmp }
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'yep' );
+});
+
 test( 'Children do not nuke parent data when inheriting from ancestors', t => {
 	const Widget = Ractive.extend({
 		template: '<p>value: {{thing.value}}</p>'


### PR DESCRIPTION
The default resolution path in `Ractive.get` isn't currently checking isolation before trying to create a mapping using the parent fragment context as a jumping off point. Naturally, that will always resolve upstream, so this adds a check for isolation before taking that path.