### PR TITLE
render {{#obj}} section only if obj is truthy

### DIFF
--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -13,7 +13,7 @@ function isEmpty ( value ) {
 
 function getType ( value, hasIndexRef ) {
 	if ( hasIndexRef || isArray( value ) ) return SECTION_EACH;
-	if ( isObject( value ) || typeof value === 'function' ) return SECTION_WITH;
+	if ( isObject( value ) || typeof value === 'function' ) return SECTION_IF_WITH;
 	if ( value === undefined ) return null;
 	return SECTION_IF;
 }

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -1334,7 +1334,19 @@ const renderTests = [
 		template: '{{#each obj}}{{@key}}{{/each}}',
 		data: { obj: { 'foo.bar': 1 } },
 		result: 'foo.bar'
-	}
+	},
+	{
+		name: '{{#obj}} doesn\'t render if obj is empty',
+		template: '{{#obj}}foo{{/obj}}',
+		data: { obj: {} },
+		result: ''
+	},
+	{
+		name: '{{#obj}} renders if obj is truthy',
+		template: '{{#obj}}foo{{/obj}}',
+		data: { obj: { x: 1 } },
+		result: 'foo'
+	},
 ];
 
 function max() { return Math.max.apply(Math, Array.prototype.slice.call(arguments, 0)); }

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -67,7 +67,7 @@ export default function() {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#foo}}<Widget visible="{{visible}}"/>{{/foo}}',
-			data: { foo: {}, visible: true },
+			data: { foo: { x: true }, visible: true },
 			components: {
 				Widget: Ractive.extend({
 					template: '{{#visible}}<p>{{test}}</p>{{/visible}}'

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -946,7 +946,7 @@ export default function() {
 			data: {
 				currentStep: 0,
 				stepsQuantity: 2,
-				steps: [{}, {}],
+				steps: [{ x: true }, { x: true }],
 				bool: true
 			}
 		});
@@ -1364,7 +1364,7 @@ export default function() {
 			},
 			data: {
 				bars: [1, 2],
-				baz: { bat: {} }
+				baz: { bat: { x: true } }
 			}
 		});
 

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -695,7 +695,7 @@ export default function() {
 					<div>{{foo}}: {{#foo}}true{{else}}false{{/}}</div>
 				{{/}}`,
 			data: {
-				context: {}
+				context: { x: true }
 			}
 		});
 


### PR DESCRIPTION
**Description of the pull request:**
Updates `{{#obj}}` to match the new `{{#with obj}}` behavior - only render if `obj` is truthy.

**Fixes the following issues:**
#2024

**Is breaking:**
Yes.