### PR TITLE
Let runtime parsed partials contain other top-level partials - #1445

### DIFF
--- a/src/view/items/partial/getPartialTemplate.js
+++ b/src/view/items/partial/getPartialTemplate.js
@@ -14,6 +14,11 @@ export default function getPartialTemplate ( ractive, name, parentFragment ) {
 		// parse and register to this ractive instance
 		let parsed = parser.parseFor( partial, ractive );
 
+		// register extra partials on the ractive instance if they don't already exist
+		for ( let k in parsed.p ) {
+			if ( !( k in ractive.partials ) ) ractive.partials[ k ] = parsed.p[ k ];
+		}
+
 		// register (and return main partial if there are others in the template)
 		return ractive.partials[ name ] = parsed.t;
 	}

--- a/test/browser-tests/partials.js
+++ b/test/browser-tests/partials.js
@@ -1,3 +1,5 @@
+/* global document */
+
 import { test } from 'qunit';
 import { hasUsableConsole, onWarn } from 'test-config';
 
@@ -906,4 +908,23 @@ test( 'Partials can be given alias context (#2298)', t => {
 	});
 
 	t.htmlEqual( fixture.innerHTML, 'one two' );
+});
+
+test( 'Partials can be parsed from a partial template (#1445)', t => {
+	fixture.innerHTML = '<div id="fixture-tmp"></div>';
+	let script = document.createElement( 'script' );
+	script.setAttribute( 'type', 'text/html' );
+	script.setAttribute( 'id', 'foo' );
+	script[ 'textContent' in script ? 'textContent' : 'innerHTML' ] = `
+		{{#partial bar}}inner{{/partial}}
+		outer
+	`;
+	fixture.appendChild( script );
+
+	new Ractive({
+		el: '#fixture-tmp',
+		template: `{{>foo}} {{>bar}}`
+	});
+
+	t.htmlEqual( fixture.childNodes[0].innerHTML, 'outer inner' );
 });


### PR DESCRIPTION
Per #1445, if you have a partial script with another partial inlined, the inlined partial is lost. This allows the inlined partials to be added to the ractive partials store if there aren't already partials with the same names.