### PR TITLE
ractive.animate should always return a promise, even if no animation

### DIFF
--- a/src/Ractive/prototype/animate.js
+++ b/src/Ractive/prototype/animate.js
@@ -1,11 +1,15 @@
 import runloop from '../../global/runloop';
 import interpolate from '../../shared/interpolate';
+import Promise from '../../utils/Promise';
+import { defineProperty } from '../../utils/object';
 import { isEqual } from '../../utils/is';
 import { splitKeypath } from '../../shared/keypaths';
 import easing from '../../Ractive/static/easing';
 import noop from '../../utils/noop';
 
-const noAnimation = { stop: noop };
+let noAnimation = Promise.resolve();
+defineProperty( noAnimation, 'stop', { value: noop });
+
 const linear = easing.linear;
 
 function getOptions ( options, instance ) {

--- a/test/browser-tests/methods/animate.js
+++ b/test/browser-tests/methods/animate.js
@@ -28,6 +28,17 @@ test( 'ractive.animate() returns a promise that resolves when the animation comp
 	});
 });
 
+test( 'ractive.animate() returns a promise even if nothing changes', t => {
+	t.expect( 3 );
+
+	const ractive = new Ractive();
+	const promise = ractive.animate( 'foo', 'x' );
+
+	t.ok( promise.then );
+	t.ok( promise.catch );
+	t.ok( promise.stop );
+});
+
 test( 'all animations are updated in a single batch', t => {
 	const done = t.async();
 


### PR DESCRIPTION
`ractive.animate(...)` was failing to return a promise in cases where it wasn't possible to interpolate values, causing unexpected behaviour. This PR fixes it