### PR TITLE
Keep complex bindings in sync - #2444

### DIFF
--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -137,6 +137,7 @@ export default class Component extends Item {
 						// this is a *bit* of a hack
 						fragment.bubble = () => {
 							Fragment.prototype.bubble.call( fragment );
+							fragment.update();
 							model.set( fragment.valueOf() );
 						};
 

--- a/src/view/items/shared/Item.js
+++ b/src/view/items/shared/Item.js
@@ -36,4 +36,8 @@ export default class Item {
 	findNextNode () {
 		return this.parentFragment.findNextNode( this );
 	}
+
+	valueOf () {
+		return this.toString();
+	}
 }

--- a/test/browser-tests/components/data-and-mappings.js
+++ b/test/browser-tests/components/data-and-mappings.js
@@ -1,5 +1,4 @@
 import { test } from 'qunit';
-import { fire } from 'simulant';
 import Model from 'helpers/Model';
 
 test( 'Static data is propagated from parent to child', t => {
@@ -1178,4 +1177,19 @@ test( 'complex mappings continue to update with their dependencies', t => {
 	r.set( 'bar', 'yes' );
 	t.equal( c.get( 'bar' ), 'yes' );
 	t.htmlEqual( fixture.innerHTML, 'foo? yes' );
+});
+
+test( `complex mappings work with a single section (#2444)`, t => {
+	const cmp = Ractive.extend({
+		template: '{{foo}}'
+	});
+	const r = new Ractive({
+		el: fixture,
+		template: '<cmp foo="{{#if thing}}{{thing}} is yep{{/if}}" />',
+		components: { cmp },
+		data: { thing: '' }
+	});
+
+	r.set( 'thing', 'hey' );
+	t.htmlEqual( fixture.innerHTML, 'hey is yep' );
 });


### PR DESCRIPTION
#2444 seems to be caused by two little issues:

1. complex mappings override bubble on their fragment to intercept change calls, but they don't also force the fragment to update before using its value to set the model. This adds an update in the bubble just before the model set to handle that.
2. the default valueOf for view items is the item itself, which is useless for this particular scenario. interpolators will, rightly, return whatever their _actual_ underlying value is, so this sets up a default valueOf function that stringifies the item. I'm pretty sure that's what you'd want for any mustache other than an interpolator.