### PR TITLE
using removeChild(firstChild) instead of innerHTML = ""

### DIFF
--- a/src/Ractive/prototype/render.js
+++ b/src/Ractive/prototype/render.js
@@ -14,7 +14,7 @@ export default function Ractive$render ( target, anchor ) {
 
 		// make sure we are the only occupants
 		if ( !this.enhance ) {
-	      	//removeChild() is faster than innerHTML = ''
+			//removeChild() is faster than innerHTML = ''
 			//test1: http://jsperf.com/innerhtml-vs-removechild/15
 			//test2: https://jsperf.com/innerhtml-vs-removechild/96
 			while ( target.firstChild ) {

--- a/src/Ractive/prototype/render.js
+++ b/src/Ractive/prototype/render.js
@@ -14,8 +14,14 @@ export default function Ractive$render ( target, anchor ) {
 
 		// make sure we are the only occupants
 		if ( !this.enhance ) {
-			target.innerHTML = ''; // TODO is this quicker than removeChild? Initial research inconclusive
-		}
+	      //removeChild() is faster than innerHTML = ''
+		//test1: http://jsperf.com/innerhtml-vs-removechild/15
+		//test2: https://jsperf.com/innerhtml-vs-removechild/96
+                 while ( target.firstChild ) {
+                    target.removeChild ( target.firstChild );
+                 }
+                 target.textContent = '';
+            }
 	}
 
 	let occupants = this.enhance ? toArray( target.childNodes ) : null;

--- a/src/Ractive/prototype/render.js
+++ b/src/Ractive/prototype/render.js
@@ -14,14 +14,8 @@ export default function Ractive$render ( target, anchor ) {
 
 		// make sure we are the only occupants
 		if ( !this.enhance ) {
-	      //removeChild() is faster than innerHTML = ''
-		//test1: http://jsperf.com/innerhtml-vs-removechild/15
-		//test2: https://jsperf.com/innerhtml-vs-removechild/96
-                 while ( target.firstChild ) {
-                    target.removeChild ( target.firstChild );
-                 }
-                 target.textContent = '';
-            }
+			target.innerHTML = ''; // TODO is this quicker than removeChild? Initial research inconclusive
+		}
 	}
 
 	let occupants = this.enhance ? toArray( target.childNodes ) : null;

--- a/src/Ractive/prototype/render.js
+++ b/src/Ractive/prototype/render.js
@@ -14,14 +14,14 @@ export default function Ractive$render ( target, anchor ) {
 
 		// make sure we are the only occupants
 		if ( !this.enhance ) {
-	      //removeChild() is faster than innerHTML = ''
-		//test1: http://jsperf.com/innerhtml-vs-removechild/15
-		//test2: https://jsperf.com/innerhtml-vs-removechild/96
-                 while ( target.firstChild ) {
-                    target.removeChild ( target.firstChild );
-                 }
-                 target.textContent = '';
-            }
+	      	//removeChild() is faster than innerHTML = ''
+			//test1: http://jsperf.com/innerhtml-vs-removechild/15
+			//test2: https://jsperf.com/innerhtml-vs-removechild/96
+			while ( target.firstChild ) {
+				target.removeChild ( target.firstChild );
+			}
+			target.textContent = '';
+		}
 	}
 
 	let occupants = this.enhance ? toArray( target.childNodes ) : null;


### PR DESCRIPTION
According to several tests innerHTML is not only slower than removeChild but also less performant than innerText: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent

I don't know how helpful my pull request is but the tests seem to be unambiguous.

http://jsperf.com/innerhtml-vs-removechild/15
https://jsperf.com/innerhtml-vs-removechild/96

Maybe there's a better explanation on how to properly use innerHTML/removeChild?

I hope the sources are properly formatted now. I had to revert the patch because of Tabs requirements from guidelines. Sorry.