### PR TITLE
Adaptor updates - #2500 and maybe more

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "karma-phantomjs-launcher": "~1.0",
     "karma-qunit": "~0.1",
     "mocha": "^2.1.0",
-    "phantomjs": "^1.9.20",
     "phantomjs-prebuilt": "~2.1",
     "promises-aplus-tests": "^2.1.0",
     "qunitjs": "~1.23",

--- a/src/Ractive/prototype/shared/makeArrayMethod.js
+++ b/src/Ractive/prototype/shared/makeArrayMethod.js
@@ -18,6 +18,7 @@ export default function ( methodName ) {
 		const result = arrayProto[ methodName ].apply( array, args );
 
 		const promise = runloop.start( this, true ).then( () => result );
+		promise.result = result;
 
 		if ( newIndices ) {
 			model.shuffle( newIndices );

--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -11,6 +11,8 @@ export default function Ractive$update ( keypath ) {
 		this.viewmodel.joinAll( keypath ) :
 		this.viewmodel;
 
+	if ( model.parent && model.parent.wrapper ) return this.update( model.parent.getKeypath( this ) );
+
 	const promise = runloop.start( this, true );
 
 	model.mark();

--- a/src/Ractive/static/adaptors/array/index.js
+++ b/src/Ractive/static/adaptors/array/index.js
@@ -50,6 +50,11 @@ class ArrayWrapper {
 		return this.value;
 	}
 
+	reset ( value ) {
+		if ( this.value === value ) return true;
+		return false;
+	}
+
 	teardown () {
 		var array, storage, wrappers, instances, index;
 

--- a/src/Ractive/static/adaptors/array/index.js
+++ b/src/Ractive/static/adaptors/array/index.js
@@ -51,8 +51,7 @@ class ArrayWrapper {
 	}
 
 	reset ( value ) {
-		if ( this.value === value ) return true;
-		return false;
+		return this.value === value;
 	}
 
 	teardown () {

--- a/src/Ractive/static/adaptors/magic.js
+++ b/src/Ractive/static/adaptors/magic.js
@@ -97,8 +97,8 @@ class MagicWrapper {
 		return this.value;
 	}
 
-	reset () {
-		throw new Error( 'TODO magic adaptor reset' ); // does this ever happen?
+	reset ( value ) {
+		return this.value === value;
 	}
 
 	set ( key, value ) {

--- a/src/Ractive/static/adaptors/magicArray.js
+++ b/src/Ractive/static/adaptors/magicArray.js
@@ -31,7 +31,7 @@ class MagicArrayWrapper {
 	}
 
 	reset ( value ) {
-		return this.magicWrapper.reset( value );
+		return this.arrayWrapper.reset( value ) && this.magicWrapper.reset( value );
 	}
 }
 

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -1780,21 +1780,21 @@ export default function() {
 				data: { array: array }
 			});
 
-			t.equal( fixture.innerHTML, '<p>123</p><p>234</p><p>345</p><p>456</p><p>567</p>' );
+			t.htmlEqual( fixture.innerHTML, '<p>123</p><p>234</p><p>345</p><p>456</p><p>567</p>' );
 
 			array.push({ foo: [ 6, 7, 8, 9, 10 ] });
-			t.equal( fixture.innerHTML, '<p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
+			t.htmlEqual( fixture.innerHTML, '<p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
 
 			array.unshift({ foo: [ 0, 1, 2, 3, 4 ] });
-			t.equal( fixture.innerHTML, '<p>012</p><p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
+			t.htmlEqual( fixture.innerHTML, '<p>012</p><p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
 
 			ractive.set( 'array', [] );
 			t.equal( array._ractive, undefined );
-			equal( fixture.innerHTML, '' );
+			t.htmlEqual( fixture.innerHTML, '' );
 
 			ractive.set( 'array', array );
 			t.ok( array._ractive );
-			t.equal( fixture.innerHTML, '<p>012</p><p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
+			t.htmlEqual( fixture.innerHTML, '<p>012</p><p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
 		});
 	}
 }

--- a/test/browser-tests/plugins/adaptors/magic.js
+++ b/test/browser-tests/plugins/adaptors/magic.js
@@ -199,27 +199,24 @@ export default function() {
 			t.htmlEqual( fixture.innerHTML, '<p>David Copperfield</p>' );
 		});
 
-		// TODO: fix this, failing since keypath-ftw
-		/*
-		   test( "Magic adapters shouldn't tear themselves down while resetting (#1342)", t => {
-		   let list = 'abcde'.split('');
-		   let ractive = new MagicRactive({
-el: fixture,
-template: '{{#list}}{{.}}{{/}}',
-data: { list: list },
-magic: true
-});
+		test( "Magic adapters shouldn't tear themselves down while resetting (#1342)", t => {
+			let list = 'abcde'.split('');
+			new MagicRactive({
+				el: fixture,
+				template: '{{#list}}{{.}}{{/}}',
+				data: { list: list },
+				magic: true
+			});
 
-t.htmlEqual( fixture.innerHTML, 'abcde' );
-// if the wrapper causes itself to be recreated, this is where it happens
-// during reset
-list.pop();
-t.htmlEqual( fixture.innerHTML, 'abcd' );
-// since the wrapper now has two magic adapters, two fragments get popped
-list.pop();
-t.htmlEqual( fixture.innerHTML, 'abc' );
-});
-*/
+			t.htmlEqual( fixture.innerHTML, 'abcde' );
+			// if the wrapper causes itself to be recreated, this is where it happens
+			// during reset
+			list.pop();
+			t.htmlEqual( fixture.innerHTML, 'abcd' );
+			// since the wrapper now has two magic adapters, two fragments get popped
+			list.pop();
+			t.htmlEqual( fixture.innerHTML, 'abc' );
+		});
 
 		test( 'Data passed into component updates from outside component in magic mode', t => {
 			const Widget = Ractive.extend({
@@ -240,6 +237,28 @@ t.htmlEqual( fixture.innerHTML, 'abc' );
 			data.world = 'venus';
 
 			t.htmlEqual( fixture.innerHTML, 'venusvenus' );
+		});
+
+		test( `splicing arrays around a magic array doesn't cause rendering errors (#2005)`, t => {
+			const items = [
+				{ num: 1, items: [] },
+				{ num: 2, items: [] },
+				{ num: 3, items: [] },
+				{ num: 4, items: [] }
+			];
+			const third = items[2];
+			new Ractive({
+				el: fixture,
+				template: `{{#items}}{{.num}}{{#.items}}-{{.num}}{{/}}{{/}}`,
+				data: { items },
+				magic: true
+			});
+
+			t.htmlEqual( fixture.innerHTML, '1234' );
+			third.items.push(items.splice(0, 1)[0]);
+			t.htmlEqual( fixture.innerHTML, '23-14' );
+			third.items.push(items.splice(0, 1)[0]);
+			t.htmlEqual( fixture.innerHTML, '3-1-24' );
 		});
 
 		test( 'Indirect changes propagate across components in magic mode (#480)', t => {


### PR DESCRIPTION
**Description of the pull request:**
This:

* consolidates all of the adaptor handling in model into the `adapt` method
* adds a check in `ractive.update` for an adapted parent and delegates the update to the parent if it is adapted
* adds reset methods to all of the provided adaptors that don't cause them to teardown if set with their current value

I think that covers the rest of the weird cases of adaptors, but I'm not sure as I haven't used them extensively. This may also fix some of the magic failures in edge, as it adds a working `reset`. At least I think it is a working `reset`... can anyone comment on the implementation?

Have I missed or completely misunderstood anything?

**Fixes the following issues:**
#2500 

**Is breaking:**
I don't think so

**Reviewers:**
Anyone familiar with how adaptors should behave