### PR TITLE
Allow keypath-taking methods to use an element for context for resolution - RFC

### DIFF
--- a/src/Ractive/prototype/add.js
+++ b/src/Ractive/prototype/add.js
@@ -1,5 +1,5 @@
 import add from './shared/add';
 
-export default function Ractive$add ( keypath, d ) {
-	return add( this, keypath, ( d === undefined ? 1 : +d ) );
+export default function Ractive$add ( ...args ) {
+	return add( this, args, 1 );
 }

--- a/src/Ractive/prototype/animate.js
+++ b/src/Ractive/prototype/animate.js
@@ -1,9 +1,10 @@
 import runloop from '../../global/runloop';
 import interpolate from '../../shared/interpolate';
-import { isEqual } from '../../utils/is';
+import { isEqual, isRactiveElement } from '../../utils/is';
 import { splitKeypath } from '../../shared/keypaths';
 import easing from '../../Ractive/static/easing';
 import noop from '../../utils/noop';
+import resolveReference from '../../view/resolvers/resolveReference';
 
 const noAnimation = { stop: noop };
 const linear = easing.linear;
@@ -26,7 +27,15 @@ function getOptions ( options, instance ) {
 	};
 }
 
-export default function Ractive$animate ( keypath, to, options ) {
+export default function Ractive$animate ( keypath, to, options, overflow ) {
+	let model;
+
+	if ( isRactiveElement( to ) ) {
+		model = resolveReference( to._ractive.fragment, keypath );
+		to = options;
+		options = overflow;
+	}
+
 	if ( typeof keypath === 'object' ) {
 		const keys = Object.keys( keypath );
 
@@ -40,7 +49,7 @@ ${keys.map( key => `ractive.animate('${key}', ${keypath[ key ]}, {...});` ).join
 
 	options = getOptions( options, this );
 
-	const model = this.viewmodel.joinAll( splitKeypath( keypath ) );
+	if ( !model ) model = this.viewmodel.joinAll( splitKeypath( keypath ) );
 	const from = model.get();
 
 	// don't bother animating values that stay the same

--- a/src/Ractive/prototype/get.js
+++ b/src/Ractive/prototype/get.js
@@ -1,26 +1,32 @@
+import { isRactiveElement } from '../../utils/is';
 import { splitKeypath } from '../../shared/keypaths';
 import resolveReference from '../../view/resolvers/resolveReference';
 
-export default function Ractive$get ( keypath ) {
+export default function Ractive$get ( keypath, context ) {
 	if ( !keypath ) return this.viewmodel.get( true );
-
-	const keys = splitKeypath( keypath );
-	const key = keys[0];
-
 	let model;
 
-	if ( !this.viewmodel.has( key ) ) {
-		// if this is an inline component, we may need to create
-		// an implicit mapping
-		if ( this.component && !this.isolated ) {
-			model = resolveReference( this.component.parentFragment, key );
+	if ( isRactiveElement( context ) ) {
+		model = resolveReference( context._ractive.fragment, keypath );
+		if ( model ) return model.get( true );
+	} else {
+		const keys = splitKeypath( keypath );
+		const key = keys[0];
 
-			if ( model ) {
-				this.viewmodel.map( key, model );
+
+		if ( !this.viewmodel.has( key ) ) {
+			// if this is an inline component, we may need to create
+			// an implicit mapping
+			if ( this.component && !this.isolated ) {
+				model = resolveReference( this.component.parentFragment, key );
+
+				if ( model ) {
+					this.viewmodel.map( key, model );
+				}
 			}
 		}
-	}
 
-	model = this.viewmodel.joinAll( keys );
-	return model.get( true );
+		model = this.viewmodel.joinAll( keys );
+		return model.get( true );
+	}
 }

--- a/src/Ractive/prototype/link.js
+++ b/src/Ractive/prototype/link.js
@@ -1,9 +1,15 @@
+import { isRactiveElement } from '../../utils/is';
 import { splitKeypath } from '../../shared/keypaths';
 import resolveReference from '../../view/resolvers/resolveReference';
 import runloop from '../../global/runloop';
 import Promise from '../../utils/Promise';
 
-export default function link( there, here ) {
+export default function link( there, here, context ) {
+	if ( isRactiveElement( context ) ) {
+		let model = resolveReference( context._ractive.fragment, there );
+		if ( model ) there = model.getKeypath();
+	}
+
 	if ( here === there || (there + '.').indexOf( here + '.' ) === 0 || (here + '.').indexOf( there + '.' ) === 0 ) {
 		throw new Error( 'A keypath cannot be linked to itself.' );
 	}

--- a/src/Ractive/prototype/shared/add.js
+++ b/src/Ractive/prototype/shared/add.js
@@ -1,12 +1,23 @@
-import { isNumeric } from '../../../utils/is';
+import { isNumeric, isRactiveElement } from '../../../utils/is';
 import { splitKeypath } from '../../../shared/keypaths';
 
 const errorMessage = 'Cannot add to a non-numeric value';
 
-export default function add ( ractive, keypath, d ) {
+export default function add ( ractive, args, def ) {
+	let keypath = args[0], d, context = args[2];
+
+	if ( args.length === 1 ) d = def;
+	else if ( isRactiveElement( args[1] ) ) {
+		d = def;
+		context = args[1];
+	} else d = args[1];
+
 	if ( typeof keypath !== 'string' || !isNumeric( d ) ) {
 		throw new Error( 'Bad arguments' );
 	}
+
+	// swap sign for subtract
+	if ( d !== def ) d = d * def;
 
 	let changes;
 
@@ -24,11 +35,11 @@ export default function add ( ractive, keypath, d ) {
 		return ractive.set( changes );
 	}
 
-	const value = ractive.get( keypath );
+	const value = ractive.get( keypath, context );
 
 	if ( !isNumeric( value ) ) {
 		throw new Error( errorMessage );
 	}
 
-	return ractive.set( keypath, +value + d );
+	return ractive.set( keypath, +value + d, context );
 }

--- a/src/Ractive/prototype/subtract.js
+++ b/src/Ractive/prototype/subtract.js
@@ -1,5 +1,5 @@
 import add from './shared/add';
 
-export default function Ractive$subtract ( keypath, d ) {
-	return add( this, keypath, ( d === undefined ? -1 : -d ) );
+export default function Ractive$subtract ( ...args ) {
+	return add( this, args, -1 );
 }

--- a/src/Ractive/prototype/toggle.js
+++ b/src/Ractive/prototype/toggle.js
@@ -1,7 +1,7 @@
 import { badArguments } from '../../config/errors';
 import { splitKeypath } from '../../shared/keypaths';
 
-export default function Ractive$toggle ( keypath ) {
+export default function Ractive$toggle ( keypath, context ) {
 	if ( typeof keypath !== 'string' ) {
 		throw new TypeError( badArguments );
 	}
@@ -18,5 +18,5 @@ export default function Ractive$toggle ( keypath ) {
 		return this.set( changes );
 	}
 
-	return this.set( keypath, !this.get( keypath ) );
+	return this.set( keypath, !this.get( keypath, context ), context );
 }

--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -1,13 +1,20 @@
+import { isRactiveElement } from '../../utils/is';
 import Hook from '../../events/Hook';
 import runloop from '../../global/runloop';
 import { splitKeypath } from '../../shared/keypaths';
+import resolveReference from '../../view/resolvers/resolveReference';
 
 const updateHook = new Hook( 'update' );
 
-export default function Ractive$update ( keypath ) {
-	const model = keypath ?
-		this.viewmodel.joinAll( splitKeypath( keypath ) ) :
-		this.viewmodel;
+export default function Ractive$update ( keypath, context ) {
+	let model;
+
+	if ( keypath ) {
+		if ( isRactiveElement( context ) ) model = resolveReference( context._ractive.fragment, keypath );
+		else model = this.viewmodel.joinAll( splitKeypath( keypath ) );
+	} else {
+		model = this.viewmodel;
+	}
 
 	const promise = runloop.start( this, true );
 	model.mark();

--- a/src/Ractive/prototype/updateModel.js
+++ b/src/Ractive/prototype/updateModel.js
@@ -1,13 +1,23 @@
 import { splitKeypath } from '../../shared/keypaths';
+import { isRactiveElement } from '../../utils/is';
+import resolveReference from '../../view/resolvers/resolveReference';
 import runloop from '../../global/runloop';
 
-export default function Ractive$updateModel ( keypath, cascade ) {
+export default function Ractive$updateModel ( keypath, cascade, overflow ) {
 	const promise = runloop.start( this, true );
 
 	if ( !keypath ) {
 		this.viewmodel.updateFromBindings( true );
 	} else {
-		this.viewmodel.joinAll( splitKeypath( keypath ) ).updateFromBindings( cascade !== false );
+		let model;
+		if ( isRactiveElement( cascade ) ) {
+			model = resolveReference( cascade._ractive.fragment, keypath );
+			cascade = overflow;
+		} else {
+			model = this.viewmodel.joinAll( splitKeypath( keypath ) );
+		}
+
+		model.updateFromBindings( cascade !== false );
 	}
 
 	runloop.end();

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -30,3 +30,7 @@ export function isNumeric ( thing ) {
 export function isObject ( thing ) {
 	return ( thing && toString.call( thing ) === '[object Object]' );
 }
+
+export function isRactiveElement ( thing ) {
+	return thing && typeof thing === 'object' && '_ractive' in thing && 'nodeType' in thing;
+}

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -6,6 +6,7 @@ import { unbind } from '../../../shared/methodCallers';
 import noop from '../../../utils/noop';
 import resolveReference from '../../resolvers/resolveReference';
 import { splitKeypath } from '../../../shared/keypaths';
+import { ELEMENT } from '../../../config/types';
 
 const eventPattern = /^event(?:\.(.+))?$/;
 const argumentsPattern = /^arguments\.(\d*)$/;
@@ -136,6 +137,7 @@ export default class EventDirective {
 			event.rootpath = this.context.getKeypath();
 			event.context = this.context.get();
 			event.index = this.parentFragment.indexRefs;
+			if ( this.owner.type === ELEMENT ) event.el = event.element = this.owner.node;
 		}
 
 		if ( this.method ) {

--- a/test/browser-tests/events/misc.js
+++ b/test/browser-tests/events/misc.js
@@ -1,6 +1,8 @@
 import { test } from 'qunit';
 import { fire } from 'simulant';
 
+/* global document, setTimeout */
+
 // TODO finish moving these into more sensible locations
 
 test( 'Grandchild component teardown when nested in element (#1360)', t => {
@@ -163,6 +165,16 @@ test( 'correct function scope for this.bar() in template', t => {
 	fire( ractive.find( 'button' ), 'click' );
 
 	t.equal( ractive.get( 'foo' ), '42' );
+});
+
+test( 'element is included in event context where there is an event object', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar.baz.bat.bip.bop.boop}}<button on-click="set('.', 'yep', event.el)">click me</button>{{/with}}`
+	});
+
+	fire( r.find( 'button' ), 'click' );
+	t.equal( r.get( 'foo.bar.baz.bat.bip.bop.boop' ), 'yep' );
 });
 
 // phantom and IE8 don't like these tests, but browsers are ok with them

--- a/test/browser-tests/methods/add.js
+++ b/test/browser-tests/methods/add.js
@@ -55,3 +55,25 @@ test( 'each keypath that matches a wildcard is added to individually (#1604)', t
 	t.equal( ractive.get( 'items[1].count' ), 3 );
 	t.equal( ractive.get( 'items[2].count' ), 4 );
 });
+
+test( 'add supports context with increment', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar}}<span></span>{{/with}}`,
+		data: { foo: { bar: { baz: 1 } } }
+	});
+
+	r.add( '.baz', 5, r.find( 'span' ) );
+	t.equal( r.get( 'foo.bar.baz' ), 6 );
+});
+
+test( 'add supports context without increment', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar}}<span></span>{{/with}}`,
+		data: { foo: { bar: { baz: 1 } } }
+	});
+
+	r.add( '.baz', r.find( 'span' ) );
+	t.equal( r.get( 'foo.bar.baz' ), 2 );
+});

--- a/test/browser-tests/methods/animate.js
+++ b/test/browser-tests/methods/animate.js
@@ -1,5 +1,7 @@
 import { test } from 'qunit';
 
+/* global setTimeout */
+
 test( 'Values that cannot be interpolated change to their final value immediately', t => {
 	const ractive = new Ractive({
 		el: fixture,
@@ -168,4 +170,19 @@ test( 'Named easing functions are taken from the instance', t => {
 	});
 
 	ractive.animate( 'x', 1, { easing: 'easeOut' });
+});
+
+test( 'animate can get used with a context', t => {
+	const done = t.async();
+
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar}}<span>{{.baz}}</span>{{/with}}`,
+		data: { foo: { bar: { baz: 1 } } }
+	});
+
+	r.animate( '.baz', r.find( 'span' ), 10 ).then( () => {
+		t.equal( r.get( 'foo.bar.baz' ), 10 );
+		done();
+	});
 });

--- a/test/browser-tests/methods/get.js
+++ b/test/browser-tests/methods/get.js
@@ -22,3 +22,23 @@ test( 'Returns mappings on root .get()', t => {
 	t.deepEqual( ractive.findComponent( 'Widget' ).get(), expected );
 	t.deepEqual( fixture.innerHTML, JSON.stringify( expected ) );
 });
+
+test( 'use context to resolve get path if given', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar.baz.bat}}<span>{{.last}}</span>{{/with}}`,
+		data: { foo: { bar: { baz: { bat: { last: 'yep' } } } } }
+	});
+
+	t.equal( r.get( '.last', r.find( 'span' ) ), 'yep' );
+});
+
+test( 'context gets have access to aliases', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar as alias}}<span></span>{{/with}}`,
+		data: { foo: { bar: { val: 'yep' } } }
+	});
+
+	t.equal( r.get( 'alias.val', r.find( 'span' ) ), 'yep' );
+});

--- a/test/browser-tests/methods/link.js
+++ b/test/browser-tests/methods/link.js
@@ -105,3 +105,15 @@ test( 'Links should not outlive their instance', t => {
 	t.ok( !r.get( 'baz' ) );
 	t.ok(r.viewmodel.joinAll(['bip', 'bop']).deps.length === 0);
 });
+
+test( 'links can be set up using element context', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '{{ foo }} {{#with bar.baz.bat}}<span>{{.}}</span>{{/with}}',
+		data: { bar: { baz: { bat: 'linked' } } }
+	});
+
+	t.htmlEqual( fixture.innerHTML, ' <span>linked</span>' );
+	r.link( '.', 'foo', r.find( 'span' ) );
+	t.htmlEqual( fixture.innerHTML, 'linked <span>linked</span>' );
+});

--- a/test/browser-tests/methods/set.js
+++ b/test/browser-tests/methods/set.js
@@ -1,0 +1,25 @@
+import { test } from 'qunit';
+
+test( 'use context to resolve set path if given', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar.baz.bat}}<span>{{.last}}</span>{{/with}}`
+	});
+
+	r.set( '.last', 'yep', r.find( 'span' ) );
+	t.htmlEqual( fixture.innerHTML, '<span>yep</span>' );
+
+	r.set( '../wat', 'again, yep', r.find( 'span' ) );
+	t.equal( r.get( 'foo.bar.baz.wat' ), 'again, yep' );
+});
+
+test( 'context resolved sets can also use aliases', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar as alias}}<span>{{foo.bar.val}}</span>{{/with}}`,
+		data: { foo: { bar: { val: 'nope' } } }
+	});
+
+	r.set( 'alias.val', 'yep', r.find( 'span' ) );
+	t.htmlEqual( fixture.innerHTML, '<span>yep</span>' );
+});

