### PR TITLE
Let array methods branch too - RFC

### DIFF
--- a/src/Ractive/prototype/shared/makeArrayMethod.js
+++ b/src/Ractive/prototype/shared/makeArrayMethod.js
@@ -8,10 +8,16 @@ const arrayProto = Array.prototype;
 export default function ( methodName ) {
 	return function ( keypath, ...args ) {
 		const model = this.viewmodel.joinAll( splitKeypath( keypath ) );
-		const array = model.get();
+		let array = model.get();
 
 		if ( !isArray( array ) ) {
-			throw new Error( `shuffle array method ${methodName} called on non-array at ${model.getKeypath()}` );
+			if ( array === undefined ) {
+				array = [];
+				const result = arrayProto[ methodName ].apply( array, args );
+				return this.set( keypath, array ).then( () => result );
+			} else {
+				throw new Error( `shuffle array method ${methodName} called on non-array at ${model.getKeypath()}` );
+			}
 		}
 
 		const newIndices = getNewIndices( array.length, methodName, args );

--- a/test/browser-tests/methods/push.js
+++ b/test/browser-tests/methods/push.js
@@ -56,6 +56,20 @@ export default function() {
 		});
 	});
 
+	test( 'grow an array if pushing to an undefined keypath', t => {
+		const done = t.async();
+
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each items}}{{.}}{{/each}}`,
+		});
+
+		const result = r.push( 'items', 1 );
+		t.htmlEqual( fixture.innerHTML, '1' );
+
+		result.then( res => t.equal( res, 1 ) ).then( done, done );
+	});
+
 	test( 'Interpolators that directly reference arrays are updated on array mutation (#1074)', t => {
 		const ractive = new Ractive({
 			el: fixture,

--- a/test/browser-tests/shuffling.js
+++ b/test/browser-tests/shuffling.js
@@ -59,7 +59,9 @@ export default function() {
 	});
 
 	test( 'an appropriate error is thrown when shuffling a non-array keypath', t => {
-		const r = new Ractive({});
+		const r = new Ractive({
+			data: { foo: null }
+		});
 
 		t.throws( () => {
 			r.push('foo', 1);


### PR DESCRIPTION
**Description of the pull request:**
Ractive will currently branch for you if you `set` an undefined keypath e.g. `r.set( 'foo.0.bar', 'test' )` with an entirely empty data dictionary results in data that looks like `{ foo: [ { bar: 'test' } ] }`. However, if you `push`, `splice`, `unshift`, etc on an undefined keypath, an error is thrown.

This adds a check for `undefined` keypaths and swaps in an empty array instead of throwing an error. This allows regular array methods to be used without having to initialize every keypath that may be used with an array method.

**Fixes the following issues:**
Makes array methods a little more method-call event friendly.

**Is breaking:**
Sort of, but I doubt anyone depends on an exception being thrown when using array methods on undefined keypaths.