### PR TITLE
Gh 2366

### DIFF
--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -57,6 +57,7 @@ export default class Model {
 		const adaptors = this.root.adaptors;
 		const value = this.value;
 		const len = adaptors.length;
+		if ( len === 0 ) return;
 
 		// TODO remove this legacy nonsense
 		const ractive = this.root.ractive;

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -55,9 +55,12 @@ export default class Model {
 
 	adapt () {
 		const adaptors = this.root.adaptors;
-		const value = this.value;
 		const len = adaptors.length;
+
+		// Exit early if no adaptors
 		if ( len === 0 ) return;
+
+		const value = this.value;
 
 		// TODO remove this legacy nonsense
 		const ractive = this.root.ractive;


### PR DESCRIPTION
Exit early from Model.adapt if there are no registered adaptors. This provides small performance boost in tight loops when setting modifyArrays to false.