### PR TITLE
Build perf

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-	"presets": [ "es2015-rollup" ],
-	"compact": false
-}

--- a/gobblefile.js
+++ b/gobblefile.js
@@ -4,14 +4,24 @@ var gobble = require( 'gobble' );
 var sander = require( 'sander' );
 var junk = require( 'junk' );
 var Promise = sander.Promise;
-var path = require( 'path' );
 var rollup = require( 'rollup' );
+var legacyBabelOptions = {
+	presets: [ 'es2015-native-modules' ],
+	plugins: [
+		"transform-es3-property-literals",
+		[ "transform-es2015-classes", { loose: true } ]
+	]
+};
 var babel = require( 'rollup-plugin-babel' )({
+	compact: false,
+	presets: [ "es2015-rollup" ],
 	plugins: [
 		[ "transform-es2015-classes", { loose: true } ]
 	]
 });
 var legacyBabel = require( 'rollup-plugin-babel' )({
+	compact: false,
+	presets: [ "es2015-rollup" ],
 	plugins: [
 		"transform-es3-property-literals",
 		[ "transform-es2015-classes", { loose: true } ]
@@ -91,8 +101,8 @@ if ( gobble.env() === 'production' ) {
 	]);
 } else {
 	lib = gobble([
-		es5.transform( 'rollup', {
-			plugins: [ adjustAndSkip(), legacyBabel ],
+		es5.transform( 'babel', legacyBabelOptions ).transform( 'rollup', {
+			plugins: [ adjustAndSkip() ],
 			format: 'umd',
 			entry: 'Ractive.js',
 			moduleName: 'Ractive',
@@ -143,8 +153,8 @@ test = (function () {
 	var testModules = gobble([
 		gobble([ browserTests, gobble( 'test/__support/js' ).moveTo( 'browser-tests' ) ]),
 		es5
-	]).transform( 'rollup', {
-			plugins: [ adjustAndSkip(), legacyBabel ],
+	]).transform( 'babel', legacyBabelOptions ).transform( 'rollup', {
+			plugins: [ adjustAndSkip() ],
 			format: 'umd',
 			entry: 'browser-tests/all.js',
 			moduleName: 'tests',

--- a/gobblefile.js
+++ b/gobblefile.js
@@ -72,7 +72,7 @@ if ( gobble.env() === 'production' ) {
 		}),
 
 		src.transform( 'rollup', {
-			plugins: [ adjustAndSkip( /legacy\,js|_parse\.js/ ), babel ],
+			plugins: [ adjustAndSkip( /legacy\.js|_parse\.js/ ), babel ],
 			format: 'umd',
 			banner: banner,
 			entry: 'Ractive.js',

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "uglify-js": "^2.6.2",
 
     "babel-preset-es2015-rollup": "^1",
+    "babel-preset-es2015-native-modules": "^6",
     "babel-plugin-transform-es3-property-literals": "^6",
     "babel-plugin-transform-es2015-classes": "^6"
   },

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "cheerio": "^0.20.0",
     "eslint": "^1.3.1",
     "gobble": "^0.10.1",
+    "gobble-babel": "^6.0.0",
     "gobble-cli": "^0.6.0",
     "gobble-replace": "^0.3.1",
     "gobble-rollup": "^0.25.0",


### PR DESCRIPTION
**Description of the pull request:**
Using `rollup-plugin-babel` means we can't take advantage of gobble's great caching, and all files are processed by babel every time. By using babel directly (for tests and dev Ractive build), the rebuild time is reduced dramatically.

**Fixes the following issues:**
Cuts down rebuild time to ~3s.

**Is breaking:**
No.