### PR TITLE
use local variable with for...in to avoid deopt

### DIFF
--- a/src/Ractive/prototype/set.js
+++ b/src/Ractive/prototype/set.js
@@ -10,9 +10,9 @@ export default function Ractive$set ( keypath, value ) {
 	if ( isObject( keypath ) ) {
 		const map = keypath;
 
-		for ( keypath in map ) {
-			if ( map.hasOwnProperty( keypath) ) {
-				set( this, keypath, map[ keypath ] );
+		for ( const k in map ) {
+			if ( map.hasOwnProperty( k) ) {
+				set( this, k, map[k] );
 			}
 		}
 	}


### PR DESCRIPTION
Chrome was barking at me about `Ractive.prototype.set` being deoptimised ('ForInStatement with non-local each variable'). This fixes it