### PR TITLE
Make sure pattern observers only fire changed paths - #2420 - RFC/Review

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -243,7 +243,6 @@ class PatternObserver {
 			runloop.addObserver( this, this.defer );
 
 			if ( this.once ) this.cancel();
-
 		}
 	}
 }

--- a/src/Ractive/prototype/toggle.js
+++ b/src/Ractive/prototype/toggle.js
@@ -1,21 +1,20 @@
 import { badArguments } from '../../config/errors';
 import { splitKeypath } from '../../shared/keypaths';
+import runloop from '../../global/runloop';
 
 export default function Ractive$toggle ( keypath ) {
 	if ( typeof keypath !== 'string' ) {
 		throw new TypeError( badArguments );
 	}
 
-	let changes;
-
 	if ( /\*/.test( keypath ) ) {
-		changes = {};
+		runloop.start();
 
 		this.viewmodel.findMatches( splitKeypath( keypath ) ).forEach( model => {
-			changes[ model.getKeypath() ] = !model.get();
+			model.set( !model.get() );
 		});
 
-		return this.set( changes );
+		return runloop.end();
 	}
 
 	return this.set( keypath, !this.get( keypath ) );

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -8,6 +8,7 @@ import { isArray, isObject } from '../utils/is';
 import KeyModel from './specials/KeyModel';
 import KeypathModel from './specials/KeypathModel';
 import { escapeKey, unescapeKey } from '../shared/keypaths';
+import runloop from '../global/runloop';
 
 const hasProp = Object.prototype.hasOwnProperty;
 
@@ -18,8 +19,6 @@ function updateFromBindings ( model ) {
 function updateKeypathDependants ( model ) {
 	model.updateKeypathDependants();
 }
-
-let originatingModel = null;
 
 export default class Model {
 	constructor ( parent, key ) {
@@ -120,8 +119,7 @@ export default class Model {
 	applyValue ( value ) {
 		if ( isEqual( value, this.value ) ) return;
 
-		// TODO deprecate this nonsense
-		this.root.changes[ this.getKeypath() ] = value;
+		runloop.addModel( this );
 
 		if ( this.parent.wrapper && this.parent.wrapper.set ) {
 			this.parent.wrapper.set( this.key, value );
@@ -151,10 +149,12 @@ export default class Model {
 		this.parent.clearUnresolveds();
 		this.clearUnresolveds();
 
-		// notify dependants
-		const previousOriginatingModel = originatingModel; // for the array.length special case
-		originatingModel = this;
+		// if this is an observed path, expand children
+		if ( this.isWatched ) {
+			this.checkChildren();
+		}
 
+		// notify dependants
 		let i = this.children.length;
 		while ( i-- ) this.children[i].mark();
 		i = this.deps.length;
@@ -166,8 +166,36 @@ export default class Model {
 			while ( i-- ) parent.deps[i].handleChange( parent, this );
 			parent = parent.parent;
 		}
+	}
 
-		originatingModel = previousOriginatingModel;
+	checkChildren ( unsafe, instance ) {
+		const result = [];
+
+		if ( isArray( this.value ) ) {
+			let i = this.value.length;
+			while ( i-- ) {
+				if ( !( i in this.childByKey ) ) {
+					this.joinKey( i );
+				}
+				result.unshift( this.childByKey[i] );
+			}
+
+		}
+
+		else if ( isObject( this.value ) || typeof this.value === 'function' ) {
+			const keys = Object.keys( this.value );
+			let i = keys.length;
+			while ( i-- ) {
+				if ( !( keys[i] in this.childByKey ) ) this.joinKey( keys[i] );
+				result.unshift( this.childByKey[keys[i]] );
+			}
+		}
+
+		else if ( this.value != null && unsafe ) {
+			throw new Error( `Cannot get values of ${this.getKeypath(instance)}.* as ${this.getKeypath(instance)} is not an array, object or function` );
+		}
+
+		return result;
 	}
 
 	clearUnresolveds ( specificKey ) {
@@ -201,7 +229,7 @@ export default class Model {
 		return branch;
 	}
 
-	findMatches ( keys ) {
+	findMatches ( keys, instance ) {
 		const len = keys.length;
 
 		let existingMatches = [ this ];
@@ -214,7 +242,8 @@ export default class Model {
 			if ( key === '*' ) {
 				matches = [];
 				existingMatches.forEach( model => {
-					matches.push.apply( matches, model.getValueChildren( model.get() ) );
+					matches.push.apply( matches, model.checkChildren( true, instance ) );
+					//matches.push.apply( matches, model.getValueChildren( model.get() ) );
 				});
 			} else {
 				matches = existingMatches.map( model => model.joinKey( key ) );
@@ -281,34 +310,6 @@ export default class Model {
 		return root;
 	}
 
-	getValueChildren ( value ) {
-
-		let children;
-		if ( isArray( value ) ) {
-			children = [];
-			// special case - array.length. This is a horrible kludge, but
-			// it'll do for now. Alternatives welcome
-			if ( originatingModel && originatingModel.parent === this && originatingModel.key === 'length' ) {
-				children.push( originatingModel );
-			}
-			value.forEach( ( m, i ) => {
-				children.push( this.joinKey( i ) );
-			});
-
-		}
-
-		else if ( isObject( value ) || typeof value === 'function' ) {
-			children = Object.keys( value ).map( key => this.joinKey( key ) );
-		}
-
-		else if ( value != null ) {
-			// TODO: this will return incorrect keypath if model is mapped
-			throw new Error( `Cannot get values of ${this.getKeypath()}.* as ${this.getKeypath()} is not an array, object or function` );
-		}
-
-		return children;
-	}
-
 	has ( key ) {
 		const value = this.get();
 		if ( !value ) return false;
@@ -326,6 +327,18 @@ export default class Model {
 		return false;
 	}
 
+	isWatched () {
+		if ( this.watchers ) return true;
+
+		let parent = this.parent;
+
+		while ( parent ) {
+			if ( parent.watchers ) return true;
+
+			parent = parent.parent;
+		}
+	}
+
 	joinKey ( key ) {
 		if ( key === undefined || key === '' ) return this;
 
@@ -333,6 +346,7 @@ export default class Model {
 			const child = new Model( this, key );
 			this.children.push( child );
 			this.childByKey[ key ] = child;
+			runloop.addModel( child );
 		}
 
 		return this.childByKey[ key ];
@@ -352,6 +366,12 @@ export default class Model {
 
 		if ( !isEqual( value, this.value ) ) {
 			this.value = value;
+
+			runloop.addModel( this );
+			// if this has a pattern observer upstream somewhere, laod all of the things
+			if ( this.isWatched() ) {
+				this.checkChildren();
+			}
 
 			let i = this.children.length;
 			while ( i-- ) this.children[i].mark();
@@ -471,6 +491,10 @@ export default class Model {
 		removeFromArray( this.bindings, binding );
 	}
 
+	unwatch () {
+		if ( this.watchers ) this.watchers--;
+	}
+
 	updateFromBindings ( cascade ) {
 		let i = this.bindings.length;
 		while ( i-- ) {
@@ -486,5 +510,10 @@ export default class Model {
 	updateKeypathDependants () {
 		this.children.forEach( updateKeypathDependants );
 		if ( this.keypathModel ) this.keypathModel.handleChange( this.keypathModel );
+	}
+
+	watch () {
+		if ( !this.watchers ) this.watchers = 1;
+		else this.watchers++;
 	}
 }

--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -13,9 +13,6 @@ export default class RootModel extends Model {
 	constructor ( options ) {
 		super( null, null );
 
-		// TODO deprecate this
-		this.changes = {};
-
 		this.isRoot = true;
 		this.root = this;
 		this.ractive = options.ractive; // TODO sever this link
@@ -35,6 +32,16 @@ export default class RootModel extends Model {
 		this.flush();
 
 		return this._changeHash;
+	}
+
+	checkChildren ( unsafe, instance ) {
+		const children = super.checkChildren( unsafe, instance );
+
+		this.extendChildren( ( key, model ) => {
+			children.push( model );
+		});
+
+		return children;
 	}
 
 	compute ( key, signature ) {
@@ -77,16 +84,6 @@ export default class RootModel extends Model {
 
 	getRactiveModel() {
 		return this.ractiveModel || ( this.ractiveModel = new RactiveModel( this.ractive ) );
-	}
-
-	getValueChildren () {
-		const children = super.getValueChildren( this.value );
-
-		this.extendChildren( ( key, model ) => {
-			children.push( model );
-		});
-
-		return children;
 	}
 
 	handleChange () {

--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -145,12 +145,16 @@ function updateValue () {
 }
 
 function updateStringValue () {
-	const value = this.getValue();
+	let value = this.getValue();
 
 	this.node._ractive.value = value;
 
-	this.node.value = safeToStringValue( value );
-	this.node.setAttribute( 'value', safeToStringValue( value ) );
+	value = safeToStringValue( value );
+
+	if ( this.node.value !== value ) {
+		this.node.value = value;
+		this.node.setAttribute( 'value', value );
+	}
 }
 
 function updateRadioName () {

--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -153,6 +153,9 @@ function updateStringValue () {
 
 	if ( this.node.value !== value ) {
 		this.node.value = value;
+	}
+
+	if ( this.node.getAttribute( 'value' ) !== value ) {
 		this.node.setAttribute( 'value', value );
 	}
 }

--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -90,22 +90,20 @@ function updateMultipleSelectValue () {
 function updateSelectValue () {
 	const value = this.getValue();
 
-	if ( !this.locked ) { // TODO is locked still a thing?
-		this.node._ractive.value = value;
+	this.node._ractive.value = value;
 
-		const options = this.node.options;
-		let i = options.length;
+	const options = this.node.options;
+	let i = options.length;
 
-		while ( i-- ) {
-			const option = options[i];
-			const optionValue = option._ractive ?
-				option._ractive.value :
-				option.value; // options inserted via a triple don't have _ractive
+	while ( i-- ) {
+		const option = options[i];
+		const optionValue = option._ractive ?
+			option._ractive.value :
+			option.value; // options inserted via a triple don't have _ractive
 
-			if ( optionValue == value ) { // double equals as we may be comparing numbers with strings
-				option.selected = true;
-				break;
-			}
+		if ( optionValue == value ) { // double equals as we may be comparing numbers with strings
+			option.selected = true;
+			break;
 		}
 	}
 
@@ -117,9 +115,7 @@ function updateSelectValue () {
 function updateContentEditableValue () {
 	const value = this.getValue();
 
-	if ( !this.locked ) {
-		this.node.innerHTML = value === undefined ? '' : value;
-	}
+	this.node.innerHTML = value === undefined ? '' : value;
 }
 
 function updateRadioValue () {
@@ -142,23 +138,19 @@ function updateRadioValue () {
 }
 
 function updateValue () {
-	if ( !this.locked ) {
-		const value = this.getValue();
+	const value = this.getValue();
 
-		this.node.value = this.node._ractive.value = value;
-		this.node.setAttribute( 'value', value );
-	}
+	this.node.value = this.node._ractive.value = value;
+	this.node.setAttribute( 'value', value );
 }
 
 function updateStringValue () {
-	if ( !this.locked ) {
-		const value = this.getValue();
+	const value = this.getValue();
 
-		this.node._ractive.value = value;
+	this.node._ractive.value = value;
 
-		this.node.value = safeToStringValue( value );
-		this.node.setAttribute( 'value', safeToStringValue( value ) );
-	}
+	this.node.value = safeToStringValue( value );
+	this.node.setAttribute( 'value', safeToStringValue( value ) );
 }
 
 function updateRadioName () {
@@ -195,17 +187,13 @@ function updateClassName () {
 }
 
 function updateBoolean () {
-	// with two-way binding, only update if the change wasn't initiated by the user
-	// otherwise the cursor will often be sent to the wrong place
-	if ( !this.locked ) {
-		if ( this.useProperty ) {
-			this.node[ this.propertyName ] = this.getValue();
+	if ( this.useProperty ) {
+		this.node[ this.propertyName ] = this.getValue();
+	} else {
+		if ( this.getValue() ) {
+			this.node.setAttribute( this.propertyName, '' );
 		} else {
-			if ( this.getValue() ) {
-				this.node.setAttribute( this.propertyName, '' );
-			} else {
-				this.node.removeAttribute( this.propertyName );
-			}
+			this.node.removeAttribute( this.propertyName );
 		}
 	}
 }

--- a/src/view/items/element/binding/Binding.js
+++ b/src/view/items/element/binding/Binding.js
@@ -72,9 +72,7 @@ export default class Binding {
 
 	handleChange () {
 		runloop.start( this.root );
-		this.attribute.locked = true;
 		this.model.set( this.getValue() );
-		runloop.scheduleTask( () => this.attribute.locked = false );
 		runloop.end();
 	}
 

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -963,7 +963,25 @@ test( 'Pattern observer expects * to only apply to arrays and objects (#1923)', 
 			t.ok( false, 'observer should not fire' );
 		});
 	}, /Cannot get values of msg\.\* as msg is not an array, object or function/ );
-})
+});
+
+test( 'pattern observers only observe changed values (#2420)', t => {
+	t.expect( 3 );
+
+	const r = new Ractive({
+		data: {
+			list: [ { foo: 1 }, { foo: 2 } ]
+		}
+	});
+
+	r.observe( 'list.*', ( n, o, k ) => {
+		t.equal( k, 'list.1' );
+		t.deepEqual( o, { foo: 2 } );
+		t.deepEqual( n, { foo: 'yep' } );
+	}, { init: false });
+
+	r.set( 'list.1', { foo: 'yep' } );
+});
 
 test( 'wildcard * fires on new property', t => {
 	t.expect( 2 );

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -429,7 +429,7 @@ test( 'Post-blur validation works (#771)', t => {
 	input.value = 'bar';
 	fire( input, 'change' );
 
-	t.equal( input.value, 'bar' );
+	t.equal( input.value, 'BAR' );
 	t.equal( ractive.get( 'foo' ), 'BAR' );
 	t.htmlEqual( fixture.innerHTML, '<input>BAR' );
 


### PR DESCRIPTION
As @martypdx pointed out in #2420, pattern observers aren't currently checking to make sure a path actually changed before firing. Instead they were just going off an equality test, which is fine for primitives and strict equality, but less so for objects that are never considered equal.

I initially tried to use the viewmodel changes registry to test the keypaths coming into handleChange, but that wasn't playing out as well as I had hoped. Setting an object at a keypath where one of the keys in the set object would match a pattern is trickier to deal with. I kinda think it would cause issues with components too. It still might be the better approach, but I went a different direction with this...

Instead of looking up and getting new values for every matching key when the base model notifies of a change somewhere, this registers an object with the matching target models that handles the new value op of the observer. The base model is still checked for new keys. I'm not positive this covers all of the weird little corner cases that observers have to deal with.

I was thinking that maybe a capture/bubble cycle for `set`s of object values may be a good way to handle pattern observers and the change event. That would also allow deeply nested observers e.g. `foo.bar.**.stuff.*` which would probably help out people trying to watch a keypath for change tracking purposes.

Any thoughts?