### PR TITLE
Reinstate Ractive.noConflict()

### DIFF
--- a/gobblefile.js
+++ b/gobblefile.js
@@ -56,6 +56,11 @@ function bloodyIE8 ( src ) {
 	return src;
 }
 
+function noConflict ( src ) {
+	src = src.replace( 'global.Ractive = factory()', '(function() { var current = global.Ractive; var next = factory(); next.noConflict = function() { global.Ractive = current; return next; }; return global.Ractive = next; })()' );
+	return src;
+}
+
 if ( gobble.env() === 'production' ) {
 	var banner = sander.readFileSync( __dirname, 'src/banner.js' ).toString()
 		.replace( '${version}', version )
@@ -70,7 +75,7 @@ if ( gobble.env() === 'production' ) {
 			moduleName: 'Ractive',
 			dest: 'ractive-legacy.js',
 			banner: banner
-		}).transform( bloodyIE8 ),
+		}).transform( bloodyIE8 ).transform( noConflict ),
 
 		src.transform( 'rollup', {
 			plugins: [ adjustAndSkip( /legacy\.js/ ), babel ],
@@ -79,7 +84,7 @@ if ( gobble.env() === 'production' ) {
 			entry: 'Ractive.js',
 			moduleName: 'Ractive',
 			dest: 'ractive.js'
-		}),
+		}).transform( noConflict ),
 
 		src.transform( 'rollup', {
 			plugins: [ adjustAndSkip( /legacy\.js|_parse\.js/ ), babel ],
@@ -88,7 +93,7 @@ if ( gobble.env() === 'production' ) {
 			entry: 'Ractive.js',
 			moduleName: 'Ractive',
 			dest: 'ractive.runtime.js'
-		}),
+		}).transform( noConflict ),
 
 		src.transform( 'rollup', {
 			plugins: [ adjustAndSkip( /_parse\.js/ ), legacyBabel ],
@@ -97,7 +102,7 @@ if ( gobble.env() === 'production' ) {
 			entry: 'Ractive.js',
 			moduleName: 'Ractive',
 			dest: 'ractive-legacy.runtime.js'
-		}).transform( bloodyIE8 )
+		}).transform( bloodyIE8 ).transform( noConflict )
 	]);
 } else {
 	lib = gobble([
@@ -107,7 +112,7 @@ if ( gobble.env() === 'production' ) {
 			entry: 'Ractive.js',
 			moduleName: 'Ractive',
 			dest: 'ractive-legacy.js'
-		}).transform( bloodyIE8 ),
+		}).transform( bloodyIE8 ).transform( noConflict ),
 
 		sandbox
 	]);

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -1765,6 +1765,16 @@ export default function() {
 			t.equal( fixture.innerHTML, '012' );
 		});
 
+		test( 'noConflict reinstates original Ractive value (#2066)', t => {
+			const r = Ractive;
+			const noConflict = r.noConflict();
+
+			t.equal( Ractive, undefined );
+			t.equal( r, noConflict );
+
+			Ractive = r;
+		});
+
 		test( 'Updating a list section with child list expressions doesn\'t throw errors', t => {
 			const array = [
 				{ foo: [ 1, 2, 3, 4, 5 ] },


### PR DESCRIPTION
**Description of the pull request:**
Adds a step to the build process to add a `Ractive.noConflict()` method that sets the `Ractive` global back to whatever it was when this particular Ractive file loaded and returns the newly removed value e.g. the current Ractive. This only affects those using no module loader.

This is slightly brittle, as it depends on a specific string coming out in the build output, but there is a test canary in the coal mine. 

**Fixes the following issues:**
#2066

**Is breaking:**
Nope