### PR TITLE
Fix server-side "window is not defined" error

### DIFF
--- a/src/model/specials/GlobalModel.js
+++ b/src/model/specials/GlobalModel.js
@@ -4,7 +4,7 @@ import Model from '../Model';
 class GlobalModel extends Model {
 	constructor ( ) {
 		super( null, '@global' );
-		this.value = typeof global !== 'undefined' ? global : window;
+		this.value = typeof global !== 'undefined' ? global : win;
 		this.isRoot = true;
 		this.root = this;
 		this.adaptors = [];


### PR DESCRIPTION
Fixes "window is not defined" error when Ractive.js is used in a server-side library (i.e. [ClearScript](https://clearscript.codeplex.com/))