### PR TITLE
Dot escape 3

### DIFF
--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -12,7 +12,7 @@ import construct from './Ractive/construct';
 import initialise from './Ractive/initialise';
 import { getCSS } from './global/css';
 import { escapeKey, unescapeKey } from './shared/keypaths';
-import { joinKeypath, splitKeypath } from './Ractive/static/keypaths';
+import { joinKeys, splitKeypath } from './Ractive/static/keypaths';
 
 // Ractive.js makes liberal use of things like Array.prototype.indexOf. In
 // older browsers, these are made available via a shim - here, we do a quick
@@ -57,7 +57,7 @@ defineProperties( Ractive, {
 	extend:         { value: extend },
 	escapeKey:      { value: escapeKey },
 	getNodeInfo:    { value: getNodeInfo },
-	joinKeypath:    { value: joinKeypath },
+	joinKeys:       { value: joinKeys },
 	parse:          { value: parse },
 	splitKeypath:   { value: splitKeypath },
 	unescapeKey:    { value: unescapeKey },

--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -12,6 +12,7 @@ import construct from './Ractive/construct';
 import initialise from './Ractive/initialise';
 import { getCSS } from './global/css';
 import { escapeKey, unescapeKey } from './shared/keypaths';
+import { joinKeypath, splitKeypath } from './Ractive/static/keypaths';
 
 // Ractive.js makes liberal use of things like Array.prototype.indexOf. In
 // older browsers, these are made available via a shim - here, we do a quick
@@ -56,7 +57,9 @@ defineProperties( Ractive, {
 	extend:         { value: extend },
 	escapeKey:      { value: escapeKey },
 	getNodeInfo:    { value: getNodeInfo },
+	joinKeypath:    { value: joinKeypath },
 	parse:          { value: parse },
+	splitKeypath:   { value: splitKeypath },
 	unescapeKey:    { value: unescapeKey },
 	getCSS:         { value: getCSS },
 

--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -11,6 +11,7 @@ import getNodeInfo from './Ractive/static/getNodeInfo';
 import construct from './Ractive/construct';
 import initialise from './Ractive/initialise';
 import { getCSS } from './global/css';
+import { escapeKey, unescapeKey } from './shared/keypaths';
 
 // Ractive.js makes liberal use of things like Array.prototype.indexOf. In
 // older browsers, these are made available via a shim - here, we do a quick
@@ -53,8 +54,10 @@ defineProperties( Ractive, {
 
 	// static methods:
 	extend:         { value: extend },
+	escapeKey:      { value: escapeKey },
 	getNodeInfo:    { value: getNodeInfo },
 	parse:          { value: parse },
+	unescapeKey:    { value: unescapeKey },
 	getCSS:         { value: getCSS },
 
 	// namespaced constructors

--- a/src/Ractive/static/keypaths.js
+++ b/src/Ractive/static/keypaths.js
@@ -1,6 +1,6 @@
 import { escapeKey, splitKeypath as splitKeypathI, unescapeKey } from '../../shared/keypaths';
 
-export function joinKeypath ( ...keys ) {
+export function joinKeys ( ...keys ) {
 	return keys.map( escapeKey ).join( '.' );
 }
 

--- a/src/Ractive/static/keypaths.js
+++ b/src/Ractive/static/keypaths.js
@@ -1,0 +1,9 @@
+import { escapeKey, splitKeypath as splitKeypathI, unescapeKey } from '../../shared/keypaths';
+
+export function joinKeypath ( ...keys ) {
+	return keys.map( escapeKey ).join( '.' );
+}
+
+export function splitKeypath ( keypath ) {
+	return splitKeypathI( keypath ).map( unescapeKey );
+}

--- a/src/model/specials/KeyModel.js
+++ b/src/model/specials/KeyModel.js
@@ -1,5 +1,6 @@
 import { removeFromArray } from '../../utils/array';
 import { handleChange } from '../../shared/methodCallers';
+import { unescapeKey } from '../../shared/keypaths';
 
 export default class KeyModel {
 	constructor ( key ) {
@@ -9,11 +10,11 @@ export default class KeyModel {
 	}
 
 	get () {
-		return this.value;
+		return unescapeKey( this.value );
 	}
 
 	getKeypath () {
-		return this.value;
+		return unescapeKey( this.value );
 	}
 
 	rebind ( key ) {

--- a/src/shared/keypaths.js
+++ b/src/shared/keypaths.js
@@ -16,12 +16,18 @@ export function normalise ( ref ) {
 }
 
 export function splitKeypath ( keypath ) {
-	let parts = normalise( keypath ).split( splitPattern ),
-		result = [];
+	let result = [],
+		match;
 
-	for ( let i = 0; i < parts.length; i += 2 ) {
-		result.push( parts[i] + ( parts[i + 1] || '' ) );
+	keypath = normalise( keypath );
+
+	while ( match = splitPattern.exec( keypath ) ) {
+		let index = match.index + match[1].length;
+		result.push( keypath.substr( 0, index ) );
+		keypath = keypath.substr( index + 1 );
 	}
+
+	result.push(keypath);
 
 	return result;
 }

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -1328,6 +1328,12 @@ const renderTests = [
 		name: '{{#with obj}} doesn\'t render if obj is false/null/undefined',
 		template: '{{#with obj}}foo{{/with}}',
 		result: ''
+	},
+	{
+		name: '{{@key}} references aren\'t escaped',
+		template: '{{#each obj}}{{@key}}{{/each}}',
+		data: { obj: { 'foo.bar': 1 } },
+		result: 'foo.bar'
 	}
 ];
 

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -1621,6 +1621,16 @@ test( 'ractive.unescapeKey() works correctly', t => {
 	t.equal( Ractive.unescapeKey( 'foo\\\\\\.bar' ), 'foo\\.bar' );
 });
 
+test( 'ractive.joinKeypath() works correctly', t => {
+	t.equal( Ractive.joinKeypath( 'foo', 'bar.baz' ), 'foo.bar\\.baz' );
+	t.equal( Ractive.joinKeypath( 'foo', 'bar\\.baz' ), 'foo.bar\\\\\\.baz' );
+});
+
+test( 'ractive.splitKeypath() works correctly', t => {
+	t.deepEqual( Ractive.splitKeypath( 'foo.bar\\.baz' ), [ 'foo', 'bar.baz' ] );
+	t.deepEqual( Ractive.splitKeypath( 'foo.bar\\\\\\.baz' ), [ 'foo', 'bar\\.baz' ] );
+});
+
 // Is there a way to artificially create a FileList? Leaving this commented
 // out until someone smarter than me figures out how
 // test( '{{#each}} iterates over a FileList (#1220)', t => {

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -1611,6 +1611,16 @@ test( 'shuffled elements have the correct keypath in their node info', t => {
 	t.equal( Ractive.getNodeInfo( r.findAll( 'span' )[2] ).keypath, 'list.2' );
 });
 
+test( 'ractive.escapeKey() works correctly', t => {
+	t.equal( Ractive.escapeKey( 'foo.bar' ), 'foo\\.bar' );
+	t.equal( Ractive.escapeKey( 'foo\\.bar' ), 'foo\\\\\\.bar' );
+});
+
+test( 'ractive.unescapeKey() works correctly', t => {
+	t.equal( Ractive.unescapeKey( 'foo\\.bar' ), 'foo.bar' );
+	t.equal( Ractive.unescapeKey( 'foo\\\\\\.bar' ), 'foo\\.bar' );
+});
+
 // Is there a way to artificially create a FileList? Leaving this commented
 // out until someone smarter than me figures out how
 // test( '{{#each}} iterates over a FileList (#1220)', t => {

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -1621,9 +1621,9 @@ test( 'ractive.unescapeKey() works correctly', t => {
 	t.equal( Ractive.unescapeKey( 'foo\\\\\\.bar' ), 'foo\\.bar' );
 });
 
-test( 'ractive.joinKeypath() works correctly', t => {
-	t.equal( Ractive.joinKeypath( 'foo', 'bar.baz' ), 'foo.bar\\.baz' );
-	t.equal( Ractive.joinKeypath( 'foo', 'bar\\.baz' ), 'foo.bar\\\\\\.baz' );
+test( 'ractive.joinKeys() works correctly', t => {
+	t.equal( Ractive.joinKeys( 'foo', 'bar.baz' ), 'foo.bar\\.baz' );
+	t.equal( Ractive.joinKeys( 'foo', 'bar\\.baz' ), 'foo.bar\\\\\\.baz' );
 });
 
 test( 'ractive.splitKeypath() works correctly', t => {


### PR DESCRIPTION
Fixes `{{@key}}` references for escaped keypaths (#1967), and adds four public methods:

```js
Ractive.escapeKey( 'foo.bar' ); // => foo\.bar
Ractive.unescapeKey( 'foo\\.bar' ); // => foo.bar
Ractive.joinKeys( 'foo', 'bar.baz' ); // => foo.bar\.baz
Ractive.splitKeypath( 'foo.bar\\.baz' ); // => [ 'foo', 'bar.baz' ]
```