### PR TITLE
PRIVATE BREAKING: Look up template refs for node info and events on the fly - RFC

### DIFF
--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -41,9 +41,7 @@ export default function initialise ( ractive, userOptions, options ) {
 		ractive.fragment = fragment = new Fragment({
 			owner: ractive,
 			template: ractive.template,
-			cssIds,
-			indexRefs: options.indexRefs || {},
-			keyRefs: options.keyRefs || {}
+			cssIds
 		}).bind( ractive.viewmodel );
 	}
 

--- a/src/Ractive/static/getNodeInfo.js
+++ b/src/Ractive/static/getNodeInfo.js
@@ -1,15 +1,16 @@
-import { extend } from '../../utils/object';
+import gatherRefs from '../../view/helpers/gatherRefs';
 
 export default function( node ) {
 	if ( !node || !node._ractive ) return {};
 
 	const storage = node._ractive;
+	const { key, index } = gatherRefs( storage.fragment );
 
 	return {
 		ractive: storage.ractive,
 		keypath: storage.keypath,
 		rootpath: storage.rootpath,
-		index: extend( {}, storage.fragment.indexRefs ),
-		key: extend( {}, storage.fragment.keyRefs )
+		index,
+		key
 	};
 }

--- a/src/Ractive/static/getNodeInfo.js
+++ b/src/Ractive/static/getNodeInfo.js
@@ -4,12 +4,14 @@ export default function( node ) {
 	if ( !node || !node._ractive ) return {};
 
 	const storage = node._ractive;
+	const ractive = storage.fragment.ractive;
 	const { key, index } = gatherRefs( storage.fragment );
+	const context = storage.fragment.findContext();
 
 	return {
-		ractive: storage.ractive,
-		keypath: storage.keypath,
-		rootpath: storage.rootpath,
+		ractive,
+		keypath: context.getKeypath( ractive ),
+		rootpath: context.getKeypath(),
 		index,
 		key
 	};

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -23,8 +23,6 @@ export default class Fragment {
 
 		this.context = null;
 		this.rendered = false;
-		this.indexRefs = options.indexRefs || ( this.parent ? this.parent.indexRefs : [] );
-		this.keyRefs = options.keyRefs || ( this.parent ? this.parent.keyRefs : {} );
 
 		// encapsulated styles should be inherited until they get applied by an element
 		this.cssIds = 'cssIds' in options ? options.cssIds : ( this.parent ? this.parent.cssIds : null );

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -3,22 +3,6 @@ import { createDocumentFragment } from '../utils/dom';
 import { isArray, isObject } from '../utils/is';
 import { toEscapedString, toString, unbind, unrender, unrenderAndDestroy, update } from '../shared/methodCallers';
 
-function getRefs ( ref, value, parent ) {
-	let refs;
-
-	if ( ref ) {
-		refs = {};
-		Object.keys( parent ).forEach( ref => {
-			refs[ ref ] = parent[ ref ];
-		});
-		refs[ ref ] = value;
-	} else {
-		refs = parent;
-	}
-
-	return refs;
-}
-
 export default class RepeatedFragment {
 	constructor ( options ) {
 		this.parent = options.owner.parentFragment;
@@ -88,15 +72,9 @@ export default class RepeatedFragment {
 	}
 
 	createIteration ( key, index ) {
-		const parentFragment = this.owner.parentFragment;
-		const keyRefs = getRefs( this.keyRef, key, parentFragment.keyRefs );
-		const indexRefs = getRefs( this.indexRef, index, parentFragment.indexRefs );
-
 		const fragment = new Fragment({
 			owner: this,
-			template: this.template,
-			indexRefs,
-			keyRefs
+			template: this.template
 		});
 
 		// TODO this is a bit hacky

--- a/src/view/helpers/gatherRefs.js
+++ b/src/view/helpers/gatherRefs.js
@@ -1,0 +1,21 @@
+export default function gatherRefs( fragment ) {
+	let key = {}, index = {};
+
+	// walk up the template gather refs as we go
+	while ( fragment ) {
+		if ( fragment.parent && ( fragment.parent.indexRef || fragment.parent.keyRef ) ) {
+			let ref = fragment.parent.indexRef;
+			if ( ref && !( ref in index ) ) index[ref] = fragment.index;
+			ref = fragment.parent.keyRef;
+			if ( ref && !( ref in key ) ) key[ref] = fragment.key;
+		}
+
+		if ( fragment.componentParent && !fragment.ractive.isolated ) {
+			fragment = fragment.componentParent;
+		} else {
+			fragment = fragment.parent;
+		}
+	}
+
+	return { key, index };
+}

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -149,8 +149,6 @@ export default class Component extends Item {
 		initialise( this.instance, {
 			partials: this._partials
 		}, {
-			indexRefs: this.instance.isolated ? {} : this.parentFragment.indexRefs,
-			keyRefs: this.instance.isolated ? {} : this.parentFragment.keyRefs,
 			cssIds: this.parentFragment.cssIds
 		});
 

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -234,16 +234,10 @@ export default class Element extends Item {
 			this.node = node;
 		}
 
-		const context = this.parentFragment.findContext();
-
 		defineProperty( node, '_ractive', {
 			value: {
 				proxy: this,
-				ractive: this.ractive,
-				fragment: this.parentFragment,
-				context,
-				keypath: context.getKeypath( this.ractive ),
-				rootpath: context.getKeypath()
+				fragment: this.parentFragment
 			}
 		});
 

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -6,6 +6,7 @@ import { unbind } from '../../../shared/methodCallers';
 import noop from '../../../utils/noop';
 import resolveReference from '../../resolvers/resolveReference';
 import { splitKeypath } from '../../../shared/keypaths';
+import gatherRefs from '../../helpers/gatherRefs';
 
 const eventPattern = /^event(?:\.(.+))?$/;
 const argumentsPattern = /^arguments\.(\d*)$/;
@@ -132,10 +133,12 @@ export default class EventDirective {
 
 		// augment event object
 		if ( event ) {
+			const refs = gatherRefs( this.parentFragment );
 			event.keypath = this.context.getKeypath( this.ractive );
 			event.rootpath = this.context.getKeypath();
 			event.context = this.context.get();
-			event.index = this.parentFragment.indexRefs;
+			event.index = refs.index;
+			event.key = refs.key;
 		}
 
 		if ( this.method ) {

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -60,7 +60,7 @@ test( 'Instances with multiple components still fire oncomplete() handlers (#486
 	});
 });
 
-test( 'Correct value is given to node._ractive.keypath when a component is torn down and re-rendered (#470)', t => {
+test( 'Correct value exists for node info keypath when a component is torn down and re-rendered (#470)', t => {
 	const ractive = new Ractive({
 		el: fixture,
 		template: '{{#foo}}<Widget visible="{{visible}}"/>{{/foo}}',
@@ -72,12 +72,12 @@ test( 'Correct value is given to node._ractive.keypath when a component is torn 
 		}
 	});
 
-	t.equal( ractive.find( 'p' )._ractive.keypath, '' );
+	t.equal( Ractive.getNodeInfo( ractive.find( 'p' ) ).keypath, '' );
 
 	ractive.set( 'visible', false );
 	ractive.set( 'visible', true );
 
-	t.equal( ractive.find( 'p' )._ractive.keypath, '' );
+	t.equal( Ractive.getNodeInfo( ractive.find( 'p' ) ).keypath, '' );
 });
 
 test( 'Nested components fire the oninit() event correctly (#511)', t => {

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -325,38 +325,6 @@ test( 'Partial templates will be drawn from script tags if not already registere
 	t.htmlEqual( fixture.innerHTML, '123' );
 });
 
-// ARGH these tests don't work in phantomJS
-/*test( 'ractive.detach() removes an instance from the DOM and returns a document fragment', t => {
-	const ractive, p, docFrag;
-
-	ractive = new Ractive({
-		el: fixture,
-		template: '<p>{{foo}}</p>',
-		data: { foo: 'whee!' }
-	});
-
-	p = ractive.find( 'p' );
-
-	docFrag = ractive.detach();
-	t.ok( docFrag instanceof DocumentFragment );
-	t.ok( docFrag.contains( p ) );
-});
-
-test( 'ractive.detach() works with a previously unrendered ractive', t => {
-	const ractive, p, docFrag;
-
-	ractive = new Ractive({
-		template: '<p>{{foo}}</p>',
-		data: { foo: 'whee!' }
-	});
-
-	p = ractive.find( 'p' );
-
-	docFrag = ractive.detach();
-	t.ok( docFrag instanceof DocumentFragment );
-	t.ok( docFrag.contains( p ) );
-});*/
-
 test( 'ractive.insert() moves an instance to a different location', t => {
 	const one = document.createElement( 'div' );
 	const two = document.createElement( 'div' );
@@ -558,19 +526,6 @@ test( 'ractive.insert() with triples doesn\'t invoke Yoda (#391)', t => {
 	ractive.insert( fixture );
 	t.htmlEqual( fixture.innerHTML, ' you are <i>very puzzled now</i>' );
 });
-
-// commenting out. PhantomJS.
-// test( '<input value="{{foo}}"> where foo === null should not render a value (#390)', t => {
-// 	const ractive = new Ractive({
-// 		el: fixture,
-// 		template: '<input value="{{foo}}">',
-// 		data: {
-// 			foo: null
-// 		}
-// 	});
-//
-// 	t.equal( ractive.find( 'input' ).value, '' );
-// });
 
 // only run these tests if magic mode is supported
 try {
@@ -1678,94 +1633,117 @@ test( 'shuffled elements have the correct keypath in their node info', t => {
 // 	t.htmlEqual( fixture.innerHTML, '<p>one.txt</p><p>two.txt</p><p>three.txt</p>' );
 // });
 
-// These tests run fine in the browser but not in PhantomJS. WTF I don't even.
-// Anyway I can't be bothered to figure it out right now so I'm just commenting
-// these out so it will build
+if ( !/phantom/i.test( navigator.userAgent ) ) {
+	test( '<input value="{{foo}}"> where foo === null should not render a value (#390)', t => {
+		const ractive = new Ractive({
+			el: fixture,
+			template: '<input value="{{foo}}">',
+			data: {
+				foo: null
+			}
+		});
 
-/*test( 'Components with two-way bindings set parent values on initialisation', t => {
-	var Dropdown, ractive;
-
-	Dropdown = Ractive.extend({
-		template: '<select value="{{value}}">{{#options}}<option value="{{this}}">{{ this[ display ] }}</option>{{/options}}</select>'
+		t.equal( ractive.find( 'input' ).value, '' );
 	});
 
-	ractive = new Ractive({
-		el: fixture,
-		template: '<h2>Select an option:</h2><dropdown options="{{numbers}}" value="{{number}}" display="word"/><p>Selected: {{number.digit}}</p>',
-		data: {
-			numbers: [
-				{ word: 'one', digit: 1 },
-				{ word: 'two', digit: 2 },
-				{ word: 'three', digit: 3 },
-				{ word: 'four', digit: 4 }
-			]
-		},
-		components: {
-			dropdown: Dropdown
-		}
+	test( 'ractive.detach() removes an instance from the DOM and returns a document fragment', t => {
+		const ractive = new Ractive({
+			el: fixture,
+			template: '<p>{{foo}}</p>',
+			data: { foo: 'whee!' }
+		});
+
+		const p = ractive.find( 'p' );
+
+		const docFrag = ractive.detach();
+		t.ok( docFrag instanceof DocumentFragment );
+		t.ok( docFrag.contains( p ) );
 	});
 
-	t.deepEqual( ractive.get( 'number' ), { word: 'one', digit: 1 });
-});
+	test( 'ractive.detach() works with a previously unrendered ractive', t => {
+		const ractive = new Ractive({
+			el: fixture,
+			template: '<p>{{foo}}</p>',
+			data: { foo: 'whee!' }
+		});
 
+		const p = ractive.find( 'p' );
 
+		const docFrag = ractive.detach();
+		t.ok( docFrag instanceof DocumentFragment );
+		t.ok( docFrag.contains( p ) );
+	});
 
-{
-	name: 'Tearing down expression mustaches and recreating them does\'t throw errors',
-	test: function () {
-		const ractive;
+	test( 'Components with two-way bindings set parent values on initialisation', t => {
+		var Dropdown, ractive;
+
+		Dropdown = Ractive.extend({
+			template: '<select value="{{value}}">{{#options}}<option value="{{this}}">{{ this[ display ] }}</option>{{/options}}</select>'
+		});
 
 		ractive = new Ractive({
+			el: fixture,
+			template: '<h2>Select an option:</h2><dropdown options="{{numbers}}" value="{{number}}" display="word"/><p>Selected: {{number.digit}}</p>',
+			data: {
+				numbers: [
+					{ word: 'one', digit: 1 },
+					{ word: 'two', digit: 2 },
+					{ word: 'three', digit: 3 },
+					{ word: 'four', digit: 4 }
+				]
+			},
+			components: {
+				dropdown: Dropdown
+			}
+		});
+
+		t.deepEqual( ractive.get( 'number' ), { word: 'one', digit: 1 });
+	});
+
+	test( 'Tearing down expression mustaches and recreating them does\'t throw errors', t => {
+		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#condition}}{{( a+b )}} {{( a+b )}} {{( a+b )}}{{/condition}}',
 			data: { a: 1, b: 2, condition: true }
 		});
 
-		equal( fixture.innerHTML, '3 3 3' );
+		t.equal( fixture.innerHTML, '3 3 3' );
 
 		ractive.set( 'condition', false );
-		equal( fixture.innerHTML, '' );
+		t.equal( fixture.innerHTML, '' );
 
 		ractive.set( 'condition', true );
-		equal( fixture.innerHTML, '3 3 3' );
-	}
-},
-{
-	name: 'Updating an expression section doesn\'t throw errors',
-	test: function () {
-		const ractive, array;
+		t.equal( fixture.innerHTML, '3 3 3' );
+	});
 
-		array = [{ foo: 1 }, { foo: 2 }, { foo: 3 }, { foo: 4 }, { foo: 5 }];
+	test( 'Updating an expression section doesn\'t throw errors', t => {
+		const array = [{ foo: 1 }, { foo: 2 }, { foo: 3 }, { foo: 4 }, { foo: 5 }];
 
-		ractive = new Ractive({
+		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#( array.slice( 0, 3 ) )}}{{foo}}{{/()}}',
-			data: { array: array }
+			data: { array }
 		});
 
-		equal( fixture.innerHTML, '123' );
+		t.equal( fixture.innerHTML, '123' );
 
 		array.push({ foo: 6 });
-		equal( fixture.innerHTML, '123' );
+		t.equal( fixture.innerHTML, '123' );
 
 		array.unshift({ foo: 0 });
-		equal( fixture.innerHTML, '012' );
+		t.equal( fixture.innerHTML, '012' );
 
 		ractive.set( 'array', [] );
-		equal( array._ractive, undefined );
-		equal( fixture.innerHTML, '' );
+		t.equal( array._ractive, undefined );
+		t.equal( fixture.innerHTML, '' );
 
 		ractive.set( 'array', array );
-		ok( array._ractive );
-		equal( fixture.innerHTML, '012' );
-	}
-},
-{
-	name: 'Updating a list section with child list expressions doesn\'t throw errors',
-	test: function () {
-		const ractive, array;
+		t.ok( array._ractive );
+		t.equal( fixture.innerHTML, '012' );
+	});
 
-		array = [
+	test( 'Updating a list section with child list expressions doesn\'t throw errors', t => {
+		const array = [
 			{ foo: [ 1, 2, 3, 4, 5 ] },
 			{ foo: [ 2, 3, 4, 5, 6 ] },
 			{ foo: [ 3, 4, 5, 6, 7 ] },
@@ -1773,26 +1751,26 @@ test( 'shuffled elements have the correct keypath in their node info', t => {
 			{ foo: [ 5, 6, 7, 8, 9 ] }
 		];
 
-		ractive = new Ractive({
+		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#array}}<p>{{#( foo.slice( 0, 3 ) )}}{{.}}{{/()}}</p>{{/array}}',
 			data: { array: array }
 		});
 
-		equal( fixture.innerHTML, '<p>123</p><p>234</p><p>345</p><p>456</p><p>567</p>' );
+		t.equal( fixture.innerHTML, '<p>123</p><p>234</p><p>345</p><p>456</p><p>567</p>' );
 
 		array.push({ foo: [ 6, 7, 8, 9, 10 ] });
-		equal( fixture.innerHTML, '<p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
+		t.equal( fixture.innerHTML, '<p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
 
 		array.unshift({ foo: [ 0, 1, 2, 3, 4 ] });
-		equal( fixture.innerHTML, '<p>012</p><p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
+		t.equal( fixture.innerHTML, '<p>012</p><p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
 
 		ractive.set( 'array', [] );
-		equal( array._ractive, undefined );
+		t.equal( array._ractive, undefined );
 		equal( fixture.innerHTML, '' );
 
 		ractive.set( 'array', array );
-		ok( array._ractive );
-		equal( fixture.innerHTML, '<p>012</p><p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
-	}
-}*/
+		t.ok( array._ractive );
+		t.equal( fixture.innerHTML, '<p>012</p><p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
+	});
+}

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -1644,6 +1644,18 @@ test( '@global special ref gives access to the vm global object', t => {
 	t.equal( target.foo.bar, 10 );
 });
 
+test( 'shuffled elements have the correct keypath in their node info', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '{{#each list}}<span>{{.}}</span>{{/each}}',
+		data: { list: [ 42, 42, 42 ] }
+	});
+
+	t.equal( Ractive.getNodeInfo( r.findAll( 'span' )[2] ).keypath, 'list.2' );
+	r.unshift( 'list', 42 );
+	t.equal( Ractive.getNodeInfo( r.findAll( 'span' )[2] ).keypath, 'list.2' );
+});
+
 // Is there a way to artificially create a FileList? Leaving this commented
 // out until someone smarter than me figures out how
 // test( '{{#each}} iterates over a FileList (#1220)', t => {


### PR DESCRIPTION
Template refs for indices and keys are currently forwarded along through the fragment hierarchy as it gets created. This seems like basically trading performance for memory, which is fine, but it also introduces a maintenance burden for splicing. That maintenance is not currently being done per #2399 and #2400.

This PR drops the forwarding of refs through and instead looks them up when needed e.g. when an event is fired or when `Ractive.getNodeInfo` is called. I looked briefly at trying to keep the `indexRefs` and `keyRefs` objects up to date when a shuffle happens, but it looked like more code than it's worth for the two places they're actually used. The only potential downside is that gathering the refs for a very very deep template on event firing might add a very slight delay to the event handler being called.

I also added the `keys` to the `event` object because it was free. That brings around the questions of whether there should actually be separate objects for indices and keys, and whether aliases should also be thrown in, since that would be basically free with this approach.

Thoughts?