--- a/test/browser-tests/methods/splice.js
+++ b/test/browser-tests/methods/splice.js
@@ -97,3 +97,33 @@ test( 'a nested object iteration should rebind with an outer array iteration whe
 	r.splice( 'arr', 0, 1 );
 	t.htmlEqual( fixture.innerHTML, 'name-Marty' );
 });
+
+test( 'splice returns the result of the actual splice alongside the promise', t => {
+	const r = new Ractive({
+		data: { array: [ 1, 2, 3 ] }
+	});
+
+	const res = r.splice( 'array', 0, 2 );
+	t.equal( res.result.length, 2 );
+	t.equal( res.result[0], 1 );
+	t.equal( res.result[1], 2 );
+});
+
+test( 'splice returns the ractive instance alongside the promise', t => {
+	const r = new Ractive({
+		data: { array: [ 1, 2, 3 ] }
+	});
+
+	t.strictEqual( r.splice( 'array', 0, 2 ).ractive, r );
+});
+
+test( 'splice can be given context along with the keypath for resolution', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar}}<span></span>{{/with}}`,
+		data: { foo: { bar: { baz: [] } } }
+	});
+
+	r.splice( '.baz', r.find( 'span' ), 0, 0, 'yep' );
+	t.equal( r.get( 'foo.bar.baz.0' ), 'yep' );
+});

--- a/test/browser-tests/methods/subtract.js
+++ b/test/browser-tests/methods/subtract.js
@@ -23,3 +23,25 @@ test( 'ractive.subtract("foo",x) subtracts x from the value of foo', t => {
 	ractive.subtract( 'foo', 3 );
 	t.equal( ractive.get( 'foo' ), 5 );
 });
+
+test( 'subtract supports context with decrement', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar}}<span></span>{{/with}}`,
+		data: { foo: { bar: { baz: 10 } } }
+	});
+
+	r.subtract( '.baz', 5, r.find( 'span' ) );
+	t.equal( r.get( 'foo.bar.baz' ), 5 );
+});
+
+test( 'subtract supports context without decrement', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar}}<span></span>{{/with}}`,
+		data: { foo: { bar: { baz: 10 } } }
+	});
+
+	r.subtract( '.baz', r.find( 'span' ) );
+	t.equal( r.get( 'foo.bar.baz' ), 9 );
+});

--- a/test/browser-tests/methods/toggle.js
+++ b/test/browser-tests/methods/toggle.js
@@ -49,3 +49,14 @@ test( 'each keypath that matches a wildcard is toggled individually (#1604)', t 
 	t.ok(  ractive.get( 'items[1].active' ) );
 	t.ok( !ractive.get( 'items[2].active' ) );
 });
+
+test( 'toggle supports toggling keypaths with context', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar}}<span></span>{{/with}}`,
+		data: { foo: { bar: { baz: false } } }
+	});
+
+	r.toggle( '.baz', r.find( 'span' ) );
+	t.ok( r.get( 'foo.bar.baz' ) );
+});

