### PR TITLE
Notify parent deps on update too - #2469

### DIFF
--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -24,6 +24,14 @@ export default function Ractive$update ( keypath ) {
 		}
 	}
 
+	// notify upstream
+	let parent = model.parent;
+	while ( parent ) {
+		let i = parent.deps.length;
+		while ( i-- ) parent.deps[i].handleChange();
+		parent = parent.parent;
+	}
+
 	runloop.end();
 
 	updateHook.fire( this, model );

--- a/test/browser-tests/components/data-and-mappings.js
+++ b/test/browser-tests/components/data-and-mappings.js
@@ -1118,6 +1118,30 @@ test( 'components should update their mappings on rebind to prevent weirdness wi
 	t.htmlEqual( ractive.find( '#s3' ).innerHTML, '12' );
 });
 
+test( 'updates to children of mappings update correctly in the parent (#2469)', t => {
+	const cmp = Ractive.extend({
+		template: '{{#each foo.baz}}{{@key}}{{/each}}'
+	});
+
+	const r = new Ractive({
+		el: fixture,
+		template: `<cmp foo="{{bar}}" />-`,
+		data: {
+			bar: { baz: { a: 1, b: 2 } }
+		},
+		components: { cmp }
+	});
+
+	t.equal( fixture.innerHTML, 'ab-' );
+
+	const c = r.findComponent( 'cmp' );
+
+	delete c.get( 'foo' ).baz.a;
+	c.update( 'foo.baz.a' );
+
+	t.equal( fixture.innerHTML, 'b-' );
+});
+
 test( 'Interpolators based on computed mappings update correctly #2261)', t => {
 	const Component = Ractive.extend({
 		template: `{{active ? "active" : "inactive"}}`


### PR DESCRIPTION
This is a weird case wherein `update`ing a child keypath doesn't flag a section iterating the parent as dirty across a component boundary and perhaps also not across the boundary in certain circumstances. `applyValue` dirties upstream deps, so it seems reasonable that `update` should also mark upstream deps, does it not?

Linking #2469