### PR TITLE
Keep primary model in sync with reference expression children - #2408 - Review

### DIFF
--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -1030,3 +1030,32 @@ test( 'textareas with non-model context should still bind correctly (#2099)', t 
 	r.find( 'button' ).click();
 	t.equal( r.find( 'textarea' ).value, 'baz' );
 });
+
+test( 'binding to an reference proxy does not cause out-of-syncitude with the actual model', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: '<span>{{foo.bar.baz}}</span>{{#with foo[what]}}<input value="{{.baz}}" />{{/with}}',
+		data: {
+			foo: {
+				bar: { baz: 'yep' },
+				bat: { baz: 'also yep' }
+			},
+			what: 'bar'
+		}
+	});
+
+	const span = r.find( 'span' );
+	const input = r.find( 'input' );
+
+	t.equal( span.innerHTML, 'yep' );
+
+	input.value = 'hey';
+	fire( input, 'change' );
+	t.equal( span.innerHTML, 'hey' );
+
+	r.set( 'foo.bar.baz', 'yep again' );
+	t.equal( input.value, 'yep again' );
+
+	r.set( 'what', 'bat' );
+	t.equal( input.value, 'also yep' );
+});


### PR DESCRIPTION
This is another slightly funky one. Basically, binding to a child of a reference expression creates a branch off the reference expression proxy that doesn't notify its source when it changes. This adds a special `ReferenceExpressionChild` model that finds its source model during `applyValue` and calls `applyValue` on it too.

Thoughts? I couldn't come up with a better way™, but that certainly doesn't mean that there isn't one. 