### PR TITLE
Allow expression proxies and object iteration sections to rebind - #2321 - RFC

### DIFF
--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -1,3 +1,5 @@
+/* global console */
+
 import { capture, startCapturing, stopCapturing } from '../global/capture';
 import { warnIfDebug } from '../utils/log';
 import Model from './Model';
@@ -49,7 +51,7 @@ export default class Computation extends Model {
 		this.signature = signature;
 
 		this.key = key; // not actually used, but helps with debugging
-		this.isExpression = key && key[0] === '@'
+		this.isExpression = key && key[0] === '@';
 
 		this.isReadonly = !this.signature.setter;
 
@@ -65,7 +67,7 @@ export default class Computation extends Model {
 		this.boundsSensitive = true;
 		this.dirty = true;
 
-		// TODO: computations don't shuffle, but this is a bit hackish
+		// TODO: is there a less hackish way to do this?
 		this.shuffle = undefined;
 	}
 

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -195,10 +195,6 @@ export default class Model {
 		return branch;
 	}
 
-	discard () {
-		this.deps.forEach( d => { if ( d.boundsSensitive ) this.unregister( d ); } );
-	}
-
 	findMatches ( keys ) {
 		const len = keys.length;
 
@@ -290,7 +286,7 @@ export default class Model {
 				children.push( originatingModel );
 			}
 			value.forEach( ( m, i ) => {
-				children.push( this.joinKey( i ) )
+				children.push( this.joinKey( i ) );
 			});
 
 		}
@@ -415,11 +411,8 @@ export default class Model {
 
 	shuffle ( newIndices ) {
 		const indexModels = [];
-		let max = 0, child;
 
 		newIndices.forEach( ( newIndex, oldIndex ) => {
-			if ( newIndex > max ) max = newIndex;
-
 			if ( !~newIndex ) return;
 
 			const model = this.indexModels[ oldIndex ];
@@ -433,14 +426,7 @@ export default class Model {
 			}
 		});
 
-		// some children, notably computations, need to be notified when they are
-		// no longer attached to anything so they don't recompute
-		while ( ( child = this.childByKey[ ++max ] ) ) {
-			if ( typeof child.discard === 'function' ) child.discard();
-		}
-
 		this.indexModels = indexModels;
-
 
 		// shuffles need to happen before marks...
 		this.deps.forEach( dep => {

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -177,17 +177,14 @@ export default class RepeatedFragment {
 	rebind ( context ) {
 		this.context = context;
 
-		// {{#each array}}...
-		if ( isArray( context.get() ) ) {
-			this.iterations.forEach( ( fragment, i ) => {
-				const model = context.joinKey( i );
-				if ( this.owner.template.z ) {
-					fragment.aliases = {};
-					fragment.aliases[ this.owner.template.z[0].n ] = model;
-				}
-				fragment.rebind( model );
-			});
-		}
+		this.iterations.forEach( ( fragment ) => {
+			const model = context.joinKey( fragment.key || fragment.index );
+			if ( this.owner.template.z ) {
+				fragment.aliases = {};
+				fragment.aliases[ this.owner.template.z[0].n ] = model;
+			}
+			fragment.rebind( model );
+		});
 	}
 
 	render ( target, occupants ) {

--- a/src/view/items/shared/Mustache.js
+++ b/src/view/items/shared/Mustache.js
@@ -46,6 +46,13 @@ export default class Mustache extends Item {
 	rebind () {
 		if ( this.isStatic || !this.model ) return;
 
+		// watch for expression proxies
+		if ( this.model.isExpression && this.model.rebind ) {
+			this.model.rebind();
+			this.handleChange();
+			return;
+		}
+
 		const model = resolve( this.parentFragment, this.template );
 
 		if ( model === this.model ) return;
@@ -63,6 +70,7 @@ export default class Mustache extends Item {
 	unbind () {
 		if ( !this.isStatic ) {
 			this.model && this.model.unregister( this );
+			this.model = undefined;
 			this.resolver && this.resolver.unbind();
 		}
 	}

--- a/src/view/items/shared/Mustache.js
+++ b/src/view/items/shared/Mustache.js
@@ -46,13 +46,6 @@ export default class Mustache extends Item {
 	rebind () {
 		if ( this.isStatic || !this.model ) return;
 
-		// watch for expression proxies
-		if ( this.model.isExpression && this.model.rebind ) {
-			this.model.rebind();
-			this.handleChange();
-			return;
-		}
-
 		const model = resolve( this.parentFragment, this.template );
 
 		if ( model === this.model ) return;

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -17,29 +17,12 @@ export default class ExpressionProxy extends Model {
 		this.template = template;
 
 		this.isReadonly = true;
+		this.isExpression = true;
 
 		this.fn = getFunction( template.s, template.r.length );
 		this.computation = null;
 
-		this.resolvers = [];
-		this.models = template.r.map( ( ref, index ) => {
-			const model = resolveReference( fragment, ref );
-			let resolver;
-
-			if ( !model ) {
-				resolver = fragment.resolve( ref, model => {
-					removeFromArray( this.resolvers, resolver );
-					this.models[ index ] = model;
-					this.bubble();
-				});
-
-				this.resolvers.push( resolver );
-			}
-
-			return model;
-		});
-
-		this.bubble();
+		this.bind();
 	}
 
 	bubble () {
@@ -80,6 +63,7 @@ export default class ExpressionProxy extends Model {
 	}
 
 	get ( shouldCapture ) {
+		if ( !this.computation ) return;
 		return this.computation.get( shouldCapture );
 	}
 
@@ -108,6 +92,33 @@ export default class ExpressionProxy extends Model {
 
 	mark () {
 		this.handleChange();
+	}
+
+	bind () {
+		this.resolvers = [];
+		this.models = this.template.r.map( ( ref, index ) => {
+			const model = resolveReference( this.fragment, ref );
+			let resolver;
+
+			if ( !model ) {
+				resolver = this.fragment.resolve( ref, model => {
+					removeFromArray( this.resolvers, resolver );
+					this.models[ index ] = model;
+					this.bubble();
+				});
+
+				this.resolvers.push( resolver );
+			}
+
+			return model;
+		});
+
+		this.bubble();
+	}
+
+	rebind () {
+		this.unbind();
+		this.bind();
 	}
 
 	retrieve () {

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -721,3 +721,27 @@ test( 'ExpressionProxy should notify its deps when it resolves (#2214)', t => {
 
 	t.htmlEqual( fixture.innerHTML, '-ok' );
 });
+
+test( 'computations should not recompute when spliced out', t => {
+	let count = 0;
+
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#each foo}}{{ check(.) ? 'yep ' : 'nope ' }}{{/each}}`,
+		data: {
+			foo: [ 1, 20 ],
+			check(n) {
+				count++;
+				return n > 10;
+			}
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'nope yep' );
+	t.equal( count, 2 );
+	r.splice( 'foo', 0, 1 );
+	t.equal( count, 3 );
+	t.htmlEqual( fixture.innerHTML, 'yep' );
+	r.set( 'foo', [] );
+	t.equal( count, 3 );
+});

--- a/test/browser-tests/methods/splice.js
+++ b/test/browser-tests/methods/splice.js
@@ -83,3 +83,17 @@ test( 'splice with one argument (#1943)', t => {
 
 	t.htmlEqual( fixture.innerHTML, '1' );
 });
+
+test( 'a nested object iteration should rebind with an outer array iteration when it is spliced (#2321)', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#each arr}}{{#each .obj:k}}{{k}}-{{.}}{{/each}}{{/each}}`,
+		data: {
+			arr: [ { obj: { name: 'Rich ' } }, { obj: { name: 'Marty ' } } ]
+		}
+	});
+
+	t.htmlEqual( fixture.innerHTML, 'name-Rich name-Marty' );
+	r.splice( 'arr', 0, 1 );
+	t.htmlEqual( fixture.innerHTML, 'name-Marty' );
+});


### PR DESCRIPTION
There are two bugs showcased in #2321.

~~The first is that computations are currently triggered again during shuffling for elements that should no longer be rendered afterwards. Since expression proxies are also kinda-fragments, I added a way to rebind them too and added a check in mustache that detects a rebindable model (isExpression and has a rebind) and calls it instead of replacing the model. That resolved the issue of calling unresolvable computations for the test case. It also seemed to render the discard checks during shuffle obsolete, so I pulled them out.~~ Yep... caused by the second one...

The second is that object iteration, as opposed to array iteration, was not allowed to rebind because it was only looking for array-like thinks being iterated. Object aren't arrays, so they were being skipped. The simple solution is to always allow rebind in repeated fragments and use the `fragment.key || fragment.index` as key on which to rebind.

Thoughts?