### PR TITLE
Keep update from running in nested runloops for repeats and sections - #2424

### DIFF
--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -305,9 +305,11 @@ export default class Fragment {
 	}
 
 	update () {
-		if ( this.dirty ) {
+		if ( this.dirty && !this.updating ) {
 			this.dirty = false;
+			this.updating = true;
 			this.items.forEach( update );
+			this.updating = false;
 		}
 	}
 

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -228,6 +228,9 @@ export default class RepeatedFragment {
 			return;
 		}
 
+		if ( this.updating ) return;
+		this.updating = true;
+
 		const value = this.context.get(),
 			  wasArray = this.isArray;
 
@@ -320,6 +323,8 @@ export default class RepeatedFragment {
 				parentNode.insertBefore( docFrag, anchor );
 			}
 		}
+
+		this.updating = false;
 	}
 
 	updatePostShuffle () {

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -109,8 +109,10 @@ export default class Section extends Mustache {
 
 	update () {
 		if ( !this.dirty ) return;
+		if ( this.updating ) return;
 		if ( !this.model && this.sectionType !== SECTION_UNLESS ) return;
 
+		this.updating = true;
 		this.dirty = false;
 
 		const value = !this.model ? undefined : this.model.isRoot ? this.model.value : this.model.get();
@@ -212,5 +214,7 @@ export default class Section extends Mustache {
 
 			this.fragment = newFragment;
 		}
+
+		this.updating = false;
 	}
 }

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -109,10 +109,8 @@ export default class Section extends Mustache {
 
 	update () {
 		if ( !this.dirty ) return;
-		if ( this.updating ) return;
 		if ( !this.model && this.sectionType !== SECTION_UNLESS ) return;
 
-		this.updating = true;
 		this.dirty = false;
 
 		const value = !this.model ? undefined : this.model.isRoot ? this.model.value : this.model.get();
@@ -214,7 +212,5 @@ export default class Section extends Mustache {
 
 			this.fragment = newFragment;
 		}
-
-		this.updating = false;
 	}
 }

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -1059,3 +1059,27 @@ test( 'binding to an reference proxy does not cause out-of-syncitude with the ac
 	r.set( 'what', 'bat' );
 	t.equal( input.value, 'also yep' );
 });
+
+test( `binding a select with mismatched option values shouldn't break section rendering (#2424)`, t => {
+	const cmp = Ractive.extend({ template: `<div>{{yield}}</div>` });
+	const r = new Ractive({
+		el: fixture,
+		components: { cmp },
+		template: `{{#if .condition}}<span>Once</span>
+			{{#each .foo}}<cmp><select value="{{.bar}}">
+				<option></option>
+				<option>a</option>
+				<option>b</option>
+				<option>c</option>
+			</select></cmp>{{/each}}
+		{{/if}}`
+	});
+
+	r.set({
+		condition: true,
+		foo: [{ bar: 'd' }, { bar: 'e' }, { bar: 'f' }]
+	});
+
+	t.equal( fixture.querySelectorAll( 'span' ).length, 1 );
+	t.equal( fixture.querySelectorAll( 'div' ).length, 3 );
+});


### PR DESCRIPTION
This fixes #2424 and maybe a few others... __not ready - no tests__

In #2407, the dirty flag got bumped around such that happenings during an update that should cause a bubble actually caused a bubble. That was also keeping an update from running during an update, which apparently causes all sorts of bizarre behavior. This adds a `updating` flag to RepeatedFragment and Section to keep them from getting out of whack whilst updating content with bindings that cause further updates. I have to ponder this a bit more, but should all items have an update guard, or just fragments, or just what I have here?