### PR TITLE
Gh 2005

### DIFF
--- a/src/Ractive/static/adaptors/magic.js
+++ b/src/Ractive/static/adaptors/magic.js
@@ -98,7 +98,7 @@ class MagicWrapper {
 	}
 
 	reset () {
-		throw new Error( 'TODO magic adaptor reset' ); // does this ever happen?
+		return false;
 	}
 
 	set ( key, value ) {

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -210,6 +210,10 @@ export default class RepeatedFragment {
 			if ( newIndex === -1 ) return;
 
 			const fragment = this.iterations[ oldIndex ];
+
+			// guard against null fragment - #2005 (feels like treating the symptom, not the cause?)
+			if ( fragment == null ) return;
+
 			iterations[ newIndex ] = fragment;
 
 			if ( newIndex !== oldIndex && fragment ) fragment.dirty = true;
@@ -362,6 +366,9 @@ export default class RepeatedFragment {
 
 		newIndices.forEach( ( newIndex, oldIndex ) => {
 			const fragment = this.previousIterations[ oldIndex ];
+
+			// guard against null fragment - #2005 (feels like treating the symptom, not the cause?)
+			if ( fragment == null ) return;
 
 			if ( newIndex === -1 ) {
 				fragment.unbind().unrender( true );

--- a/test/browser-tests/plugins/adaptors/magic.js
+++ b/test/browser-tests/plugins/adaptors/magic.js
@@ -49,6 +49,64 @@ try {
 		t.htmlEqual( fixture.innerHTML, 'Fozzie: bear' );
 	});
 
+	test( 'Test that splice array works in magic mode', t => {
+		const items = [
+			{ name: 'a' },
+			{ name: 'b' },
+			{ name: 'c' }
+		];
+
+		new Ractive({
+			template: '{{#each items}} {{name}} {{/each}}',
+			el: fixture,
+			data: { items: items },
+			magic: true
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'abc' );
+
+		arr.splice( 0, 1 );
+
+		t.htmlEqual( fixture.innerHTML, 'bc' );
+	});
+
+	test( 'test moving one array to another #2005', t => {
+
+		var parents = [
+		    { name: 'first', children: [] },
+			{ name: 'second', children: [] },
+			{ name: 'third', children: [] },
+			{ name: 'fourth', children: [] }
+		],
+		third = parents[2];
+
+		new Ractive({
+			template: '{{#parents}}<li>{{this.name}}</li><ul>{{#this.children}}<li>{{this.name}}</li>{{/}}</ul>{{/}}',
+			el: fixture,
+			data: { parents: parents },
+			magic: true
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<li>first</li><ul></ul><li>second</li><ul></ul><li>third</li><ul></ul><li>fourth</li><ul></ul>' );
+
+		third.children.push( parents[0] );
+		parents.splice( 0, 1 );
+		t.htmlEqual( fixture.innerHTML, '<li>second</li><ul></ul><li>third</li><ul><li>first</li></ul><li>fourth</li><ul></ul>' );
+
+		// Keep slicing until all parents are removed
+		third.children.push( parents[0] );
+		parents.splice( 0, 1 );
+		t.htmlEqual( fixture.innerHTML, '<li>third</li><ul><li>first</li><li>second</li></ul><li>fourth</li><ul></ul>' );
+
+		parents.splice( 0, 1 );
+		third.children.push( parents[0] );
+		t.htmlEqual( fixture.innerHTML, '<li>fourth</li><ul></ul>' );
+
+		parents.splice( 0, 1 );
+		third.children.push( parents[0] );
+		t.htmlEqual( fixture.innerHTML, '' );
+	});
+
 	test( 'Multiple instances can share an object', t => {
 		const muppet = makeObj();
 
@@ -196,7 +254,6 @@ try {
 	});
 
 	// TODO: fix this, failing since keypath-ftw
-	/*
 	test( "Magic adapters shouldn't tear themselves down while resetting (#1342)", t => {
 		let list = 'abcde'.split('');
 		let ractive = new MagicRactive({
@@ -215,7 +272,6 @@ try {
 		list.pop();
 		t.htmlEqual( fixture.innerHTML, 'abc' );
 	});
-	*/
 
 	test( 'Data passed into component updates from outside component in magic mode', t => {
 		const Widget = Ractive.extend({


### PR DESCRIPTION
This PR is an attempt to fix #2005.

Currently magic.js#reset throws an error and a comment that this method is unlikely to be called. Seems it is called after all. Here I removed the error thrown and return false. Magic.js#reset is invoked from Model.js#applyChanges. Returning false from magic#reset will forces a teardown and adaption of the new value. Not sure what the correct solution here is, but the tests pass...

The next two errors faced was in RepeatedFragment#shuffle and RepeatedFragment#updatePostShuffle where fragments are looked up but could be undefined. So I added null checks to guard against executing the functions further. Feels like treating the symptoms rather than the cause though?

I've also uncommented the test #1342 which seems to work now.
