### PR TITLE
Forms should unrender properly - #2352

### DIFF
--- a/src/view/items/element/specials/Form.js
+++ b/src/view/items/element/specials/Form.js
@@ -12,8 +12,9 @@ export default class Form extends Element {
 		this.node.addEventListener( 'reset', handleReset, false );
 	}
 
-	unrender () {
+	unrender ( shouldDestroy ) {
 		this.node.removeEventListener( 'reset', handleReset, false );
+		super.unrender( shouldDestroy );
 	}
 }
 

--- a/test/browser-tests/forms.js
+++ b/test/browser-tests/forms.js
@@ -136,3 +136,16 @@ test( 'input that has binding change to undefined should be blank (#2279)', t =>
 	r.set( 'foo', undefined );
 	t.equal( r.find( 'input' ).value, '' );
 });
+
+test( 'forms should unrender properly #2352', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: 'foo: {{#if foo}}<form>Yep</form>{{/if}}',
+		data: { foo: true }
+	});
+
+	r.toggle( 'foo' );
+	t.htmlEqual( fixture.innerHTML, 'foo:' );
+	r.toggle( 'foo' );
+	t.htmlEqual( fixture.innerHTML, 'foo: <form>Yep</form>' );
+});


### PR DESCRIPTION
Turns out the Form item was missing its call to super in unrender. I didn't event know there was a Form item :smile:. See #2352.