### PR TITLE
Make sure nodes queued to detach after transition has started actually get detached - #2310

### DIFF
--- a/src/global/TransitionManager.js
+++ b/src/global/TransitionManager.js
@@ -74,7 +74,7 @@ function check ( tm ) {
 	// we notify the parent if there is one, otherwise
 	// start detaching nodes
 	if ( !tm.outrosComplete ) {
-		if ( tm.parent ) {
+		if ( tm.parent && !tm.parent.outrosComplete ) {
 			tm.parent.decrementOutros( tm );
 		} else {
 			tm.detachNodes();

--- a/test/browser-tests/plugins/transitions.js
+++ b/test/browser-tests/plugins/transitions.js
@@ -356,3 +356,19 @@ test( 'Conditional sections that become truthy are not rendered if a parent simu
 
 	t.ok( !transitionRan );
 });
+
+test( 'Nodes that are affected by deferred observers should actually get dettached (#2310)', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#if bar}}<span>baz</span>{{/if}}`,
+		data: { foo: true, bar: true }
+	});
+
+	r.observe( 'foo', v => r.set( 'bar', v ), { defer: true } );
+
+	t.htmlEqual( fixture.innerHTML, '<span>baz</span>' );
+	r.set( 'foo', false );
+	t.htmlEqual( fixture.innerHTML, '' );
+	r.set( 'foo', true );
+	t.htmlEqual( fixture.innerHTML, '<span>baz</span>' );
+});


### PR DESCRIPTION
This fixes #2310. The issue is that the transition manager starts and completes its outros before the deferred observers fire, and the deferred observers cause nodes to be removed and their transition manager is a child of the already completed original transition manager. So when the second round goes to detach, they never do because the parent transition manager is already done.

This skips the parent queue if the parent is already done and just goes ahead with the detachment. Would it be more appropriate to move the transition manager start to after the deferred observers fire?

@JonDum, can you try this out and let me know if it definitely fixes your problem?

@gaelicmichael, if you have a few spare cycles, could you try this as an alternative for the fixes in #2284?

I can provide test builds if anyone needs them.