### PR TITLE
ensure correct transition context

### DIFF
--- a/src/view/items/element/Transition.js
+++ b/src/view/items/element/Transition.js
@@ -234,6 +234,6 @@ export default class Transition {
 			return;
 		}
 
-		this._fn.apply( this.root, [ this ].concat( this.params ) );
+		this._fn.apply( this.ractive, [ this ].concat( this.params ) );
 	}
 }

--- a/test/browser-tests/plugins/transitions.js
+++ b/test/browser-tests/plugins/transitions.js
@@ -372,3 +372,21 @@ test( 'Nodes that are affected by deferred observers should actually get dettach
 	r.set( 'foo', true );
 	t.htmlEqual( fixture.innerHTML, '<span>baz</span>' );
 });
+
+test( 'Context of transition function is current instance', t => {
+	t.expect( 1 );
+
+	const ractive = new Ractive({
+		el: fixture,
+		template: `{{#if visible}}<div intro='test'></div>{{/if}}`,
+		data: { visible: false },
+		transitions: {
+			test ( transition ) {
+				t.ok( this === ractive );
+				transition.complete;
+			}
+		}
+	});
+
+	ractive.set( 'visible', true );
+});


### PR DESCRIPTION
Regression via typo: the context of a transition function should be the instance in question