### PR TITLE
Skip deferred sync of select value - #2428 - RFC

### DIFF
--- a/src/view/items/element/specials/Select.js
+++ b/src/view/items/element/specials/Select.js
@@ -1,5 +1,4 @@
 import Element from '../../Element';
-import runloop from '../../../../global/runloop';
 import { toArray } from '../../../../utils/array';
 
 function valueContains ( selectValue, optionValue ) {

--- a/src/view/items/element/specials/Select.js
+++ b/src/view/items/element/specials/Select.js
@@ -18,14 +18,6 @@ export default class Select extends Element {
 	bubble () {
 		if ( !this.dirty ) {
 			this.dirty = true;
-
-			if ( this.rendered ) {
-				runloop.scheduleTask( () => {
-					this.sync();
-					this.dirty = false;
-				});
-			}
-
 			this.parentFragment.bubble(); // default behaviour
 		}
 	}

--- a/src/view/items/element/specials/Select.js
+++ b/src/view/items/element/specials/Select.js
@@ -15,13 +15,6 @@ export default class Select extends Element {
 		this.options = [];
 	}
 
-	bubble () {
-		if ( !this.dirty ) {
-			this.dirty = true;
-			this.parentFragment.bubble(); // default behaviour
-		}
-	}
-
 	render ( target, occupants ) {
 		super.render( target, occupants );
 		this.sync();

--- a/test/browser-tests/select.js
+++ b/test/browser-tests/select.js
@@ -505,3 +505,21 @@ test( 'safe to render options into select outside of ractive', t => {
 
 	t.htmlEqual( select.innerHTML, '<option>a</option>' );
 });
+
+test( `select options fragment should update correctly (#2428)`, t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `
+			<select multiple>{{#each .list}}{{#if .selected}}<option value="{{@index}}">{{.name}}</option>{{/if}}{{/each}}</select>
+			{{#each .list}}<input type="checkbox" checked="{{.selected}}" />{{/each}}
+		`,
+		data: {}
+	});
+	r.set( 'list', [ { value: 'a', selected: true }, { value: 'b', selected: false }, { value: 'c' } ] );
+
+	t.equal( r.findAll( 'option' ).length, 1 );
+
+	r.set( 'list.2.selected', true );
+
+	t.equal( r.findAll( 'option' ).length, 2 );
+});


### PR DESCRIPTION
It seems that with the runloop stuff that's happened recently, it has become unnecessary and detrimental to do a deferred sync of the value in a select element after a bubble. It looks like the combo of only using dirty flags for cleanliness and letting the runloop detect runloop triggered changes took care of the original case that made that necessary. Does that sound right?

With this patch, the options fragments in the example in #2428 are updated correctly.