### PR TITLE
Fragments and bubbling while also updating - #2406 - Review

### DIFF
--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -77,15 +77,20 @@ function dispatch ( observer ) {
 }
 
 function flushChanges () {
-	batch.immediateObservers.forEach( dispatch );
+	let which = batch.immediateObservers;
+	batch.immediateObservers = [];
+	which.forEach( dispatch );
 
 	// Now that changes have been fully propagated, we can update the DOM
 	// and complete other tasks
 	let i = batch.fragments.length;
 	let fragment;
 
+	which = batch.fragments;
+	batch.fragments = [];
+
 	while ( i-- ) {
-		fragment = batch.fragments[i];
+		fragment = which[i];
 
 		// TODO deprecate this. It's annoying and serves no useful function
 		const ractive = fragment.ractive;
@@ -94,11 +99,12 @@ function flushChanges () {
 
 		fragment.update();
 	}
-	batch.fragments.length = 0;
 
 	batch.transitionManager.start();
 
-	batch.deferredObservers.forEach( dispatch );
+	which = batch.deferredObservers;
+	batch.deferredObservers = [];
+	which.forEach( dispatch );
 
 	const tasks = batch.tasks;
 	batch.tasks = [];
@@ -110,5 +116,5 @@ function flushChanges () {
 	// If updating the view caused some model blowback - e.g. a triple
 	// containing <option> elements caused the binding on the <select>
 	// to update - then we start over
-	if ( batch.fragments.length ) return flushChanges();
+	if ( batch.fragments.length || batch.immediateObservers.length || batch.deferredObservers.length ) return flushChanges();
 }

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -75,9 +75,9 @@ export default class Computation extends Model {
 		if ( shouldCapture ) capture( this );
 
 		if ( this.dirty ) {
+			this.dirty = false;
 			this.value = this.getValue();
 			this.adapt();
-			this.dirty = false;
 		}
 
 		return this.value;

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -305,8 +305,8 @@ export default class Fragment {
 
 	update () {
 		if ( this.dirty ) {
-			this.items.forEach( update );
 			this.dirty = false;
+			this.items.forEach( update );
 		}
 	}
 

--- a/src/view/items/Alias.js
+++ b/src/view/items/Alias.js
@@ -87,10 +87,9 @@ export default class Alias extends Item {
 	}
 
 	update () {
-		if ( !this.dirty ) return;
-
-		this.fragment.update();
-
-		this.dirty = false;
+		if ( this.dirty ) {
+			this.dirty = false;
+			this.fragment.update();
+		}
 	}
 }

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -296,9 +296,9 @@ export default class Component extends Item {
 	}
 
 	update () {
+		this.dirty = false;
 		this.instance.fragment.update();
 		this.checkYielders();
 		this.eventHandlers.forEach( update );
-		this.dirty = false;
 	}
 }

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -392,14 +392,14 @@ export default class Element extends Item {
 
 	update () {
 		if ( this.dirty ) {
+			this.dirty = false;
+
 			this.attributes.forEach( update );
 			this.conditionalAttributes.forEach( update );
 			this.eventHandlers.forEach( update );
 
 			if ( this.decorator ) this.decorator.update();
 			if ( this.fragment ) this.fragment.update();
-
-			this.dirty = false;
 		}
 	}
 }

--- a/src/view/items/Interpolator.js
+++ b/src/view/items/Interpolator.js
@@ -57,11 +57,10 @@ export default class Interpolator extends Mustache {
 
 	update () {
 		if ( this.dirty ) {
+			this.dirty = false;
 			if ( this.rendered ) {
 				this.node.data = this.getString();
 			}
-
-			this.dirty = false;
 		}
 	}
 

--- a/src/view/items/Partial.js
+++ b/src/view/items/Partial.js
@@ -124,6 +124,8 @@ export default class Partial extends Mustache {
 		let template;
 
 		if ( this.dirty ) {
+			this.dirty = false;
+
 			if ( !this.named ) {
 				if ( this.model ) {
 					template = this.model.get();
@@ -142,7 +144,6 @@ export default class Partial extends Mustache {
 			}
 
 			this.fragment.update();
-			this.dirty = false;
 		}
 	}
 }

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -111,6 +111,8 @@ export default class Section extends Mustache {
 		if ( !this.dirty ) return;
 		if ( !this.model && this.sectionType !== SECTION_UNLESS ) return;
 
+		this.dirty = false;
+
 		const value = !this.model ? undefined : this.model.isRoot ? this.model.value : this.model.get();
 		const lastType = this.sectionType;
 
@@ -210,7 +212,5 @@ export default class Section extends Mustache {
 
 			this.fragment = newFragment;
 		}
-
-		this.dirty = false;
 	}
 }

--- a/src/view/items/Triple.js
+++ b/src/view/items/Triple.js
@@ -81,6 +81,8 @@ export default class Triple extends Mustache {
 
 	update () {
 		if ( this.rendered && this.dirty ) {
+			this.dirty = false;
+
 			this.unrender();
 			const docFrag = createDocumentFragment();
 			this.render( docFrag );
@@ -89,8 +91,6 @@ export default class Triple extends Mustache {
 			const anchor = this.parentFragment.findNextNode( this );
 
 			parentNode.insertBefore( docFrag, anchor );
-
-			this.dirty = false;
 		}
 	}
 }

--- a/src/view/items/Yielder.js
+++ b/src/view/items/Yielder.js
@@ -109,7 +109,7 @@ export default class Yielder extends Item {
 	}
 
 	update () {
-		this.fragment.update();
 		this.dirty = false;
+		this.fragment.update();
 	}
 }

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -151,9 +151,9 @@ export default class Attribute extends Item {
 
 	update () {
 		if ( this.dirty ) {
+			this.dirty = false;
 			if ( this.fragment ) this.fragment.update();
 			if ( this.rendered ) this.updateDelegate();
-			this.dirty = false;
 		}
 	}
 }

--- a/src/view/items/element/ConditionalAttribute.js
+++ b/src/view/items/element/ConditionalAttribute.js
@@ -65,6 +65,8 @@ export default class ConditionalAttribute extends Item {
 		let attrs;
 
 		if ( this.dirty ) {
+			this.dirty = false;
+
 			this.fragment.update();
 
 			if ( this.rendered ) {
@@ -83,8 +85,6 @@ export default class ConditionalAttribute extends Item {
 
 				this.attributes = attrs;
 			}
-
-			this.dirty = false;
 		}
 	}
 }

--- a/src/view/items/element/Decorator.js
+++ b/src/view/items/element/Decorator.js
@@ -94,6 +94,8 @@ export default class Decorator {
 	update () {
 		if ( !this.dirty ) return;
 
+		this.dirty = false;
+
 		let nameChanged = false;
 
 		if ( this.dynamicName && this.nameFragment.dirty ) {
@@ -130,7 +132,5 @@ export default class Decorator {
 		if ( this.dynamicArgs && this.argsFragment.dirty ) {
 			this.argsFragment.update();
 		}
-
-		this.dirty = false;
 	}
 }

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -240,12 +240,12 @@ export default class EventDirective {
 	}
 
 	update () {
-		if ( this.method ) return; // nothing to do
+		if ( this.method || !this.dirty ) return; // nothing to do
+
+		this.dirty = false;
 
 		// ugh legacy
 		if ( this.action.update ) this.action.update();
 		if ( this.template.d ) this.args.update();
-
-		this.dirty = false;
 	}
 }


### PR DESCRIPTION
This is a really funky one... basically, the binding causes a bubble while inside update. Since the fragment is still dirty during the update, the bubble doesn't pass the updating fragment. Then the update completes and marks the fragment as clean, but it now has dirty children that won't get registered until something causes them to bubble again.

Making the dirty flag get reset at the beginning of the update fixes that, but it also breaks some assumptions about how things flow in the runloop. So, this takes the existing process, which allows new fragments to be registered _after_ the fragments are processed, and lets new fragments (or the same ones) be registered _during_ the processing. That messes up assumptions about how observers will fire, so the same thing is done with them.

There have been a couple of issues pop up related to fragments and observers and bindings messing with each other that had terribly complex scenarios that couldn't be reduced. I think this would probably solve them without the need to get extra-crazy like #2284, but I can't really try it because I couldn't reproduce it.

This fixes #2406, but I'm not positive it's the best way to do so. Thoughts?

If this is good, I'll try to cook up a slightly simpler test to stave off regressions in the future.