### PR TITLE
Avoid exporting all reachable keypaths from rootmodel when using has - #2366 - RFC

### DIFF
--- a/src/view/items/Partial.js
+++ b/src/view/items/Partial.js
@@ -7,8 +7,6 @@ import parser from '../../Ractive/config/runtime-parser';
 
 export default class Partial extends Mustache {
 	bind () {
-		super.bind();
-
 		// keep track of the reference name for future resets
 		this.refName = this.template.r;
 
@@ -19,15 +17,20 @@ export default class Partial extends Mustache {
 		if ( template ) {
 			this.named = true;
 			this.setTemplate( this.template.r, template );
-		} else if ( this.model && ( templateObj = this.model.get() ) && typeof templateObj === 'object' && ( typeof templateObj.template === 'string' || isArray( templateObj.t ) ) ) {
-			if ( templateObj.template ) {
-				templateObj = parsePartial( this.template.r, templateObj.template, this.ractive );
+		}
+
+		if ( !template ) {
+			super.bind();
+			if ( this.model && ( templateObj = this.model.get() ) && typeof templateObj === 'object' && ( typeof templateObj.template === 'string' || isArray( templateObj.t ) ) ) {
+				if ( templateObj.template ) {
+					templateObj = parsePartial( this.template.r, templateObj.template, this.ractive );
+				}
+				this.setTemplate( this.template.r, templateObj.t );
+			} else if ( ( !this.model || typeof this.model.get() !== 'string' ) && this.refName ) {
+				this.setTemplate( this.refName, template );
+			} else {
+				this.setTemplate( this.model.get() );
 			}
-			this.setTemplate( this.template.r, templateObj.t );
-		} else if ( ( !this.model || typeof this.model.get() !== 'string' ) && this.refName ) {
-			this.setTemplate( this.refName, template );
-		} else {
-			this.setTemplate( this.model.get() );
 		}
 
 		this.fragment = new Fragment({


### PR DESCRIPTION
One of the things that @sabob dug up in #2366 was that lots of resolution in a heavily iterated template was unnecessarily creating full `RootModel` exports just to check for presence of keys. This works around that by implementing the whole `has` method for `RootModel`.

I was going to make the full export opt-in only by adding a flag to `RootModel.get` and possibly `Ractive.get`, but that breaks the assumption that `model.get` can be called for any model anywhere. Thoughts?