### PR TITLE
Resolve unresolveds up the context hierarchy when update is called - #2141

### DIFF
--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -5,12 +5,25 @@ import { splitKeypath } from '../../shared/keypaths';
 const updateHook = new Hook( 'update' );
 
 export default function Ractive$update ( keypath ) {
+	if ( keypath ) keypath = splitKeypath( keypath );
+
 	const model = keypath ?
-		this.viewmodel.joinAll( splitKeypath( keypath ) ) :
+		this.viewmodel.joinAll( keypath ) :
 		this.viewmodel;
 
 	const promise = runloop.start( this, true );
+
 	model.mark();
+
+	if ( keypath ) {
+		// there may be unresolved refs that are now resolvable up the context tree
+		let parent = model.parent;
+		while ( keypath.length && parent ) {
+			if ( parent.clearUnresolveds ) parent.clearUnresolveds( keypath.pop() );
+			parent = parent.parent;
+		}
+	}
+
 	runloop.end();
 
 	updateHook.fire( this, model );

--- a/test/browser-tests/methods/update.js
+++ b/test/browser-tests/methods/update.js
@@ -1,0 +1,15 @@
+import { test } from 'qunit';
+
+test( 'resolves any unresolved references from parent contexts (#2141)', t => {
+	const foo = {};
+	const r = new Ractive({
+		el: fixture,
+		template: `{{#foo}}{{#bar.baz}}{{#bat}}yep{{/}}{{/}}{{/}}`,
+		data: { foo }
+	});
+
+	foo.bar = { baz: { bat: true } };
+	r.update( 'foo.bar.baz.bat' );
+
+	t.htmlEqual( fixture.innerHTML, 'yep' );
+});


### PR DESCRIPTION
Was going to put this in `mark`, but it seems like the best way to catch this case is to do it at exactly where the user requests updates to be processed.