### PR TITLE
Check attribute values while shuffling to see if an update is in order - #2422 - RFC

### DIFF
--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -78,15 +78,7 @@ export default class Attribute extends Item {
 	}
 
 	rebind () {
-		const current = this.getValue();
-
-		this.unbind();
-		this.bind();
-
-		// the value may have actually changed if it depends on a template context (@index, etc)
-		if ( this.getValue() !== current ) {
-			this.bubble();
-		}
+		if (this.fragment) this.fragment.rebind();
 	}
 
 	render () {

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -78,8 +78,15 @@ export default class Attribute extends Item {
 	}
 
 	rebind () {
+		const current = this.getValue();
+
 		this.unbind();
 		this.bind();
+
+		// the value may have actually changed if it depends on a template context (@index, etc)
+		if ( this.getValue() !== current ) {
+			this.bubble();
+		}
 	}
 
 	render () {

--- a/test/browser-tests/shuffling.js
+++ b/test/browser-tests/shuffling.js
@@ -228,6 +228,25 @@ test( 'shuffled sections that unrender at the same time should not leave orphans
 	t.htmlEqual( fixture.innerHTML, '' );
 });
 
+test( `shuffled elements with attributes depending on template context (@index, etc) should have appropriately updated attributes (#2422)`, t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#each foo}}<span data-wat="{{50 * @index}}">{{50 * @index}}</span>{{/each}}`,
+		data: { foo: [ 0, 0, 0 ] }
+	});
+
+	r.push( 'foo', 0 );
+
+	let spans = r.findAll( 'span' );
+
+	for ( let i = 0; i < spans.length; i++ ) t.equal( spans[i].getAttribute( 'data-wat' ), spans[i].innerHTML );
+
+	r.splice( 'foo', 2, 1 );
+	r.splice( 'foo', 1, 0, 0 );
+
+	for ( let i = 0; i < spans.length; i++ ) t.equal( spans[i].getAttribute( 'data-wat' ), spans[i].innerHTML );
+});
+
 // TODO reinstate this in some form. Commented out for purposes of #1740
 // test( `Array shuffling only adjusts context and doesn't tear stuff down to rebuild it`, t => {
 // 	let ractive = new Ractive({


### PR DESCRIPTION
The test case from #2422 involves rebinding an attribute value that depends on an `@index` ref, but since attributes aren't sensitive to the change (they just wholesale unbind and bind), they never get notified of a change during the shuffle. This adds a step that grabs the value at the start of rebinding and checks it against the value after rebinding. If the value is not strict equal, it bubbles.

An alternate fix would be simply: `rebind() { if ( this.fragment ) this.fragment.rebind(); }`. It seems to work, but for some reason it didn't feel right (I think stepping through too much code may be throwing me). I'm not wild about calling `getValue` twice on every attribute shuffle, so if there's no reason not to do that, it would probably be better.

Thoughts?

