### PR TITLE
Only fire pattern observers for changed keypaths - #2420

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -238,7 +238,8 @@ class PatternObserver {
 
 				this.baseModel.findMatches( this.keys ).forEach( model => {
 					const keypath = model.getKeypath( this.ractive );
-					if ( ok.find( k => keypath.indexOf( k ) === 0 ) ) {
+					// is this model on a changed keypath?
+					if ( ok.filter( k => keypath.indexOf( k ) === 0 ).length ) {
 						this.newValues[ keypath ] = model.get();
 					}
 				});

--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -24,15 +24,8 @@ export default function Ractive$update ( keypath ) {
 		}
 	}
 
-	// notify upstream
-	let parent = model.parent, prev = model;
-	while ( parent ) {
-		if ( parent.patternObservers.length ) parent.patternObservers.forEach( o => o.notify( prev.key ) );
-		let i = parent.deps.length;
-		while ( i-- ) parent.deps[i].handleChange();
-		prev = parent;
-		parent = parent.parent;
-	}
+	// notify upstream of changes
+	model.notifyUpstream();
 
 	runloop.end();
 

--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -14,6 +14,7 @@ export default function Ractive$update ( keypath ) {
 	const promise = runloop.start( this, true );
 
 	model.mark();
+	model.registerChange( model.getKeypath(), model.retrieve() );
 
 	if ( keypath ) {
 		// there may be unresolved refs that are now resolvable up the context tree

--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -25,10 +25,12 @@ export default function Ractive$update ( keypath ) {
 	}
 
 	// notify upstream
-	let parent = model.parent;
+	let parent = model.parent, prev = model;
 	while ( parent ) {
+		if ( parent.patternObservers.length ) parent.patternObservers.forEach( o => o.notify( prev.key ) );
 		let i = parent.deps.length;
 		while ( i-- ) parent.deps[i].handleChange();
+		prev = parent;
 		parent = parent.parent;
 	}
 

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -9,6 +9,7 @@ import { isArray, isObject } from '../utils/is';
 import KeyModel from './specials/KeyModel';
 import KeypathModel from './specials/KeypathModel';
 import { escapeKey, unescapeKey } from '../shared/keypaths';
+import runloop from '../global/runloop';
 
 const hasProp = Object.prototype.hasOwnProperty;
 
@@ -129,7 +130,7 @@ export default class Model {
 		if ( isEqual( value, this.value ) ) return;
 
 		// TODO deprecate this nonsense
-		this.root.changes[ this.getKeypath() ] = value;
+		this.registerChange( this.getKeypath(), value );
 
 		if ( this.parent.wrapper && this.parent.wrapper.set ) {
 			this.parent.wrapper.set( this.key, value );
@@ -414,6 +415,15 @@ export default class Model {
 
 	register ( dep ) {
 		this.deps.push( dep );
+	}
+
+	registerChange ( key, value ) {
+		if ( !this.isRoot ) {
+			this.root.registerChange( key, value );
+		} else {
+			this.changes[ key ] = value;
+			runloop.addInstance( this.root.ractive );
+		}
 	}
 
 	registerPatternObserver ( observer ) {

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -35,6 +35,7 @@ export default class Model {
 		this.unresolvedByKey = {};
 
 		this.bindings = [];
+		this.patternObservers = [];
 
 		this.value = undefined;
 
@@ -166,9 +167,11 @@ export default class Model {
 		this.children.forEach( mark );
 		this.deps.forEach( handleChange );
 
-		let parent = this.parent;
+		let parent = this.parent, prev = this;
 		while ( parent ) {
+			if ( parent.patternObservers.length ) parent.patternObservers.forEach( o => o.notify( prev.key ) );
 			parent.deps.forEach( handleChange );
+			prev = parent;
 			parent = parent.parent;
 		}
 
@@ -411,6 +414,11 @@ export default class Model {
 		this.deps.push( dep );
 	}
 
+	registerPatternObserver ( observer ) {
+		this.patternObservers.push( observer );
+		this.register( observer );
+	}
+
 	registerTwowayBinding ( binding ) {
 		this.bindings.push( binding );
 	}
@@ -469,6 +477,11 @@ export default class Model {
 
 	unregister ( dependant ) {
 		removeFromArray( this.deps, dependant );
+	}
+
+	unregisterPatternObserver ( observer ) {
+		removeFromArray( this.patternObservers, observer );
+		this.unregister( observer );
 	}
 
 	unregisterTwowayBinding ( binding ) {

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -167,13 +167,7 @@ export default class Model {
 		this.children.forEach( mark );
 		this.deps.forEach( handleChange );
 
-		let parent = this.parent, prev = this;
-		while ( parent ) {
-			if ( parent.patternObservers.length ) parent.patternObservers.forEach( o => o.notify( prev.key ) );
-			parent.deps.forEach( handleChange );
-			prev = parent;
-			parent = parent.parent;
-		}
+		this.notifyUpstream();
 
 		originatingModel = previousOriginatingModel;
 	}
@@ -406,6 +400,16 @@ export default class Model {
 		this.parent.value[ this.key ] = array;
 		this._merged = true;
 		this.shuffle( newIndices );
+	}
+
+	notifyUpstream () {
+		let parent = this.parent, prev = this;
+		while ( parent ) {
+			if ( parent.patternObservers.length ) parent.patternObservers.forEach( o => o.notify( prev.key ) );
+			parent.deps.forEach( handleChange );
+			prev = parent;
+			parent = parent.parent;
+		}
 	}
 
 	register ( dep ) {

--- a/src/model/specials/GlobalModel.js
+++ b/src/model/specials/GlobalModel.js
@@ -8,12 +8,14 @@ class GlobalModel extends Model {
 		this.isRoot = true;
 		this.root = this;
 		this.adaptors = [];
-		this.changes = {};
 	}
 
 	getKeypath() {
 		return '@global';
 	}
+
+	// global model doesn't contribute changes events because it has no instance
+	registerChange () {}
 }
 
 export default new GlobalModel();

--- a/test/browser-tests/init/hooks/misc.js
+++ b/test/browser-tests/init/hooks/misc.js
@@ -94,6 +94,34 @@ export default function() {
 		ractive.set( 'bool', true );
 	});
 
+	test( 'change hook fires even if no fragments changed (#2090)', t => {
+		t.expect( 8 );
+
+		let count = 1, next = false;
+		const r = new Ractive({
+			data: { foo: 1 }
+		});
+
+		r.on( 'change', delta => {
+			t.equal( Object.keys(delta).length, 1 );
+
+			if ( !next ) t.equal( delta.foo, count );
+			else t.equal( delta.bar, 'yep' );
+		});
+
+		count++;
+		r.set( 'foo', count );
+
+		count = 42;
+		r.set( 'foo', count );
+
+		next = true;
+		r.set( 'bar', 'yep' );
+
+		r.get().bar = 'hmm';
+		r.update( 'bar' );
+	});
+
 	test( 'correct behaviour of deprecated beforeInit hook (#1395)', t => {
 		t.expect( 6 );
 

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -967,7 +967,25 @@ export default function() {
 				t.ok( false, 'observer should not fire' );
 			});
 		}, /Cannot get values of msg\.\* as msg is not an array, object or function/ );
-	})
+	});
+
+	test( 'pattern observers only observe changed values (#2420)', t => {
+		t.expect( 3 );
+
+		const r = new Ractive({
+			data: {
+				list: [ { foo: 1 }, { foo: 2 } ]
+			}
+		});
+
+		r.observe( 'list.*', ( n, o, k ) => {
+			t.equal( k, 'list.1' );
+			t.deepEqual( o, { foo: 2 } );
+			t.deepEqual( n, { foo: 'yep' } );
+		}, { init: false });
+
+		r.set( 'list.1', { foo: 'yep' } );
+	});
 
 	test( 'wildcard * fires on new property', t => {
 		t.expect( 2 );

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -468,12 +468,12 @@ export default function() {
 			data: { foo: { bar: { baz: 1 } } }
 		});
 
-		ractive.observe( 'foo.*', function ( n, o, keypath ) {
-			t.ok( this === window )
+		ractive.observe( 'foo.*', function () {
+			t.ok( this === window );
 		}, { context: window });
 
-		ractive.observe( 'foo', function ( n, o, keypath ) {
-			t.ok( this === window )
+		ractive.observe( 'foo', function () {
+			t.ok( this === window );
 		}, { context: window });
 
 		ractive.set( 'foo.bar.baz', 2 );
@@ -985,6 +985,24 @@ export default function() {
 		}, { init: false });
 
 		r.set( 'list.1', { foo: 'yep' } );
+	});
+
+	test( 'pattern observers only observe changed values on update', t => {
+		t.expect( 2 );
+
+		const r = new Ractive({
+			data: {
+				list: [ { foo: 1 }, { foo: 2 } ]
+			}
+		});
+
+		r.observe( 'list.*', ( n, o, k ) => {
+			t.equal( k, 'list.1' );
+			t.deepEqual( n, { foo: 'yep' } );
+		}, { init: false });
+
+		r.get( 'list.1' ).foo = 'yep';
+		r.update( 'list.1.foo' );
 	});
 
 	test( 'wildcard * fires on new property', t => {


### PR DESCRIPTION
**Description of the pull request:**
This adds a list of pattern observers to `Model`, which is notified when a child is `update`d or `set`. `PatternObserver` then checks to see if a child keypath triggered the change and:

* if there were no keys/children registered, the change happened on the base model, so all matches are collected
* if there were keys registered
  * collect the list of registered keypaths
  * iterate the list of matches and collect the ones that have a keypath overlapping the registered list
  * clear the registered list for the next round

Does this seem like a reasonable approach?

I was going to try to address some of the change event issues here too, but #2421 got a bit too complicated, so I'll punt on that for now.

**Fixes the following issues:**
#2420

**Is breaking:**
No

**Reviewers:**
Yes, please.