### PR TITLE
Fix #1856

### DIFF
--- a/src/parse/converters/mustache/handlebarsBlockCodes.js
+++ b/src/parse/converters/mustache/handlebarsBlockCodes.js
@@ -1,9 +1,8 @@
-import { SECTION_EACH, SECTION_IF, SECTION_IF_WITH, SECTION_WITH, SECTION_UNLESS } from '../../../config/types';
+import { SECTION_EACH, SECTION_IF, SECTION_IF_WITH, SECTION_UNLESS } from '../../../config/types';
 
 export default {
 	'each':    SECTION_EACH,
 	'if':      SECTION_IF,
-	'if-with': SECTION_IF_WITH,
-	'with':    SECTION_WITH,
+	'with':    SECTION_IF_WITH,
 	'unless':  SECTION_UNLESS
 };

--- a/src/parse/converters/mustache/readSection.js
+++ b/src/parse/converters/mustache/readSection.js
@@ -1,4 +1,4 @@
-import { ALIAS, SECTION, SECTION_IF, SECTION_UNLESS, SECTION_WITH, SECTION_IF_WITH, PREFIX_OPERATOR, INFIX_OPERATOR, BRACKETED } from '../../../config/types';
+import { ALIAS, SECTION, SECTION_IF, SECTION_UNLESS, PREFIX_OPERATOR, INFIX_OPERATOR, BRACKETED } from '../../../config/types';
 import { READERS } from '../../_parse';
 import readClosing from './section/readClosing';
 import readElse from './section/readElse';
@@ -153,14 +153,6 @@ export default function readSection ( parser, tag ) {
 	} while ( !closed );
 
 	if ( unlessBlock ) {
-		// special case - `with` should become `if-with` (TODO is this right?
-		// seems to me that `with` ought to behave consistently, regardless
-		// of the presence/absence of `else`. In other words should always
-		// be `if-with`
-		if ( section.n === SECTION_WITH ) {
-			section.n = SECTION_IF_WITH;
-		}
-
 		section.l = unlessBlock;
 	}
 

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -141,7 +141,7 @@ export default class Section extends Mustache {
 			}
 		}
 
-		// TODO same comment as before - WITH should be IF_WITH
+		// WITH is now IF_WITH; WITH is only used for {{>partial context}}
 		else if ( this.sectionType === SECTION_WITH ) {
 			if ( this.fragment ) {
 				this.fragment.update();

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -1317,8 +1317,18 @@ const renderTests = [
 		name: 'integers can be aliased (#2397)',
 		template: '{{#with 1 as num, 42 as answer}}{{num}} {{answer}}{{/with}}',
 		result: '1 42'
+	},
+	{
+		name: '{{#with obj}} doesn\'t render if obj is empty',
+		template: '{{#with obj}}foo{{/with}}',
+		data: { obj: {} },
+		result: ''
+	},
+	{
+		name: '{{#with obj}} doesn\'t render if obj is false/null/undefined',
+		template: '{{#with obj}}foo{{/with}}',
+		result: ''
 	}
-
 ];
 
 function max() { return Math.max.apply(Math, Array.prototype.slice.call(arguments, 0)); }

--- a/test/browser-tests/components/data-and-mappings.js
+++ b/test/browser-tests/components/data-and-mappings.js
@@ -1152,7 +1152,7 @@ test( 'root references inside a component should resolve to the component', t =>
 		template: '<cmp foo="{{baz.bat}}" />',
 		components: { cmp },
 		data: {
-			baz: { bat: 'nope' }
+			baz: { bat: { bar: 1 } }
 		}
 	});
 

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -577,7 +577,7 @@ test( 'Data is synced as soon as an unresolved mapping is resolved', t => {
 		el: fixture,
 		template: '<Outer/>',
 		data: {
-			item: {}
+			item: { x: 1 }
 		},
 		components: {
 			Outer: Ractive.extend({
@@ -903,7 +903,7 @@ test( 'component @keypath references should be relative to the component', t => 
 
 test( 'nested component @keypath references should be relative to the nested component', t => {
 	const cmp1 = Ractive.extend({
-		template: '{{#with foo.bar}}{{@keypath}}{{/with}} {{#with baz.notbat}}{{@keypath}}{{/with}}'
+		template: '{{#with foo.bar}}{{@keypath}}{{/with}}'
 	}),
 	cmp2 = Ractive.extend({
 		template: '{{#with baz.bat}}<cmp1 foo="{{.}}" />{{/with}}',
@@ -919,7 +919,7 @@ test( 'nested component @keypath references should be relative to the nested com
 		components: { cmp2 }
 	});
 
-	t.htmlEqual( fixture.innerHTML, 'foo.bar baz.notbat' );
+	t.htmlEqual( fixture.innerHTML, 'foo.bar' );
 });
 
 test( 'component @rootpath references should be relative to the root', t => {

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -711,7 +711,7 @@ test( 'ExpressionProxy should notify its deps when it resolves (#2214)', t => {
 		el: fixture,
 		template: '-{{#with foo}}{{#if bar[0] && bar[0] === bar[1]}}ok{{/if}}{{/with}}',
 		data: {
-			foo: {}
+			foo: { x: 1 }
 		}
 	});
 

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -477,7 +477,7 @@ test( 'Ambiguous reference expressions in two-way bindings attach to correct con
 			{{/with}}`,
 		data: {
 			bar: 0,
-			obj: {}
+			obj: { x: 1 }
 		}
 	});
 
@@ -732,7 +732,7 @@ if ( hasUsableConsole ) {
 			el: fixture,
 			template: `{{#with whatever}}<input value='{{uniqueToThisTest}}'>{{/with}}`,
 			data: {
-				whatever: {}
+				whatever: { x: 1 }
 			}
 		});
 	});


### PR DESCRIPTION
Doesn't change behavior of `{{>partial context}}`, as I think partial should render even if `context` is undefined. Thoughts?