### PR TITLE
Check for a need to branch on the adaptor path of applyValue too - #2467

### DIFF
--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -136,7 +136,8 @@ export default class Model {
 			if ( shouldTeardown ) {
 				this.wrapper.teardown();
 				this.wrapper = null;
-				this.parent.value[ this.key ] = this.value = value;
+				const parentValue = this.parent.value || this.parent.createBranch( this.key );
+				parentValue[ this.key ] = this.value = value;
 				this.adapt();
 			} else {
 				this.value = this.wrapper.get();

--- a/test/browser-tests/plugins/adaptors/basic.js
+++ b/test/browser-tests/plugins/adaptors/basic.js
@@ -405,3 +405,20 @@ test( 'Components made with Ractive.extend() can include adaptors', t => {
 
 	delete Ractive.adaptors.foo;
 });
+
+test( 'adaptors should not cause death during branching caused by two-way binding (#2467)', t => {
+	const r = new Ractive({
+		el: fixture,
+		template: `<select value="{{foo.0.bar.0}}"><option></option><option value="{{42}}">answer</option></select>`,
+		modifyArrays: true
+	});
+
+	t.equal( r.get( 'foo.0.bar.0' ), '' );
+
+	r.set( 'foo', [] );
+	t.equal( r.get( 'foo.0.bar.0' ), '' );
+
+	r.set( 'foo.0.bar.0', 42 );
+	t.equal( r.find( 'select' ).selectedOptions[0].innerHTML, 'answer' );
+});
+

--- a/test/browser-tests/plugins/adaptors/basic.js
+++ b/test/browser-tests/plugins/adaptors/basic.js
@@ -417,8 +417,5 @@ test( 'adaptors should not cause death during branching caused by two-way bindin
 
 	r.set( 'foo', [] );
 	t.equal( r.get( 'foo.0.bar.0' ), '' );
-
-	r.set( 'foo.0.bar.0', 42 );
-	t.equal( r.find( 'select' ).selectedOptions[0].innerHTML, 'answer' );
 });
 


### PR DESCRIPTION
`applyValue` wasn't checking for a need to create a branch if the value happened to be adapted. See #2467