### PR TITLE
Defer unresolved to after update for expressions - #2224 - RFC

### DIFF
--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -46,6 +46,8 @@ const runloop = {
 		batch.transitionManager.add( transition );
 	},
 
+	active () { return !!batch; },
+
 	// synchronise node detachments with transition ends
 	detachWhenReady ( thing ) {
 		batch.transitionManager.detachQueue.push( thing );

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -4,6 +4,7 @@ import { handleChange, unbind } from '../../shared/methodCallers';
 import getFunction from '../../shared/getFunction';
 import resolveReference from './resolveReference';
 import { removeFromArray } from '../../utils/array';
+import runloop from '../../global/runloop';
 
 function getValue ( model ) {
 	return model ? model.get( true ) : undefined;
@@ -77,6 +78,11 @@ export default class ExpressionProxy extends Model {
 		computation.register( this );
 
 		this.handleChange();
+	}
+
+	clearUnresolveds () {
+		if ( this.fragment.dirty && runloop.active() ) runloop.scheduleTask( () => this.clearUnresolveds() );
+		else super.clearUnresolveds();
 	}
 
 	get ( shouldCapture ) {

--- a/test/browser-tests/partials.js
+++ b/test/browser-tests/partials.js
@@ -928,3 +928,30 @@ test( 'Partials can be parsed from a partial template (#1445)', t => {
 
 	t.htmlEqual( fixture.childNodes[0].innerHTML, 'outer inner' );
 });
+
+
+test( 'Context computations are not called unnecessarily (#2224)', t => {
+	t.expect( 2 );
+
+	const ractive = new Ractive({
+		el: fixture,
+		template: `
+			{{#if foo}}
+				{{>p { x: y( foo.bar )} }}
+			{{/if}}`,
+		data: {
+			foo: { bar: 42 },
+			y ( num ) {
+				t.equal( num, 42 );
+				return num;
+			}
+		},
+		partials: {
+			p: '{{x}}'
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, '42' );
+
+	ractive.set( 'foo', null );
+});


### PR DESCRIPTION
See #2224. This is one of those chewy places where `ExpressionProxy` acts like a model and a virtual DOM item at the same time. Even though the item side is about to be removed, the model side is updated before that happens and triggers the computation again.

I tried to come at this from a few different angles:

1. Getting the computation to see if its fragment should be rendered by asking up the fragment hierarchy, but that was a big ugly change and was confusing to trace through at best.
2. Avoiding the call to `get` in `has`, but here there's no clear indicator as to when to skip.
  1. Using the cached `value` in `has` if the fragment is dirty. This breaks a few things too.
3. I finally landed on deferring unresolved clear for `ExpressionProxy`s to be deferred until after the round of fragment updates is processed if the fragment is dirty.

Number 3 seems to work fairly well, but I'm not positive it's the best approach. I had to add support for checking to see if there is an active batch to the `runloop` to avoid an infinite recursion scenario. Thoughts?