--- a/test/browser-tests/methods/update.js
+++ b/test/browser-tests/methods/update.js
@@ -1,0 +1,16 @@
+import { test } from 'qunit';
+
+test( 'update can be called with context', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar}}<span>{{.baz}}</span>{{/with}}`,
+		data: { foo: { bar: { baz: 'nope' } } }
+	});
+
+	const bar = r.get( 'foo.bar' );
+	bar.baz = 'yep';
+
+	t.htmlEqual( fixture.innerHTML, '<span>nope</span>' );
+	r.update( '.baz', r.find( 'span' ) );
+	t.htmlEqual( fixture.innerHTML, '<span>yep</span>' );
+});

--- a/test/browser-tests/methods/updateModel.js
+++ b/test/browser-tests/methods/updateModel.js
@@ -25,3 +25,15 @@ test( 'Works across component boundary', t => {
 	t.equal( fixture.innerHTML, '<input value="changed">changed' );
 	t.equal( ractive.findComponent( 'widget' ).get( 'bar' ), 'changed' );
 });
+
+test( 'can be used with element context', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#with foo.bar}}<input value="{{.baz}}" />{{/with}}`,
+		data: { foo: { bar: { baz: 'nope' } } }
+	});
+
+	r.find( 'input' ).value = 'yep';
+	r.updateModel( '.baz', r.find( 'input' ) );
+	t.equal( r.get( 'foo.bar.baz' ), 'yep' );
+});


