### PR TITLE
Avoid exponential firstNode search - #2395 - Review

### DIFF
--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -146,7 +146,7 @@ export default class Fragment {
 		for ( let i = item.index + 1; i < this.items.length; i++ ) {
 			if ( !this.items[ i ] ) continue;
 
-			let node = this.items[ i ].firstNode();
+			let node = this.items[ i ].firstNode( true );
 			if ( node ) return node;
 		}
 
@@ -197,15 +197,18 @@ export default class Fragment {
 		return fragment;
 	}
 
-	firstNode () {
+	firstNode ( skipParent ) {
 		let node;
 		for ( let i = 0; i < this.items.length; i++ ) {
-			node = this.items[i].firstNode();
+			node = this.items[i].firstNode( true );
 
 			if ( node ) {
 				return node;
 			}
 		}
+
+		if ( skipParent ) return null;
+
 		return this.parent.findNextNode( this.owner );
 	}
 

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -162,7 +162,7 @@ export default class RepeatedFragment {
 	findNextNode ( iteration ) {
 		if ( iteration.index < this.iterations.length - 1 ) {
 			for ( let i = iteration.index + 1; i < this.iterations.length; i++ ) {
-				let node = this.iterations[ i ].firstNode();
+				let node = this.iterations[ i ].firstNode( true );
 				if ( node ) return node;
 			}
 		}
@@ -170,8 +170,8 @@ export default class RepeatedFragment {
 		return this.owner.findNextNode();
 	}
 
-	firstNode () {
-		return this.iterations[0] ? this.iterations[0].firstNode() : null;
+	firstNode ( skipParent ) {
+		return this.iterations[0] ? this.iterations[0].firstNode( skipParent ) : null;
 	}
 
 	rebind ( context ) {

--- a/src/view/items/Alias.js
+++ b/src/view/items/Alias.js
@@ -58,8 +58,8 @@ export default class Alias extends Item {
 		}
 	}
 
-	firstNode () {
-		return this.fragment && this.fragment.firstNode();
+	firstNode ( skipParent ) {
+		return this.fragment && this.fragment.firstNode( skipParent );
 	}
 
 	rebind () {

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -205,8 +205,8 @@ export default class Component extends Item {
 		this.instance.fragment.findAllComponents( name, query );
 	}
 
-	firstNode () {
-		return this.instance.fragment.firstNode();
+	firstNode ( skipParent ) {
+		return this.instance.fragment.firstNode( skipParent );
 	}
 
 	rebind () {

--- a/src/view/items/Partial.js
+++ b/src/view/items/Partial.js
@@ -59,8 +59,8 @@ export default class Partial extends Mustache {
 		this.fragment.findAllComponents( name, query );
 	}
 
-	firstNode () {
-		return this.fragment.firstNode();
+	firstNode ( skipParent ) {
+		return this.fragment.firstNode( skipParent );
 	}
 
 	forceResetTemplate () {

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -70,8 +70,8 @@ export default class Section extends Mustache {
 		}
 	}
 
-	firstNode () {
-		return this.fragment && this.fragment.firstNode();
+	firstNode ( skipParent ) {
+		return this.fragment && this.fragment.firstNode( skipParent );
 	}
 
 	rebind () {

--- a/src/view/items/Yielder.js
+++ b/src/view/items/Yielder.js
@@ -73,8 +73,8 @@ export default class Yielder extends Item {
 		return this.containerFragment.findNextNode( this );
 	}
 
-	firstNode () {
-		return this.fragment.firstNode();
+	firstNode ( skipParent ) {
+		return this.fragment.firstNode( skipParent );
 	}
 
 	rebind () {


### PR DESCRIPTION
When searching for the next node in a complex repeated fragment in order to insert a new iteration, edge is currently checking each element from the parent, each element is checking the parent, and so forth until the browser gives up.

This adds a flag to `firstNode` that, when set, tells it not to punt to the parent if it can't find a node for itself. That avoids repeated sections calling children that call it back.

Thoughts?

_I fat-finger tab-enter submitted this a little early... sorry_