### PR TITLE
Ractive @state RFC

### DIFF
--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -1,5 +1,6 @@
 import { capture } from '../global/capture';
 import { extend } from '../utils/object';
+import { stateKeyword } from '../shared/patterns';
 import Computation from './Computation';
 import Model from './Model';
 import { handleChange, mark } from '../shared/methodCallers';
@@ -63,7 +64,7 @@ export default class RootModel extends Model {
 
 		this.extendChildren( ( key, model ) => {
 			result[ key ] = model.value;
-		})
+		});
 
 		return result;
 	}
@@ -81,7 +82,7 @@ export default class RootModel extends Model {
 
 		this.extendChildren( ( key, model ) => {
 			children.push( model );
-		})
+		});
 
 		return children;
 	}
@@ -97,6 +98,14 @@ export default class RootModel extends Model {
 	joinKey ( key ) {
 		if ( key === '@global' ) return GlobalModel;
 		if ( key === '@ractive' ) return this.getRactiveModel();
+        
+        // state joins: not a keyword, starts with '@' but not a computation/expression
+        if ( key && !stateKeyword.test( key ) && key[0] === '@' && key[1] !== '{' ) {
+            if ( key[1] === '@' ) {
+                return this.getRactiveModel().joinKey( 'root' ).joinKey( key.slice(2) );
+            }
+            return this.getRactiveModel().joinKey( key.slice(1) );
+        }
 
 		return this.mappings.hasOwnProperty( key ) ? this.mappings[ key ] :
 		       this.computations.hasOwnProperty( key ) ? this.computations[ key ] :

--- a/src/model/specials/RactiveModel.js
+++ b/src/model/specials/RactiveModel.js
@@ -4,7 +4,9 @@ export default class RactiveModel extends Model {
 	constructor ( ractive ) {
 		super( null, '' );
 		this.value = ractive;
-		this.isRoot = true;
+		// removed because state keypaths need to include @ractive
+		// are there other sideeffects?
+		// this.isRoot = true;
 		this.root = this;
 		this.adaptors = [];
 		this.ractive = ractive;

--- a/src/shared/patterns.js
+++ b/src/shared/patterns.js
@@ -1,0 +1,1 @@
+export const stateKeyword =  /^@(?:keypath|rootpath|index|key|ractive|global)/;

--- a/test/browser-tests/render/state.js
+++ b/test/browser-tests/render/state.js
@@ -1,0 +1,114 @@
+import { test } from 'qunit';
+
+/* globals Ractive, fixture */
+
+test( 'Non-keywords @state as alias for @ractive.state in template mustaches', t => {
+	new Ractive({
+		el: fixture,
+		template: `{{@ractive.foo}}-{{@ractive['foo']}}-{{@ractive.bar()}}|{{@foo}}-{{@['foo']}}-{{@bar()}}`,
+		foo: 'foo',
+        bar () { return 'bar'; }
+	});
+
+	t.equal( fixture.innerHTML, 'foo-foo-bar|foo-foo-bar' );
+});
+
+test( 'Global @ractive.root state in template', t => {
+	new Ractive({
+		el: fixture,
+        template: '<child/>',
+		foo: 'foo',
+        bar () { return 'bar'; },
+        components: {
+            child: Ractive.extend({
+                // template: `{{@@foo}}-{{@@['foo']}}-{{@@bar()}}|{{@foo}}-{{@['foo']}}-{{@bar()}}`,
+               	template: `{{@@foo}}-{{@@bar()}}|{{@foo}}-{{@['foo']}}-{{@bar()}}`,
+                foo: 'f',
+                bar () { return 'b'; }
+            })
+        }
+	});
+
+	t.equal( fixture.innerHTML, 'foo-bar|f-f-b' /*'foo-foo-bar|f-f-b'*/ );
+});
+
+test( 'Basic @state via api', t => {
+	const ractive = new Ractive({
+		foo: 'foo'
+	});
+
+	t.equal( ractive.get( '@ractive.foo' ), 'foo' );
+	t.equal( ractive.get( '@foo' ), 'foo' );
+});
+
+
+test( 'Global @@state via api', t => {
+	const ractive = new Ractive({
+		el: fixture,
+        template: '<child/>',
+		foo: 'foo',
+        qux: 'qux',
+        components: {
+            child: Ractive.extend({
+                foo: 'f',
+            })
+        }
+	});
+
+    const child = ractive.findComponent( 'child' );
+    
+	t.equal( child.get( '@@foo' ), 'foo' );
+	t.equal( child.get( '@foo' ), 'f' );
+    
+    // no parent lookup for state
+    t.equal( child.get( '@qux' ), undefined );
+});
+
+test( 'Component @state mappings', t => {
+	const ractive = new Ractive({
+		el: fixture,
+        template: `<child @foo='{{@foo}}' @bar='{{bar}}' qux='{{@bizz}}'/>`,
+        data: { bar: 'bar' },
+		foo: 'foo',
+        bizz: 'bizz',
+        components: {
+            child: Ractive.extend({ isolated: true })
+        }
+	});
+
+    const child = ractive.findComponent( 'child' );
+    
+	t.equal( child.get( '@foo' ), 'foo' );
+	t.equal( child.foo, 'foo' );
+    
+	t.equal( child.get( '@bar' ), 'bar' );
+	t.equal( child.bar, 'bar' );
+    
+	t.equal( child.get( 'qux' ), 'bizz' );
+	t.equal( child.qux, undefined );
+	
+	// state parameters are "copied", so these should not update:
+	ractive.set( '@foo', 'f' );
+	ractive.set( 'bar', 'b' );
+	t.equal( child.get( '@foo' ), 'foo' );
+	t.equal( child.foo, 'foo' );
+	t.equal( child.get( '@bar' ), 'bar' );
+	t.equal( child.bar, 'bar' );
+	
+	// but data parameters "should" update when they're based on state
+	ractive.set( '@bizz', 'b' );
+	t.equal( child.get( 'qux' ), 'b' );
+	
+	// like-wise, state updates should not propagate upwards:
+	child.set( '@foo', 'oof' );
+	t.equal( ractive.foo, 'f' );
+	child.set( '@bar', 'rab' );
+	t.equal( ractive.get( 'bar' ), 'b' );
+	
+	// but data parameters mapped to parent state do update:
+	child.set( 'qux', 'xuq' );
+	t.equal( ractive.bizz, 'xuq' );
+	 
+});
+
+


### PR DESCRIPTION
With @evs-chris' work on #2250 which introduced the `@ractive` keyword, it did most of the heavy lifting to open the door to a state mechanism that works in along side with ractive `data`.
## how it works
- Because having to use the prefix `{{@ractive.foo}}` would litter the template with extraneous noise, at parse-time, refs that use the format `{{@foo}}` are treated as aliases for state on the ractive instance, _except for the the reserved keywords `keypath|rootpath|index|key|ractive|global`_:
  
  ``` js
  new Ractive({
      el: 'main',
      template: `{{@foo}} {{@upper(bar)}}`,
      data: { bar: 'bar' },
      foo: 'foo',
      upper ( str ) { return str.toUpperCase(); } 
  });
  ```
- The double `@@` is an alias for `@ractive.root`, with the intent being global "app" state. For example, if you add a `user` property to the root instance, you can access `{{@@user}}` anywhere.
  
  ``` js
  new Ractive({
      el: 'main',
      template: `<child/>`,
      data: { content },
      user,
      components: {
          child: Ractive.extend({ template: `{{@@user}}` })
      }
  });
  ```
- The api also supports `@foo`, so you can use it in computations or anywhere else you would access keypaths.
  
  ``` js
  ractive.get( '@foo' );
  ractive.set( '@bar', 'barzy' );
  ```

State behaves differently than data in the following ways:
1. State is always bound to the ractive instance and not the context stack, which makes sense as it refers to a property of the ractive instance.
2. As a corollary to 1., there is no lookup of state up the context stack _or up the component stack_. It's always on the instance.

Given those rules, when passing state between components:
1. State can be passed into components and become data:
   
   ``` handlebars
   <child bar='{{@foo}}'/>
   ```
   
   In this case, it is mapped like normal component data and `bar` will update as `@foo` updates in the parent and vice-versa.
2. State can be set in components (from either parent state or parent data):
   
   ``` handlebars
   <child @bar='{{@foo}}' @qux='{{bizz}}'/>
   ```
   
   **However**, when setting state on a component **it is copied and not mapped**. Object references would of course point to the same object, but would not be updated if changed to another instance in one and not the other. So passing state works as a starting point for the state on the component much more like a traditional js function parameter.
## concerns
1. `@state` exists on the instance, so it is possible to munge the ractive api, so perhaps these should be disallowed at parse time.
2. Also, there are internally used property names like `ractive.viewmodel` that probably need to get changed to `ractive._viewmodel` or added to the disallow list.
3. While this is all optional, and based on use cases people have shared, perhaps it is more confusion than help.
## misc

An additional level of state that could be added would be using a property prefixed with `@` on an existing data model. This would allow it to be associated with that data model keypath without actually writing it to that data. So it would look like: `{{ someObject.@foo }}`, `{{ this.@selected }}`, etc.  
