### PR TITLE
Don't throw when a pattern observer encounters a value type - #2503

### DIFF
--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -219,7 +219,8 @@ export default class Model {
 			if ( key === '*' ) {
 				matches = [];
 				existingMatches.forEach( model => {
-					matches.push.apply( matches, model.getValueChildren( model.get() ) );
+					const children = model.getValueChildren( model.get() );
+					if ( children ) matches.push.apply( matches, children );
 				});
 			} else {
 				matches = existingMatches.map( model => model.joinKey( key ) );
@@ -287,7 +288,6 @@ export default class Model {
 	}
 
 	getValueChildren ( value ) {
-
 		let children;
 		if ( isArray( value ) ) {
 			children = [];
@@ -307,8 +307,7 @@ export default class Model {
 		}
 
 		else if ( value != null ) {
-			// TODO: this will return incorrect keypath if model is mapped
-			throw new Error( `Cannot get values of ${this.getKeypath()}.* as ${this.getKeypath()} is not an array, object or function` );
+			return false;
 		}
 
 		return children;

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -219,8 +219,7 @@ export default class Model {
 			if ( key === '*' ) {
 				matches = [];
 				existingMatches.forEach( model => {
-					const children = model.getValueChildren( model.get() );
-					if ( children ) matches.push.apply( matches, children );
+					matches.push.apply( matches, model.getValueChildren( model.get() ) );
 				});
 			} else {
 				matches = existingMatches.map( model => model.joinKey( key ) );
@@ -307,7 +306,7 @@ export default class Model {
 		}
 
 		else if ( value != null ) {
-			return false;
+			return [];
 		}
 
 		return children;

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -958,16 +958,33 @@ export default function() {
 	});
 
 	test( 'Pattern observer expects * to only apply to arrays and objects (#1923)', t => {
+		t.expect(0);
 		const ractive = new Ractive({
 			data: { msg: 'hello world' }
 		});
 
-		t.throws( () => {
-			ractive.observe( 'msg.*', () => {
-				t.ok( false, 'observer should not fire' );
-			});
-		}, /Cannot get values of msg\.\* as msg is not an array, object or function/ );
-	})
+		ractive.observe( 'msg.*', () => {
+			t.ok( false, 'observer should not fire' );
+		});
+	});
+
+	test( `pattern observer doesn't die on primitive values (#2503)`, t => {
+		const done = t.async();
+		const r = new Ractive({
+			el: fixture,
+			template: '',
+			data: { foo: 0 }
+		});
+
+		r.observe( '* *.*', (n, o, k) => {
+			t.equal( n, 1 );
+			t.equal( o, 0 );
+			t.equal( k, 'foo' );
+			done();
+		}, { init: false });
+
+		r.add( 'foo' );
+	});
 
 	test( 'wildcard * fires on new property', t => {
 		t.expect( 2 );


### PR DESCRIPTION
**Description of the pull request:**
Instead of throwing when a pattern observer tries to check a value type (not object, array, or function) for children, this returns false and has the caller check to see if any children were actually returned.

**Fixes the following issues:**
#2503

**Is breaking:**
Nope