### PR TITLE
Add a splice-oriented handler for updatePostShuffle - RFC/Review

### DIFF
--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -357,11 +357,18 @@ export default class RepeatedFragment {
 		// This algorithm (for detaching incorrectly-ordered fragments from the DOM and
 		// storing them in a document fragment for later reinsertion) seems a bit hokey,
 		// but it seems to work for now
-		let previousNewIndex = -1;
-		let reinsertFrom = null;
+		const len = this.context.get().length;
+		let i, maxIdx = 0, merged = false;
 
 		newIndices.forEach( ( newIndex, oldIndex ) => {
 			const fragment = this.previousIterations[ oldIndex ];
+
+			// check for merged shuffles
+			if ( !merged && newIndex !== -1 ) {
+				if ( newIndex < maxIdx ) merged = true;
+				if ( newIndex > maxIdx ) maxIdx = newIndex;
+			}
+
 
 			if ( newIndex === -1 ) {
 				fragment.unbind().unrender( true );
@@ -373,42 +380,46 @@ export default class RepeatedFragment {
 					fragment.aliases[ this.owner.template.z[0].n ] = model;
 				}
 				fragment.rebind( model );
-
-				if ( reinsertFrom === null && ( newIndex !== previousNewIndex + 1 ) ) {
-					reinsertFrom = oldIndex;
-				}
 			}
-
-			previousNewIndex = newIndex;
 		});
 
 		// create new iterations
 		const docFrag = this.rendered ? createDocumentFragment() : null;
 		const parentNode = this.rendered ? this.parent.findParentNode() : null;
 
-		const len = this.context.get().length;
-		let i;
+		if ( merged ) {
+			for ( i = 0; i < len; i += 1 ) {
+				let frag = this.iterations[i];
 
-		for ( i = 0; i < len; i += 1 ) {
-			let existingFragment = this.iterations[i];
-
-			if ( this.rendered ) {
-				if ( existingFragment ) {
-					if ( reinsertFrom !== null && i >= reinsertFrom ) {
-						docFrag.appendChild( existingFragment.detach() );
+				if ( this.rendered ) {
+					if ( frag ) {
+						docFrag.appendChild( frag.detach() );
+					} else {
+						this.iterations[i] = this.createIteration( i, i );
+						this.iterations[i].render( docFrag );
 					}
+				}
 
-					else if ( docFrag.childNodes.length ) {
-						parentNode.insertBefore( docFrag, existingFragment.firstNode() );
+				if ( !this.rendered ) {
+					if ( !frag ) {
+						this.iterations[i] = this.createIteration( i, i );
 					}
-				} else {
-					this.iterations[i] = this.createIteration( i, i );
-					this.iterations[i].render( docFrag );
 				}
 			}
+		} else {
+			for ( i = 0; i < len; i++ ) {
+				let frag = this.iterations[i];
 
-			if ( !this.rendered ) {
-				if ( !existingFragment ) {
+				if ( this.rendered ) {
+					if ( frag && docFrag.childNodes.length ) {
+						parentNode.insertBefore( docFrag, frag.firstNode() );
+					}
+
+					if ( !frag ) {
+						frag = this.iterations[i] = this.createIteration( i, i );
+						frag.render( docFrag );
+					}
+				} else if ( !frag ) {
 					this.iterations[i] = this.createIteration( i, i );
 				}
 			}


### PR DESCRIPTION
For background, see #2366

There are two scenarios to arrive in `updatePostShuffle`: `merge` and `splice`(ish things). The current algorithm is a sort-of hybrid for handling merges and splices that ends up detaching and re-attaching everything past a certain point. The detaching and re-attaching is required for merges, which tend to be more of a jumble, and the 'past a certain point' is aimed at splices, which operate on a single contiguous region.

For the delete test on which Ractive performs poorly, part of the performance issue seems to be caused by detaching and re-attaching _every_ element in the repeated fragment. This adds a check to see if everything remains sequential, and if it does, avoids detaching and re-attaching iterations that are already in place. New iterations are aggregated and stuffed in before the next existing iteration or the end of the repeated fragment, whichever comes first.

I was going to try to use the same loop to handle both merges and splices, but I couldn't come up with a fast way to make sure the existing fragments were in the proper order for the merge. I figured the existing method would probably end up being faster than trying to sort in the DOM. I also thing that splices are probably more common than merges.

On latest, the test takes ~700ms for the first run on my machine and settles down to ~300ms. On edge, the test takes ~160ms every time, but deleting the _second_ element takes ~280ms. From there, the closer you get to the end of the list, the faster it runs. With this change, the test still takes roughly ~160ms (it might be a few ms better, but is close enough I'll call it the same), but deleting further elements also clocks in at ~160ms.

For further reference, the actual shuffling that Ractive does takes ~70ms. I'm assuming that the rest of the time is taken by the browser, which would mean that some of the other libraries in the test do the delete in ~10ms or less.