### PR TITLE
Delete references to observers after calling .cancel() (closes #2499)

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -1,7 +1,7 @@
 import runloop from '../../global/runloop';
 import { isArray, isEqual, isObject } from '../../utils/is';
+import { removeFromArray } from '../../utils/array';
 import { splitKeypath } from '../../shared/keypaths';
-import { cancel } from '../../shared/methodCallers';
 import resolveReference from '../../view/resolvers/resolveReference';
 
 export default function observe ( keypath, callback, options ) {
@@ -43,13 +43,8 @@ export default function observe ( keypath, callback, options ) {
 
 	return {
 		cancel: () => {
-			observers.forEach( (observer) => {
-				let index = this._observers.indexOf( observer );
-
-				if ( index !== -1 ) {
-					this._observers.splice( index , 1 );
-				}
-
+			observers.forEach( ( observer ) => {
+				removeFromArray ( this._observers, observer );
 				observer.cancel();
 			} );
 		}

--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -42,8 +42,16 @@ export default function observe ( keypath, callback, options ) {
 	this._observers.push.apply( this._observers, observers );
 
 	return {
-		cancel () {
-			observers.forEach( cancel );
+		cancel: () => {
+			observers.forEach( (observer) => {
+				let index = this._observers.indexOf( observer );
+
+				if ( index !== -1 ) {
+					this._observers.splice( index , 1 );
+				}
+
+				observer.cancel();
+			} );
 		}
 	};
 }

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -981,4 +981,20 @@ export default function() {
 
 		ractive.set( 'foo', 'bar' );
 	});
+
+	test( 'References to observers are not retained after cancel()', t => {
+		const ractive = new Ractive({ data: { counter: 0 } });
+		const obs = ractive.observe( 'counter', ( newValue, oldValue ) => {
+			if ( oldValue ) {
+				return obs.cancel();
+			}
+		});
+
+		t.equal( ractive._observers.length, 1 );
+
+		ractive.add( 'counter' );
+		obs.cancel();
+
+		t.equal( ractive._observers.length, 0 );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
Delete references to observers after calling `.cancel()`.

**Fixes the following issues:**
#2499 

**Is breaking:**
No.