### PR TITLE
Don't force the first option to be selected in a select with no matching value - #2494

### DIFF
--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -104,13 +104,12 @@ function updateSelectValue () {
 
 			if ( optionValue == value ) { // double equals as we may be comparing numbers with strings
 				option.selected = true;
-				break;
+				return;
 			}
 		}
-	}
 
-	// if we're still here, it means the new value didn't match any of the options...
-	// TODO figure out what to do in this situation
+		this.node.selectedIndex = -1;
+	}
 }
 
 

--- a/src/view/items/element/specials/Option.js
+++ b/src/view/items/element/specials/Option.js
@@ -16,7 +16,7 @@ export default class Option extends Element {
 
 		// If the value attribute is missing, use the element's content,
 		// as long as it isn't disabled
-		if ( template.a.value === undefined && !( 'disabled' in template ) ) {
+		if ( template.a.value === undefined && !( 'disabled' in template.a ) ) {
 			template.a.value = template.f || '';
 		}
 

--- a/src/view/items/element/specials/Select.js
+++ b/src/view/items/element/specials/Select.js
@@ -76,10 +76,6 @@ export default class Select extends Element {
 			});
 
 			if ( !optionWasSelected && !isMultiple ) {
-				if ( options[0] ) {
-					options[0].selected = true;
-				}
-
 				if ( this.binding ) {
 					this.binding.forceUpdate();
 				}

--- a/test/browser-tests/plugins/adaptors/basic.js
+++ b/test/browser-tests/plugins/adaptors/basic.js
@@ -420,6 +420,6 @@ export default function() {
 		t.equal( r.get( 'foo.0.bar.0' ), '' );
 
 		r.set( 'foo', [] );
-		t.equal( r.get( 'foo.0.bar.0' ), '' );
+		t.equal( r.get( 'foo.0.bar.0' ), undefined );
 	});
 }

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -831,13 +831,20 @@ export default function() {
 	test( 'select with no matching value option selects none (#2494)', t => {
 		const r = new Ractive({
 			el: fixture,
-			template: '<select value="{{foo}}"><option>1</option><option>2</option></select>'
+			template: '<select value="{{foo}}">{{#if opt1}}<option>1</option>{{/if}}<option>2</option></select>',
+			data: { opt1: true }
 		});
 
 		t.equal( r.get( 'foo' ), '1' );
 
 		r.set( 'foo', 'nerp' );
 		t.equal( r.find( 'select' ).selectedIndex, -1 );
+
+		r.set( 'foo', '1' );
+		t.equal( r.find( 'select' ).selectedIndex, 0 );
+
+		r.toggle( 'opt1' );
+		t.equal( r.find( 'select' ).selectedIndex, 0 );
 	});
 
 	test( 'type attribute does not have to be first (#1968)', t => {

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -828,6 +828,18 @@ export default function() {
 		}
 	});
 
+	test( 'select with no matching value option selects none (#2494)', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: '<select value="{{foo}}"><option>1</option><option>2</option></select>'
+		});
+
+		t.equal( r.get( 'foo' ), '1' );
+
+		r.set( 'foo', 'nerp' );
+		t.equal( r.find( 'select' ).selectedIndex, -1 );
+	});
+
 	test( 'type attribute does not have to be first (#1968)', t => {
 		const ractive = new Ractive({
 			el: fixture,


### PR DESCRIPTION
**Description of the pull request:**
Removes the forced selection of the first option for bound selects that don't have an option with a matching value.

**Fixes the following issues:**
#2494

**Is breaking:**
No