### PR TITLE
Adding toCSS method WIP - RFC

### DIFF
--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -10,6 +10,7 @@ import parse from './parse/_parse';
 import getNodeInfo from './Ractive/static/getNodeInfo';
 import construct from './Ractive/construct';
 import initialise from './Ractive/initialise';
+import { getCSS } from './global/css';
 
 // Ractive.js makes liberal use of things like Array.prototype.indexOf. In
 // older browsers, these are made available via a shim - here, we do a quick
@@ -54,6 +55,7 @@ defineProperties( Ractive, {
 	extend:         { value: extend },
 	getNodeInfo:    { value: getNodeInfo },
 	parse:          { value: parse },
+	getCSS:         { value: getCSS },
 
 	// namespaced constructors
 	Promise:        { value: Promise },

--- a/src/Ractive/config/custom/css/css.js
+++ b/src/Ractive/config/custom/css/css.js
@@ -1,4 +1,4 @@
-import css from '../../../../global/css';
+import { addCSS } from '../../../../global/css';
 import transformCss from './transform';
 import { uuid } from '../../../../utils/id';
 import { warnIfDebug } from '../../../../utils/log';
@@ -10,11 +10,12 @@ export default {
 	extend: ( Parent, proto, options ) => {
 		if ( !options.css ) return;
 
-		let id = uuid();
-		let styles = options.noCssTransform ? options.css : transformCss( options.css, id );
+		const id = uuid();
+		const styles = options.noCssTransform ? options.css : transformCss( options.css, id );
 
 		proto.cssId = id;
-		css.add( { id, styles } );
+
+		addCSS( { id, styles } );
 
 	},
 

--- a/src/Ractive/config/custom/css/css.js
+++ b/src/Ractive/config/custom/css/css.js
@@ -1,19 +1,19 @@
 import css from '../../../../global/css';
 import transformCss from './transform';
-
-let uid = 1;
+import { uuid } from '../../../../utils/id';
 
 export default {
 	name: 'css',
 
 	extend: ( Parent, proto, options ) => {
-		if ( options.css ) {
-			let id = uid++;
-			let styles = options.noCssTransform ? options.css : transformCss( options.css, id );
+		if ( !options.css ) return;
 
-			proto.cssId = id;
-			css.add({ id, styles });
-		}
+		let id = uuid();
+		let styles = options.noCssTransform ? options.css : transformCss( options.css, id );
+
+		proto.cssId = id;
+		css.add({ id, styles });
+
 	},
 
 	init: () => {}

--- a/src/Ractive/config/custom/css/css.js
+++ b/src/Ractive/config/custom/css/css.js
@@ -1,10 +1,12 @@
 import css from '../../../../global/css';
 import transformCss from './transform';
 import { uuid } from '../../../../utils/id';
+import { warnIfDebug } from '../../../../utils/log';
 
 export default {
 	name: 'css',
 
+	// Called when creating a new component definition
 	extend: ( Parent, proto, options ) => {
 		if ( !options.css ) return;
 
@@ -16,6 +18,21 @@ export default {
 
 	},
 
-	init: () => {}
+	// Called when creating a new component instance
+	init: ( Parent, target, options ) => {
+		if ( !options.css ) return;
+
+		warnIfDebug( `
+The css option is currently not supported on a per-instance basis and will be discarded. Instead, we recommend instantiating from a component definition with a css option.
+
+const Component = Ractive.extend({
+	...
+	css: '/* your css */',
+	...
+});
+
+const componentInstance = new Component({ ... })
+		` );
+	}
 
 };

--- a/src/Ractive/config/custom/css/css.js
+++ b/src/Ractive/config/custom/css/css.js
@@ -12,9 +12,10 @@ export default {
 		let styles = options.noCssTransform ? options.css : transformCss( options.css, id );
 
 		proto.cssId = id;
-		css.add({ id, styles });
+		css.add( { id, styles } );
 
 	},
 
 	init: () => {}
+
 };

--- a/src/Ractive/prototype.js
+++ b/src/Ractive/prototype.js
@@ -32,6 +32,7 @@ import splice from './prototype/splice';
 import subtract from './prototype/subtract';
 import teardown from './prototype/teardown';
 import toggle from './prototype/toggle';
+import toCSS from './prototype/toCSS';
 import toHTML from './prototype/toHTML';
 import unlink from './prototype/unlink';
 import unrender from './prototype/unrender';
@@ -76,6 +77,8 @@ export default {
 	subtract,
 	teardown,
 	toggle,
+	toCSS,
+	toCss: toCSS,
 	toHTML,
 	toHtml: toHTML,
 	unlink,

--- a/src/Ractive/prototype/toCSS.js
+++ b/src/Ractive/prototype/toCSS.js
@@ -1,0 +1,5 @@
+import css from '../../global/css';
+
+export default function Ractive$toCSS () {
+  return css.toCSS();
+}

--- a/src/Ractive/prototype/toCSS.js
+++ b/src/Ractive/prototype/toCSS.js
@@ -1,5 +1,5 @@
 import css from '../../global/css';
 
 export default function Ractive$toCSS () {
-  return css.toCSS();
+	return css.toCSS();
 }

--- a/src/Ractive/prototype/toCSS.js
+++ b/src/Ractive/prototype/toCSS.js
@@ -1,5 +1,7 @@
-import css from '../../global/css';
+import { getCSS } from '../../global/css';
 
-export default function Ractive$toCSS () {
-	return css.toCSS();
+export default function Ractive$toCSS() {
+	const cssIds = [ this.cssId, ...this.findAllComponents().map( c => c.cssId ) ];
+	const uniqueCssIds = Object.keys(cssIds.reduce( ( ids, id ) => (ids[id] = true, ids), {}));
+	return getCSS( uniqueCssIds );
 }

--- a/src/Ractive/render.js
+++ b/src/Ractive/render.js
@@ -1,5 +1,5 @@
 import { doc } from '../config/environment';
-import css from '../global/css';
+import { applyCSS } from '../global/css';
 import Hook from '../events/Hook';
 import { getElement } from '../utils/dom';
 import runloop from '../global/runloop';
@@ -25,7 +25,7 @@ export default function render ( ractive, target, anchor, occupants ) {
 	ractive.anchor = anchor;
 
 	// ensure encapsulated CSS is up-to-date
-	if ( ractive.cssId ) css.apply();
+	if ( ractive.cssId ) applyCSS();
 
 	if ( target ) {
 		( target.__ractive_instances__ || ( target.__ractive_instances__ = [] ) ).push( ractive );

--- a/src/global/css.js
+++ b/src/global/css.js
@@ -13,33 +13,33 @@ let styleElement = null;
 let styleSheet = null;
 let styleProperty = null;
 
-function add( styleDefinition ){
+function add( styleDefinition ) {
 	styleDefinitions.push( styleDefinition );
 	isDirty = true;
 }
 
-function toCSS(){
+function toCSS() {
 	return PREFIX + styleDefinitions.map( s => `\n/* {${s.id}} */\n${s.styles}` ).join( '\n' );
 }
 
-function apply(){
+function apply() {
 
 	// Apply only seems to make sense when we're in the DOM. Server-side renders
 	// can call toCSS to get the updated CSS.
-	if( !doc || !isDirty ) return;
+	if ( !doc || !isDirty ) return;
 
-	styleElement[styleProperty] = toCSS();
+	styleElement[ styleProperty ] = toCSS();
 
 	isDirty = false;
 }
 
 // If we're on the browser, additional setup needed.
-if(doc && (!styleElement || !styleElement.parentNode)){
+if ( doc && ( !styleElement || !styleElement.parentNode ) ) {
 
 	styleElement = doc.createElement( 'style' );
 	styleElement.type = 'text/css';
 
-	doc.getElementsByTagName( 'head' )[0].appendChild(styleElement);
+	doc.getElementsByTagName( 'head' )[ 0 ].appendChild( styleElement );
 
 	styleSheet = styleElement.styleSheet;
 

--- a/src/global/css.js
+++ b/src/global/css.js
@@ -1,9 +1,9 @@
 import { doc } from '../config/environment';
 
-const PREFIX = '/* Ractive.js component styles */\n';
+const PREFIX = '/* Ractive.js component styles */';
 
-// Holds current definitions of styles
-let styleDefinitions = [];
+// Holds current definitions of styles.
+const styleDefinitions = [];
 
 // Flag to tell if we need to update the CSS
 let isDirty = false;
@@ -13,24 +13,28 @@ let styleElement = null;
 let styleSheet = null;
 let styleProperty = null;
 
-function add( styleDefinition ) {
+export function addCSS( styleDefinition ) {
 	styleDefinitions.push( styleDefinition );
 	isDirty = true;
 }
 
-function toCSS() {
-	return PREFIX + styleDefinitions.map( s => `\n/* {${s.id}} */\n${s.styles}` ).join( '\n' );
-}
-
-function apply() {
+export function applyCSS() {
 
 	// Apply only seems to make sense when we're in the DOM. Server-side renders
 	// can call toCSS to get the updated CSS.
 	if ( !doc || !isDirty ) return;
 
-	styleElement[ styleProperty ] = toCSS();
+	styleElement[ styleProperty ] = getCSS( null );
 
 	isDirty = false;
+}
+
+export function getCSS( cssIds ) {
+
+	const filteredStyleDefinitions = cssIds ? styleDefinitions.filter( style => ~cssIds.indexOf( style.id ) ) : styleDefinitions;
+
+	return filteredStyleDefinitions.reduce( ( styles, style ) => `${styles}\n\n/* {${style.id}} */\n${style.styles}`, PREFIX );
+
 }
 
 // If we're on the browser, additional setup needed.
@@ -45,9 +49,3 @@ if ( doc && ( !styleElement || !styleElement.parentNode ) ) {
 
 	styleProperty = styleSheet ? 'cssText' : 'innerHTML';
 }
-
-export default {
-	add,
-	apply,
-	toCSS
-};

--- a/src/global/css.js
+++ b/src/global/css.js
@@ -16,7 +16,7 @@ let styleProperty = null;
 function add( styleDefinition ){
 	styleDefinitions.push( styleDefinition );
 	isDirty = true;
-};
+}
 
 function toCSS(){
 	return PREFIX + styleDefinitions.map( s => `\n/* {${s.id}} */\n${s.styles}` ).join( '\n' );

--- a/src/utils/id.js
+++ b/src/utils/id.js
@@ -1,7 +1,7 @@
 function s4() {
-  return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+	return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
 }
 
 export function uuid() {
-  return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
+	return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
 }

--- a/src/utils/id.js
+++ b/src/utils/id.js
@@ -1,0 +1,7 @@
+function s4() {
+  return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+}
+
+export function uuid() {
+  return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
+}

--- a/test/browser-tests/getCSS.js
+++ b/test/browser-tests/getCSS.js
@@ -1,0 +1,117 @@
+import { test }
+from 'qunit';
+
+function createIsolatedEnv() {
+
+	return new Ractive.Promise( ( resolve, reject ) => {
+
+		const frame = document.createElement( 'iframe' );
+		document.body.appendChild( frame );
+
+		frame.style.width = '0';
+		frame.style.height = '0';
+
+		const win = frame.contentWindow || frame;
+		const doc = frame.contentDocument || frame.contentWindow.document;
+
+		const script = document.createElement( 'script' );
+		doc.body.appendChild( script );
+
+		script.onload = () => {
+			resolve( {
+				Ractive: win.Ractive,
+				env: frame,
+				body: doc.body
+			} );
+		};
+		script.onerror = () => {
+			reject();
+		};
+
+		script.src = '../ractive-legacy.js';
+
+	} );
+
+}
+
+function createComponentDefinition( Ractive ) {
+
+	return Ractive.extend( {
+		css: `
+			.green {
+				color: green
+			}
+		`
+	} );
+
+}
+
+test( 'getCSS with a single component definition', t => {
+
+	const Component = createComponentDefinition( Ractive );
+
+	const cssId = Component.prototype.cssId;
+	const css = Ractive.getCSS();
+
+	t.ok( !!~css.indexOf( `.green[data-ractive-css~="{${cssId}}"], [data-ractive-css~="{${cssId}}"] .green`, `.green selector for ${cssId} should exist` ) );
+
+} );
+
+test( 'getCSS with multiple components definition', t => {
+
+	const ComponentA = createComponentDefinition( Ractive );
+
+	const ComponentB = createComponentDefinition( Ractive );
+
+	const cssIdA = ComponentA.prototype.cssId;
+	const cssIdB = ComponentB.prototype.cssId;
+	const css = Ractive.getCSS();
+
+	// Look for the selectors
+	t.ok( !!~css.indexOf( `.green[data-ractive-css~="{${cssIdA}}"], [data-ractive-css~="{${cssIdA}}"] .green` ), `.green selector for ${cssIdA} should exist` );
+	t.ok( !!~css.indexOf( `.green[data-ractive-css~="{${cssIdB}}"], [data-ractive-css~="{${cssIdB}}"] .green` ), `.green selector for ${cssIdB} should exist` );
+
+} );
+
+test( 'getCSS with component definitions constructed from Ractive of different environments', t => {
+	t.expect( 5 );
+
+	const done1 = t.async();
+	const done2 = t.async();
+	const done3 = t.async();
+	const done4 = t.async();
+	const done5 = t.async();
+
+	// Simulate two separate Ractive environments using iframes
+	Ractive.Promise.all( [ createIsolatedEnv(), createIsolatedEnv() ] ).then( envs => {
+
+		const ComponentA = createComponentDefinition( envs[ 0 ].Ractive );
+		const ComponentB = createComponentDefinition( envs[ 1 ].Ractive );
+
+		const cssIdA = ComponentA.prototype.cssId;
+		const cssIdB = ComponentB.prototype.cssId;
+
+		const cssA = envs[ 0 ].Ractive.getCSS();
+		const cssB = envs[ 1 ].Ractive.getCSS();
+
+		t.notEqual( cssIdA, cssIdB, `Two top-level components from different environments should not have the same ID` );
+		done1();
+
+		t.ok( !!~cssA.indexOf( `.green[data-ractive-css~="{${cssIdA}}"], [data-ractive-css~="{${cssIdA}}"] .green` ), `.green selector for ${cssIdA} should exist on component definition A` );
+		done2();
+
+		t.ok( !~cssA.indexOf( `.green[data-ractive-css~="{${cssIdB}}"], [data-ractive-css~="{${cssIdB}}"] .green` ), `.green selector for ${cssIdB} should NEVER exist on component definition A` );
+		done3();
+
+		t.ok( !!~cssB.indexOf( `.green[data-ractive-css~="{${cssIdB}}"], [data-ractive-css~="{${cssIdB}}"] .green` ), `.green selector for ${cssIdB} should exist on component definition B` );
+		done4();
+
+		t.ok( !~cssB.indexOf( `.green[data-ractive-css~="{${cssIdA}}"], [data-ractive-css~="{${cssIdA}}"] .green` ), `.green selector for ${cssIdA} should NEVER exist on component definition B` );
+		done5();
+
+		envs[ 0 ].env.remove();
+		envs[ 1 ].env.remove();
+
+	} );
+
+} );

--- a/test/browser-tests/methods/toCSS.js
+++ b/test/browser-tests/methods/toCSS.js
@@ -1,8 +1,9 @@
-import { test } from 'qunit';
+import { test }
+from 'qunit';
 
 test( 'toCSS with a single component', t => {
 
-	let Component = Ractive.extend({
+	const Component = Ractive.extend( {
 		template: `
 			<div class="child-component">
 				<p>This is also red</p>
@@ -14,24 +15,24 @@ test( 'toCSS with a single component', t => {
 				color: green
 			}
 		`
-	});
+	} );
 
-	let app = new Component({
+	const app = new Component( {
 		el: fixture
-	});
+	} );
 
-	let css = app.toCSS();
+	const css = app.toCSS();
 
 	// Look for the selector
-	t.ok( ~css.indexOf( `.green[data-ractive-css~="{${app.cssId}}"], [data-ractive-css~="{${app.cssId}}"] .green` ) );
+	t.ok( ~css.indexOf( `.green[data-ractive-css~="{${app.cssId}}"], [data-ractive-css~="{${app.cssId}}"] .green`, `.green selector for ${app.cssId} should exist` ) );
 
 	app.teardown();
 
-});
+} );
 
 test( 'toCSS with a nested component', t => {
 
-	let ChildComponent = Ractive.extend({
+	const ChildComponent = Ractive.extend( {
 		template: `
 			<div class="child-component">
 				<p>This is also red</p>
@@ -43,9 +44,9 @@ test( 'toCSS with a nested component', t => {
 				color: green
 			}
 		`
-	});
+	} );
 
-	let ParentComponent = Ractive.extend({
+	const ParentComponent = Ractive.extend( {
 		template: `
 			<div class="parent-component">
 				<p>This should be red</p>
@@ -64,21 +65,114 @@ test( 'toCSS with a nested component', t => {
 		components: {
 			ChildComponent
 		}
-	});
+	} );
 
-	let app = new ParentComponent({
+	const app = new ParentComponent( {
 		el: fixture
-	});
+	} );
 
-	let css = app.toCSS();
-	let parentCssId = ParentComponent.prototype.cssId;
-	let childCssId = ChildComponent.prototype.cssId;
+	const css = app.toCSS();
+	const parentCssId = ParentComponent.prototype.cssId;
+	const childCssId = ChildComponent.prototype.cssId;
 
 	// Look for the selectors
-	t.ok( ~css.indexOf( `.green[data-ractive-css~="{${childCssId}}"], [data-ractive-css~="{${childCssId}}"] .green` ) );
-	t.ok( ~css.indexOf( `.parent-component[data-ractive-css~="{${parentCssId}}"], [data-ractive-css~="{${parentCssId}}"] .parent-component` ) );
-	t.ok( ~css.indexOf( `.blue[data-ractive-css~="{${parentCssId}}"], [data-ractive-css~="{${parentCssId}}"] .blue` ) );
+	t.ok( ~css.indexOf( `.green[data-ractive-css~="{${childCssId}}"], [data-ractive-css~="{${childCssId}}"] .green` ), `.green selector for ${childCssId} should exist` );
+	t.ok( ~css.indexOf( `.parent-component[data-ractive-css~="{${parentCssId}}"], [data-ractive-css~="{${parentCssId}}"] .parent-component` ), `.parent-component selector for ${parentCssId} should exist` );
+	t.ok( ~css.indexOf( `.blue[data-ractive-css~="{${parentCssId}}"], [data-ractive-css~="{${parentCssId}}"] .blue` ), `.blue selector for ${parentCssId} should exist` );
 
 	app.teardown();
 
-});
+} );
+
+
+
+test( 'toCSS from separate Ractive instances', t => {
+	t.expect( 3 );
+
+	const done1 = t.async();
+	const done2 = t.async();
+	const done3 = t.async();
+
+	function createIsolatedEnv() {
+
+		return new Ractive.Promise( ( resolve, reject ) => {
+
+			const frame = document.createElement( 'iframe' );
+			document.body.appendChild( frame );
+
+			frame.style.width = '0';
+			frame.style.height = '0';
+
+			const win = frame.contentWindow || frame;
+			const doc = frame.contentDocument || frame.contentWindow.document;
+
+			const script = document.createElement( 'script' );
+			doc.body.appendChild( script );
+
+			script.onload = () => {
+				resolve( {
+					Ractive: win.Ractive,
+					env: frame,
+					body: doc.body
+				} );
+			};
+			script.onerror = () => {
+				reject();
+			};
+
+			script.src = '../ractive-legacy.js';
+
+		} );
+
+	}
+
+	function createComponentDefinition( Ractive ) {
+
+		return Ractive.extend( {
+			template: `
+				<div class="child-component">
+					<p>This is also red</p>
+					<p class="green">This should be green</p>
+				</div>
+			`,
+			css: `
+				.green {
+					color: green
+				}
+			`
+		} );
+
+	}
+
+	// Simulate two separate Ractive environments using iframes
+	Ractive.Promise.all( [ createIsolatedEnv(), createIsolatedEnv() ] ).then( envs => {
+
+		const ComponentA = createComponentDefinition( envs[ 0 ].Ractive );
+		const ComponentB = createComponentDefinition( envs[ 1 ].Ractive );
+
+		const cssIdA = ComponentA.prototype.cssId;
+		const cssIdB = ComponentB.prototype.cssId;
+
+		const instanceA = new ComponentA( {	el: envs[ 0 ].body } );
+		const instanceB = new ComponentB( {	el: envs[ 1 ].body } );
+
+		const cssA = instanceA.toCSS();
+		const cssB = instanceB.toCSS();
+
+		t.notEqual( cssIdA, cssIdB, `Two top-level components from different environments should not have the same ID` );
+		done1();
+
+		t.ok( ~cssA.indexOf( `.green[data-ractive-css~="{${cssIdA}}"], [data-ractive-css~="{${cssIdA}}"] .green` ), `.green selector for ${cssIdA} should exist` );
+		done2();
+
+		t.ok( ~cssB.indexOf( `.green[data-ractive-css~="{${cssIdB}}"], [data-ractive-css~="{${cssIdB}}"] .green` ), `.green selector for ${cssIdB} should exist` );
+		done3();
+
+		instanceA.teardown();
+		instanceB.teardown();
+		envs[ 0 ].env.remove();
+		envs[ 1 ].env.remove();
+
+	} );
+
+} );

--- a/test/browser-tests/methods/toCSS.js
+++ b/test/browser-tests/methods/toCSS.js
@@ -23,7 +23,7 @@ test( 'toCSS with a single component', t => {
 	let css = app.toCSS();
 
 	// Look for the selector
-	t.ok( !!~css.indexOf( '.green[data-ractive-css~="{1}"], [data-ractive-css~="{1}"] .green' ) );
+	t.ok( ~css.indexOf( `.green[data-ractive-css~="{${app.cssId}}"], [data-ractive-css~="{${app.cssId}}"] .green` ) );
 
 	app.teardown();
 
@@ -71,11 +71,13 @@ test( 'toCSS with a nested component', t => {
 	});
 
 	let css = app.toCSS();
+	let parentCssId = ParentComponent.prototype.cssId;
+	let childCssId = ChildComponent.prototype.cssId;
 
 	// Look for the selectors
-	t.ok( !!~css.indexOf( '.green[data-ractive-css~="{1}"], [data-ractive-css~="{1}"] .green' ) );
-	t.ok( !!~css.indexOf( '.parent-component[data-ractive-css~="{2}"], [data-ractive-css~="{2}"] .parent-component' ) );
-	t.ok( !!~css.indexOf( '.blue[data-ractive-css~="{2}"], [data-ractive-css~="{2}"] .blue' ) );
+	t.ok( ~css.indexOf( `.green[data-ractive-css~="{${childCssId}}"], [data-ractive-css~="{${childCssId}}"] .green` ) );
+	t.ok( ~css.indexOf( `.parent-component[data-ractive-css~="{${parentCssId}}"], [data-ractive-css~="{${parentCssId}}"] .parent-component` ) );
+	t.ok( ~css.indexOf( `.blue[data-ractive-css~="{${parentCssId}}"], [data-ractive-css~="{${parentCssId}}"] .blue` ) );
 
 	app.teardown();
 

--- a/test/browser-tests/methods/toCSS.js
+++ b/test/browser-tests/methods/toCSS.js
@@ -1,0 +1,80 @@
+test( 'toCSS with a single component', t => {
+
+	let Component = Ractive.extend({
+		template: `
+			<div class="child-component">
+				<p>This is also red</p>
+				<p class="green">This should be green</p>
+			</div>
+		`,
+		css: `
+			.green {
+				color: green
+			}
+		`
+	});
+
+	let app = new Component({
+		el: fixture
+	});
+
+	let css = app.toCSS();
+
+	// Look for the selector
+	t.ok( !!~css.indexOf( '.green[data-ractive-css~="{1}"], [data-ractive-css~="{1}"] .green' ) );
+
+	app.teardown();
+
+});
+
+test( 'toCSS with a nested component', t => {
+
+	let ChildComponent = Ractive.extend({
+		template: `
+			<div class="child-component">
+				<p>This is also red</p>
+				<p class="green">This should be green</p>
+			</div>
+		`,
+		css: `
+			.green {
+				color: green
+			}
+		`
+	});
+
+	let ParentComponent = Ractive.extend({
+		template: `
+			<div class="parent-component">
+				<p>This should be red</p>
+				<p class="blue">This should be blue</p>
+				<ChildComponent />
+			</div>
+		`,
+		css: `
+			.parent-component{
+				color: red;
+			}
+			.blue{
+				color: blue;
+			}
+		`,
+		components: {
+			ChildComponent
+		}
+	});
+
+	let app = new ParentComponent({
+		el: fixture
+	});
+
+	let css = app.toCSS();
+
+	// Look for the selectors
+	t.ok( !!~css.indexOf( '.green[data-ractive-css~="{1}"], [data-ractive-css~="{1}"] .green' ) );
+	t.ok( !!~css.indexOf( '.parent-component[data-ractive-css~="{2}"], [data-ractive-css~="{2}"] .parent-component' ) );
+	t.ok( !!~css.indexOf( '.blue[data-ractive-css~="{2}"], [data-ractive-css~="{2}"] .blue' ) );
+
+	app.teardown();
+
+});

--- a/test/browser-tests/methods/toCSS.js
+++ b/test/browser-tests/methods/toCSS.js
@@ -1,3 +1,5 @@
+import { test } from 'qunit';
+
 test( 'toCSS with a single component', t => {
 
 	let Component = Ractive.extend({

--- a/test/node-tests/getCSS.js
+++ b/test/node-tests/getCSS.js
@@ -1,0 +1,47 @@
+/*global require, describe, it */
+const Ractive = require( '../../ractive' );
+const assert = require( 'assert' );
+
+function createComponentDefinition( Ractive ) {
+
+	return Ractive.extend( {
+		css: `
+			.green {
+				color: green
+			}
+		`
+	} );
+
+}
+
+describe( 'ractive.toCSS()', () => {
+
+	it( 'should render CSS with a single component definition', () => {
+
+		const Component = createComponentDefinition( Ractive );
+
+		const cssId = Component.prototype.cssId;
+		const css = Ractive.getCSS();
+
+		assert( !!~css.indexOf( `.green[data-ractive-css~="{${cssId}}"], [data-ractive-css~="{${cssId}}"] .green`, `.green selector for ${cssId} should exist` ) );
+
+	} );
+
+	it( 'should render CSS with multiple components definition', () => {
+
+		const ComponentA = createComponentDefinition( Ractive );
+
+		const ComponentB = createComponentDefinition( Ractive );
+
+		const cssIdA = ComponentA.prototype.cssId;
+		const cssIdB = ComponentB.prototype.cssId;
+		const css = Ractive.getCSS();
+
+		// Look for the selectors
+		assert( !!~css.indexOf( `.green[data-ractive-css~="{${cssIdA}}"], [data-ractive-css~="{${cssIdA}}"] .green` ), `.green selector for ${cssIdA} should exist` );
+		assert( !!~css.indexOf( `.green[data-ractive-css~="{${cssIdB}}"], [data-ractive-css~="{${cssIdB}}"] .green` ), `.green selector for ${cssIdB} should exist` );
+
+	} );
+
+
+} );

--- a/test/node-tests/getCSS.js
+++ b/test/node-tests/getCSS.js
@@ -1,47 +1,40 @@
 /*global require, describe, it */
-const Ractive = require( '../../ractive' );
-const assert = require( 'assert' );
+'use strict';
+
+var Ractive = require( '../../ractive' );
+var assert = require( 'assert' );
 
 function createComponentDefinition( Ractive ) {
 
 	return Ractive.extend( {
-		css: `
-			.green {
-				color: green
-			}
-		`
+		css: '\n\t\t\t.green {\n\t\t\t\tcolor: green\n\t\t\t}\n\t\t'
 	} );
-
 }
 
-describe( 'ractive.toCSS()', () => {
+describe( 'ractive.toCSS()', function() {
 
-	it( 'should render CSS with a single component definition', () => {
+	it( 'should render CSS with a single component definition', function() {
 
-		const Component = createComponentDefinition( Ractive );
+		var Component = createComponentDefinition( Ractive );
 
-		const cssId = Component.prototype.cssId;
-		const css = Ractive.getCSS();
+		var cssId = Component.prototype.cssId;
+		var css = Ractive.getCSS();
 
-		assert( !!~css.indexOf( `.green[data-ractive-css~="{${cssId}}"], [data-ractive-css~="{${cssId}}"] .green`, `.green selector for ${cssId} should exist` ) );
-
+		assert( !!~css.indexOf( '.green[data-ractive-css~="{' + cssId + '}"], [data-ractive-css~="{' + cssId + '}"] .green', '.green selector for ' + cssId + ' should exist' ) );
 	} );
 
-	it( 'should render CSS with multiple components definition', () => {
+	it( 'should render CSS with multiple components definition', function() {
 
-		const ComponentA = createComponentDefinition( Ractive );
+		var ComponentA = createComponentDefinition( Ractive );
 
-		const ComponentB = createComponentDefinition( Ractive );
+		var ComponentB = createComponentDefinition( Ractive );
 
-		const cssIdA = ComponentA.prototype.cssId;
-		const cssIdB = ComponentB.prototype.cssId;
-		const css = Ractive.getCSS();
+		var cssIdA = ComponentA.prototype.cssId;
+		var cssIdB = ComponentB.prototype.cssId;
+		var css = Ractive.getCSS();
 
 		// Look for the selectors
-		assert( !!~css.indexOf( `.green[data-ractive-css~="{${cssIdA}}"], [data-ractive-css~="{${cssIdA}}"] .green` ), `.green selector for ${cssIdA} should exist` );
-		assert( !!~css.indexOf( `.green[data-ractive-css~="{${cssIdB}}"], [data-ractive-css~="{${cssIdB}}"] .green` ), `.green selector for ${cssIdB} should exist` );
-
+		assert( !!~css.indexOf( '.green[data-ractive-css~="{' + cssIdA + '}"], [data-ractive-css~="{' + cssIdA + '}"] .green' ), '.green selector for ' + cssIdA + ' should exist' );
+		assert( !!~css.indexOf( '.green[data-ractive-css~="{' + cssIdB + '}"], [data-ractive-css~="{' + cssIdB + '}"] .green' ), '.green selector for ' + cssIdB + ' should exist' );
 	} );
-
-
 } );

--- a/test/node-tests/index.js
+++ b/test/node-tests/index.js
@@ -2,4 +2,6 @@
 require( './basic' );
 require( './components' );
 require( './parse' );
+require( './getCSS' );
 require( './toHTML' );
+require( './toCSS' );

--- a/test/node-tests/toCSS.js
+++ b/test/node-tests/toCSS.js
@@ -2,9 +2,9 @@
 let Ractive = require('../../ractive');
 let assert = require('assert');
 
-describe('ractive.toCSS()', function() {
+describe('ractive.toCSS()', () => {
 
-	it('should be able to return CSS for a single component', function() {
+	it('should be able to return CSS for a single component', () => {
 
 		let Component = Ractive.extend({
 			template: `
@@ -33,7 +33,7 @@ describe('ractive.toCSS()', function() {
 
 	});
 
-	it('should be able to return CSS for nested components', function() {
+	it('should be able to return CSS for nested components', () => {
 
 		let ChildComponent = Ractive.extend({
 			template: `

--- a/test/node-tests/toCSS.js
+++ b/test/node-tests/toCSS.js
@@ -1,110 +1,80 @@
 /*global require, describe, it */
-const Ractive = require( '../../ractive' );
-const assert = require( 'assert' );
+'use strict';
 
+var Ractive = require( '../../ractive' );
+var assert = require( 'assert' );
 
-describe( 'ractive.toCSS()', () => {
+describe( 'ractive.toCSS()', function() {
 
-	it( 'should render CSS with a single component instance', () => {
+	it( 'should render CSS with a single component instance', function() {
 
-		const Component = Ractive.extend( {
-			template: `<div></div>`,
-			css: `
-			.green {
-				color: green
-			}
-		`
+		var Component = Ractive.extend( {
+			template: '<div></div>',
+			css: '\n\t\t\t\t.green {\n\t\t\t\t\tcolor: green\n\t\t\t\t}\n\t\t'
 		} );
 
-		const app = new Component( {} );
+		var app = new Component( {} );
 
-		const cssId = Component.prototype.cssId;
-		const css = app.toCSS();
+		var cssId = Component.prototype.cssId;
+		var css = app.toCSS();
 
 		// Look for the selector
-		assert( !!~css.indexOf( `.green[data-ractive-css~="{${cssId}}"], [data-ractive-css~="{${cssId}}"] .green`, `.green selector for ${cssId} should exist` ) );
+		assert( !!~css.indexOf( '.green[data-ractive-css~="{' + cssId + '}"], [data-ractive-css~="{' + cssId + '}"] .green', '.green selector for ' + cssId + ' should exist' ) );
 
 		app.teardown();
-
 	} );
 
-	it( 'should render CSS with nested component instances', () => {
+	it( 'should render CSS with nested component instances', function() {
 
-		const GrandChildComponent = Ractive.extend( {
-			template: `<div></div>`,
-			css: `
-			.green {
-				color: green;
-			}
-		`
+		var GrandChildComponent = Ractive.extend( {
+			template: '<div></div>',
+			css: '\n\t\t\t\t.green {\n\t\t\t\t\tcolor: green;\n\t\t\t\t}\n\t\t'
 		} );
 
-		const ChildComponent = Ractive.extend( {
-			template: `
-			<div></div>
-			<GrandChildComponent />
-		`,
-			css: `
-			.red {
-				color: red;
-			}
-		`,
+		var ChildComponent = Ractive.extend( {
+			template: '\n\t\t\t\t<div></div>\n\t\t\t\t<GrandChildComponent />\n\t\t\t',
+			css: '\n\t\t\t\t.red {\n\t\t\t\t\tcolor: red;\n\t\t\t\t}\n\t\t',
 			components: {
-				GrandChildComponent
+				GrandChildComponent: GrandChildComponent
 			}
 		} );
 
-		const ParentComponent = Ractive.extend( {
-			template: `
-			<div></div>
-			<ChildComponent />
-		`,
-			css: `
-			.blue{
-				color: blue;
-			}
-		`,
+		var ParentComponent = Ractive.extend( {
+			template: '\n\t\t\t\t<div></div>\n\t\t\t\t<ChildComponent />\n\t\t\t',
+			css: '\n\t\t\t\t.blue{\n\t\t\t\t\tcolor: blue;\n\t\t\t\t}\n\t\t\t',
 			components: {
-				ChildComponent
+				ChildComponent: ChildComponent
 			}
 		} );
 
-		const app = new ParentComponent( {} );
+		var app = new ParentComponent( {} );
 
-		const css = app.toCSS();
-		const grandChildCssId = GrandChildComponent.prototype.cssId;
-		const childCssId = ChildComponent.prototype.cssId;
-		const parentCssId = ParentComponent.prototype.cssId;
+		var css = app.toCSS();
+		var grandChildCssId = GrandChildComponent.prototype.cssId;
+		var childCssId = ChildComponent.prototype.cssId;
+		var parentCssId = ParentComponent.prototype.cssId;
 
 		// Look for the selectors
-		assert( !!~css.indexOf( `.green[data-ractive-css~="{${grandChildCssId}}"], [data-ractive-css~="{${grandChildCssId}}"] .green` ), `.green selector for ${grandChildCssId} should exist` );
+		assert( !!~css.indexOf( '.green[data-ractive-css~="{' + grandChildCssId + '}"], [data-ractive-css~="{' + grandChildCssId + '}"] .green' ), '.green selector for ' + grandChildCssId + ' should exist' );
 
-		assert( !!~css.indexOf( `.red[data-ractive-css~="{${childCssId}}"], [data-ractive-css~="{${childCssId}}"] .red` ), `.red selector for ${childCssId} should exist` );
+		assert( !!~css.indexOf( '.red[data-ractive-css~="{' + childCssId + '}"], [data-ractive-css~="{' + childCssId + '}"] .red' ), '.red selector for ' + childCssId + ' should exist' );
 
-		assert( !!~css.indexOf( `.blue[data-ractive-css~="{${parentCssId}}"], [data-ractive-css~="{${parentCssId}}"] .blue` ), `.blue selector for ${parentCssId} should exist` );
+		assert( !!~css.indexOf( '.blue[data-ractive-css~="{' + parentCssId + '}"], [data-ractive-css~="{' + parentCssId + '}"] .blue' ), '.blue selector for ' + parentCssId + ' should exist' );
 
 		app.teardown();
-
 	} );
 
-	it( 'should NEVER render CSS with a Ractive instance', () => {
+	it( 'should NEVER render CSS with a Ractive instance', function() {
 
-		const app = new Ractive( {
-			template: `<div></div>`,
-			css: `
-			.green {
-				color: green
-			}
-		`
+		var app = new Ractive( {
+			template: '<div></div>',
+			css: '\n\t\t\t\t.green {\n\t\t\t\t\tcolor: green\n\t\t\t\t}\n\t\t\t'
 		} );
 
-		const css = app.toCSS();
+		var css = app.toCSS();
 
-		assert( !~css.indexOf( `.green[data-ractive-css~="{${app.cssId}}"], [data-ractive-css~="{${app.cssId}}"] .green`, `.green selector for ${app.cssId} should NEVER exist` ) );
+		assert( !~css.indexOf( '.green[data-ractive-css~="{' + app.cssId + '}"], [data-ractive-css~="{' + app.cssId + '}"] .green', '.green selector for ' + app.cssId + ' should NEVER exist' ) );
 
 		app.teardown();
-
 	} );
-
-
 } );

--- a/test/node-tests/toCSS.js
+++ b/test/node-tests/toCSS.js
@@ -1,12 +1,12 @@
 /*global require, describe, it */
-let Ractive = require('../../ractive');
-let assert = require('assert');
+const Ractive = require( '../../ractive' );
+const assert = require( 'assert' );
 
-describe('ractive.toCSS()', () => {
+describe( 'ractive.toCSS()', () => {
 
-	it('should be able to return CSS for a single component', () => {
+	it( 'should be able to return CSS for a single component', () => {
 
-		let Component = Ractive.extend({
+		const Component = Ractive.extend( {
 			template: `
 				<div class="child-component">
 					<p>This is also red</p>
@@ -18,24 +18,24 @@ describe('ractive.toCSS()', () => {
 					color: green
 				}
 			`
-		});
+		} );
 
-		let app = new Component({
+		const app = new Component( {
 			el: fixture
-		});
+		} );
 
-		let css = app.toCSS();
+		const css = app.toCSS();
 
 		// Look for the selector
-		assert(!!~css.indexOf('.green[data-ractive-css~="{1}"], [data-ractive-css~="{1}"] .green'));
+		assert( ~css.indexOf( `.green[data-ractive-css~="{${app.cssId}}"], [data-ractive-css~="{${app.cssId}}"] .green` ) );
 
 		app.teardown();
 
-	});
+	} );
 
-	it('should be able to return CSS for nested components', () => {
+	it( 'should be able to return CSS for nested components', () => {
 
-		let ChildComponent = Ractive.extend({
+		const ChildComponent = Ractive.extend( {
 			template: `
 				<div class="child-component">
 					<p>This is also red</p>
@@ -47,9 +47,9 @@ describe('ractive.toCSS()', () => {
 					color: green
 				}
 			`
-		});
+		} );
 
-		let ParentComponent = Ractive.extend({
+		const ParentComponent = Ractive.extend( {
 			template: `
 				<div class="parent-component">
 					<p>This should be red</p>
@@ -68,18 +68,21 @@ describe('ractive.toCSS()', () => {
 			components: {
 				ChildComponent
 			}
-		});
+		} );
 
-		let app = new ParentComponent();
-		let css = app.toCSS();
+		const app = new ParentComponent();
+
+		const css = app.toCSS();
+		const parentCssId = ParentComponent.prototype.cssId;
+		const childCssId = ChildComponent.prototype.cssId;
 
 		// Look for the selectors
-		assert(!!~css.indexOf('.green[data-ractive-css~="{1}"], [data-ractive-css~="{1}"] .green'));
-		assert(!!~css.indexOf('.parent-component[data-ractive-css~="{2}"], [data-ractive-css~="{2}"] .parent-component'));
-		assert(!!~css.indexOf('.blue[data-ractive-css~="{2}"], [data-ractive-css~="{2}"] .blue'));
+		assert( ~css.indexOf( `.green[data-ractive-css~="{${childCssId}}"], [data-ractive-css~="{${childCssId}}"] .green` ) );
+		assert( ~css.indexOf( `.parent-component[data-ractive-css~="{${parentCssId}}"], [data-ractive-css~="{${parentCssId}}"] .parent-component` ) );
+		assert( ~css.indexOf( `.blue[data-ractive-css~="{${parentCssId}}"], [data-ractive-css~="{${parentCssId}}"] .blue` ) );
 
 		app.teardown();
 
-	});
+	} );
 
-});
+} );

--- a/test/node-tests/toCSS.js
+++ b/test/node-tests/toCSS.js
@@ -1,0 +1,85 @@
+/*global require, describe, it */
+let Ractive = require('../../ractive');
+let assert = require('assert');
+
+describe('ractive.toCSS()', function() {
+
+	it('should be able to return CSS for a single component', function() {
+
+		let Component = Ractive.extend({
+			template: `
+				<div class="child-component">
+					<p>This is also red</p>
+					<p class="green">This should be green</p>
+				</div>
+			`,
+			css: `
+				.green {
+					color: green
+				}
+			`
+		});
+
+		let app = new Component({
+			el: fixture
+		});
+
+		let css = app.toCSS();
+
+		// Look for the selector
+		assert(!!~css.indexOf('.green[data-ractive-css~="{1}"], [data-ractive-css~="{1}"] .green'));
+
+		app.teardown();
+
+	});
+
+	it('should be able to return CSS for nested components', function() {
+
+		let ChildComponent = Ractive.extend({
+			template: `
+				<div class="child-component">
+					<p>This is also red</p>
+					<p class="green">This should be green</p>
+				</div>
+			`,
+			css: `
+				.green {
+					color: green
+				}
+			`
+		});
+
+		let ParentComponent = Ractive.extend({
+			template: `
+				<div class="parent-component">
+					<p>This should be red</p>
+					<p class="blue">This should be blue</p>
+					<ChildComponent />
+				</div>
+			`,
+			css: `
+				.parent-component{
+					color: red;
+				}
+				.blue{
+					color: blue;
+				}
+			`,
+			components: {
+				ChildComponent
+			}
+		});
+
+		let app = new ParentComponent();
+		let css = app.toCSS();
+
+		// Look for the selectors
+		assert(!!~css.indexOf('.green[data-ractive-css~="{1}"], [data-ractive-css~="{1}"] .green'));
+		assert(!!~css.indexOf('.parent-component[data-ractive-css~="{2}"], [data-ractive-css~="{2}"] .parent-component'));
+		assert(!!~css.indexOf('.blue[data-ractive-css~="{2}"], [data-ractive-css~="{2}"] .blue'));
+
+		app.teardown();
+
+	});
+
+});


### PR DESCRIPTION
Exposes the CSS generated by Ractive via a new toCSS method, plus a few cleanups and tests here and there. Since there wasn't a PR (just a commit on some fork), decided to create one.

ToDo:

- [x] Render CSS  https://github.com/ractivejs/ractive/issues/1127
- [x] Multiple copies of Ractive generating CSS https://github.com/ractivejs/ractive/issues/2292
- [x] Warn when using `css` option for instances https://github.com/ractivejs/ractive/issues/2365
- [x] `toCSS` to trace through instance components only https://github.com/ractivejs/ractive/pull/2362#issuecomment-179639832