### PR TITLE
pass CSS IDs down through {{#each}} blocks

### DIFF
--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -29,6 +29,9 @@ export default class RepeatedFragment {
 		this.owner = options.owner;
 		this.ractive = this.parent.ractive;
 
+		// encapsulated styles should be inherited until they get applied by an element
+		this.cssIds = 'cssIds' in options ? options.cssIds : ( this.parent ? this.parent.cssIds : null );
+
 		this.context = null;
 		this.rendered = false;
 		this.iterations = [];

--- a/test/browser-tests/render/css.js
+++ b/test/browser-tests/render/css.js
@@ -298,3 +298,34 @@ test( 'data-ractive-css only gets applied to one level of elements', t => {
 	t.ok( ractive.find( 'div' ).hasAttribute( 'data-ractive-css' ) );
 	t.ok( !ractive.find( 'p' ).hasAttribute( 'data-ractive-css' ) );
 });
+
+test( 'top-level elements inside each blocks get encapsulated styles', t => {
+	const Widget = Ractive.extend({
+		template: `
+			<div class='one'>a</div>
+
+			{{#each list}}
+				<div class='two'>{{this}}</div>
+			{{/each}}`,
+		css: `
+			div { font-weight: 900; }
+			.one { color: red; }
+			.two { color: blue; }`
+	});
+
+	const ractive = new Widget({
+		el: fixture,
+		data: {
+			list: [ 1 ]
+		}
+	});
+
+	const one = ractive.find( '.one' );
+	const two = ractive.find( '.two' );
+
+	t.equal( getComputedStyle( one ).fontWeight, 900 );
+	t.equal( getComputedStyle( two ).fontWeight, 900 );
+
+	t.equal( getHexColor( one ), hexCodes.red );
+	t.equal( getHexColor( two ), hexCodes.blue );
+});


### PR DESCRIPTION
Another regression – the `data-ractive-css` IDs weren't getting passed down through `{{#each}}` blocks, causing errors with scoped CSS. [Demo](http://jsfiddle.net/rich_harris/2f2Lek77/)