### PR DESCRIPTION
This is an attempt to make life outside of template context (method events, decorators, and other strange and dark corners of javascript) by allowing the keypath-taking methods of Ractive instances to take an element reference as a context parameter used for resolving the keypath. Here's an example:

## Example

```js
const r = new Ractive({
  template: `<ul>{{#each people as person}}
    {{#person.details.address}}
      <li {{#if .picked}}class="picked"{{/if}} on-click="toggle('.picked', event.original.target)">
        {{address}}, {{city}}, {{state}} {{zip}}
      </li>
    {{/}}
  {{/each}}</ul>`,
  ...
});
r.set({ '.city': 'Hell', '.state': 'MI' }, r.find('ul li'));
console.log(r.get('person', r.findAll('ul li')[2]));
``` 

In this example:

1. Clicking on one of the `li`s `toggle`s the `picked` flag on the context of the first `ul li`, which happens to be the first item in the `people` list. The benefits to this become lots more compelling if you have contexts with aliases that pop around different objects, such as looking up an object in a root context lookup e.g. `~/states[.state].directory` inside a user `li`.

2. The city and state for the first address are changed to 'Hell, MI' without the intervening keypath gubbins, which in this case are admittedly minor but can become much more complex in the wild.

3. The third item in the `people` array is logged to console by looking it up from the `li` to which it is attached.

## Changes

This adds an extra optional parameter for context in the following methods:
```
set( keypath, value [, context] )
set( object [, context] )
get( keypath [, context] )
add( keypath [, number] [, context ] )
subtract( keypath [, number] [, context] )
toggle( keypath [, context] )
splice( keypath, [context,] index, drop, ...add )
push( keypath, [context,] ...values )
pop( keypath [, context] )
shift( keypath [, context] )
unshift( keypath, [context,] ...values )
sort( keypath [, context] )
reverse( keypath [, context] )
update( keypath [, context] )
updateModel( keypath [, cascade] [, context] )
animate( keypath, [context,] value [, options] )
link( keypathSrc, keypathDest [, context] )
```

If a keypath has a wildcard, context is not supported.

## RFC

First off, am I the only one who has ever wished for this? Second, I tried to make the API as consistent as possible with the current methods. With the exception of `set`<sub>1</sub>, `add`, and `subtract`, you can just add a context after the keypath. Should those be adjusted to match the others? I did them first, and it felt more natural to have the context trailing there. I suppose the context could be shifted to trail on the varargs methods, and that would make it a little more consistent too.

Another alternative would be to supply an `options` object with a `context` flag for each of the relevant methods.

## Addendum

I also considered another special ref (heh), `@element` that would grab the node of the nearest parent element for use in events. Another option would be to add the appropriate value to the `event` object that is available during method event resolution e.g. `event.el` or `event.element` or `event.target`.

## TL;DR

Use keypaths outside of templates as if they were in template by passing an element from which to start resolution.

Thoughts?