### PR TITLE
Don't count non-breaking spaces as whitespace when stripping space - #2327

### DIFF
--- a/src/parse/utils/stripStandalones.js
+++ b/src/parse/utils/stripStandalones.js
@@ -1,8 +1,8 @@
 import { COMMENT, DELIMCHANGE, SECTION, INVERTED } from '../../config/types';
 import { lastItem } from '../../utils/array';
 
-var leadingLinebreak = /^\s*\r?\n/,
-	trailingLinebreak = /\r?\n\s*$/;
+var leadingLinebreak = /^[ \t\f\r\n]*\r?\n/,
+	trailingLinebreak = /\r?\n[ \t\f\r\n]*$/;
 
 export default function ( items ) {
 	var i, current, backOne, backTwo, lastSectionItem;

--- a/test/browser-tests/render/misc.js
+++ b/test/browser-tests/render/misc.js
@@ -266,3 +266,13 @@ if ( typeof Object.create === 'function' ) {
 		t.equal( ractive.toHTML(), expected );
 	});
 }
+
+test( 'space entity refs should not be consumed during trimming (#2327)', t => {
+	new Ractive({
+		el: fixture,
+		template: '\n  {{#if check}}\n    &nbsp;\n    {{first}}\n    &nbsp;\n    {{second}}\n    &nbsp;\n  {{/if}}\n',
+		data: { check: true, first: 1, second: 2 }
+	});
+
+	t.equal( fixture.innerHTML, '&nbsp; 1 &nbsp; 2 &nbsp;' );
+});


### PR DESCRIPTION
Turned out to be less painful than I thought it would. It was just a `\s` where `[ \t\f\r\n]` was called for instead because `\s` matches `&nbsp;` where the other class does not. Fixes #2327.