### PR TITLE
Reduce memory use with this one simple trick! - #2477

### DIFF
--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -157,4 +157,13 @@ export default class Computation extends Model {
 
 		this.dependencies = dependencies;
 	}
+
+	teardown () {
+		let i = this.dependencies.length;
+		while ( i-- ) {
+			if ( this.dependencies[i] ) this.dependencies[i].unregister( this );
+		}
+		if ( this.root.computations[this.key] === this ) delete this.root.computations[this.key];
+		super.teardown();
+	}
 }

--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -152,6 +152,16 @@ export default class RootModel extends Model {
 		return this.value;
 	}
 
+	teardown () {
+		const keys = Object.keys( this.mappings );
+		let i = keys.length;
+		while ( i-- ){
+			if ( this.mappings[ keys[i] ] ) this.mappings[ keys[i] ].unregister( this );
+		}
+
+		super.teardown();
+	}
+
 	update () {
 		// noop
 	}

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -114,7 +114,27 @@ export default class ExpressionProxy extends Model {
 		return this.get();
 	}
 
+	teardown () {
+		this.unbind();
+		this.fragment = undefined;
+		if ( this.computation ) {
+			this.computation.teardown();
+		}
+		this.computation = undefined;
+		super.teardown();
+	}
+
+	unregister( dep ) {
+		super.unregister( dep );
+		if ( !this.deps.length ) this.teardown();
+	}
+
 	unbind () {
 		this.resolvers.forEach( unbind );
+
+		let i = this.models.length;
+		while ( i-- ) {
+			if ( this.models[i] ) this.models[i].unregister( this );
+		}
 	}
 }


### PR DESCRIPTION
It looks like this fixes #2477, and may fix part of #2461. The timeline view is a little wonky with what it shows based on when a gc happens, but I've done heap profiling and that is saying that this no longer has a gazillion detached nodes still hanging around.

1. Component mappings are not un-mapped when the component is torn down, which lets the component and all its related gubbins stick around in memory. This adds a teardown, which overlaps with the one in #2462, that handles unregistering mappings so that the components don't hang around. I haven't looked to hard, but it looks like maybe breaking the mapping link will also let the computations get gc'ed when the component is torn down too.

2. ExpressionProxies get a reference to their fragment, create their own Computation (always!), and don't ever unregister. This adds a check on the `unregister` of ExpressionProxy to see if there are any surviving deps, and if there are none, it is torn down. The teardown drops the ref to the fragment and also triggers a teardown on the Computation. That cleans up some of the extra computation stuff that would get overwritten on the next appearance of that signature anyways, and it lets the DOM owned by the fragment go as well.

Thoughts?