### PR TITLE
Detach non-transitioning nodes immediately - #2027 - RFC

### DIFF
--- a/src/global/TransitionManager.js
+++ b/src/global/TransitionManager.js
@@ -100,28 +100,19 @@ function check ( tm ) {
 // check through the detach queue to see if a node is up or downstream from a
 // transition and if not, go ahead and detach it
 function detachImmediate ( manager ) {
+	if ( manager.totalChildren ) return;
+
 	const queue = manager.detachQueue;
 	const outros = manager.outros;
 
-	let i = queue.length;
+	let i = queue.length, j = 0, node, trans;
 	start: while ( i-- ) {
-		const node = queue[i].node;
-		let j = outros.length;
+		node = queue[i].node;
+		j = outros.length;
 		while ( j-- ) {
-			// check to see if the node is a parent of the transition
-			const trans = outros[j].node;
-			let parent = trans;
-			while ( parent ) {
-				if ( parent === node ) continue start;
-				parent = parent.parentNode;
-			}
-
-			// check to see if the transition is a parent of the node
-			parent = node;
-			while ( parent ) {
-				if ( parent === trans ) continue start;
-				parent = parent.parentNode;
-			}
+			trans = outros[j].node;
+			// check to see if the node is, contains, or is contained by the transitioning node
+			if ( trans === node || trans.contains( node ) || node.contains( trans ) ) continue start;
 		}
 
 		// no match, we can drop it

--- a/src/global/TransitionManager.js
+++ b/src/global/TransitionManager.js
@@ -100,10 +100,8 @@ function check ( tm ) {
 // check through the detach queue to see if a node is up or downstream from a
 // transition and if not, go ahead and detach it
 function detachImmediate ( manager ) {
-	if ( manager.totalChildren ) return;
-
 	const queue = manager.detachQueue;
-	const outros = manager.outros;
+	const outros = collectAllOutros( manager );
 
 	let i = queue.length, j = 0, node, trans;
 	start: while ( i-- ) {
@@ -118,5 +116,21 @@ function detachImmediate ( manager ) {
 		// no match, we can drop it
 		queue[i].detach();
 		queue.splice( i, 1 );
+	}
+}
+
+function collectAllOutros ( manager, list ) {
+	if ( !list ) {
+		list = [];
+		let parent = manager;
+		while ( parent.parent ) parent = parent.parent;
+		return collectAllOutros( parent, list );
+	} else {
+		let i = manager.children.length;
+		while ( i-- ) {
+			list = collectAllOutros( manager.children[i], list );
+		}
+		list = list.concat( manager.outros );
+		return list;
 	}
 }

--- a/test/browser-tests/plugins/transitions.js
+++ b/test/browser-tests/plugins/transitions.js
@@ -417,25 +417,27 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<span>baz</span>' );
 	});
 
-	test( 'Nodes not affected by a transition should be immediately handled (#2027)', t => {
-		const done = t.async();
-		t.expect( 3 );
+	if ( !/phantom/i.test( navigator.userAgent ) ) {
+		test( 'Nodes not affected by a transition should be immediately handled (#2027)', t => {
+			const done = t.async();
+			t.expect( 3 );
 
-		function trans() {
-			t.ok( true, 'transition actually ran' );
-			return new Promise( ok => setTimeout( ok, 500 ) );
-		}
-		const r = new Ractive({
-			el: fixture,
-			template: `{{#if foo}}<span outro="trans" id="span1" /><span id="span2" />{{/if}}`,
-			data: { foo: true },
-			transitions: { trans }
+			function trans() {
+				t.ok( true, 'transition actually ran' );
+				return new Promise( ok => setTimeout( ok, 200 ) );
+			}
+			const r = new Ractive({
+				el: fixture,
+				template: `{{#if foo}}<span outro="trans" id="span1" /><span id="span2" />{{/if}}`,
+				data: { foo: true },
+				transitions: { trans }
+			});
+
+			r.set( 'foo', false ).then( done, done );
+			t.ok( !/span2/.test( fixture.innerHTML ), 'span2 is gone immediately' );
+			t.ok( /span1/.test( fixture.innerHTML ), 'span1 hangs around until the transition is done' );
 		});
-
-		r.set( 'foo', false ).then( done, done );
-		t.ok( !fixture.querySelector( '#span2' ), 'span2 is gone immediately' );
-		t.ok( fixture.querySelector( '#span1', 'span1 hangs around until the transition is done' ) );
-	});
+	}
 
 	test( 'Context of transition function is current instance', t => {
 		t.expect( 1 );

--- a/test/browser-tests/plugins/transitions.js
+++ b/test/browser-tests/plugins/transitions.js
@@ -279,12 +279,12 @@ export default function() {
 
 	test( 'Parameter objects are not polluted (#1239)', t => {
 		const done = t.async();
-	
+
 		t.expect(3)
-	
+
 		let uid = 0;
 		let objects = [];
-	
+
 		new Ractive({
 			el: fixture,
 			template: '{{#each list}}<p intro="foo:{}"></p>{{/each}}',
@@ -325,10 +325,10 @@ export default function() {
 
 	test( 'An intro will be aborted if a corresponding outro begins before it completes', t => {
 		var ractive, tooLate;
-	
+
 		const done = t.async();
 		t.expect( 0 );
-	
+
 		ractive = new Ractive({
 			el: fixture,
 			template: '{{#showBox}}<div intro="wait:2000" outro="wait:1"></div>{{/showBox}}',
@@ -338,17 +338,17 @@ export default function() {
 				}
 			}
 		});
-	
+
 		ractive.set( 'showBox', true ).then( function ( t ) {
 			if ( !tooLate ) {
 				done();
 			}
 		});
-	
+
 		setTimeout( function () {
 			ractive.set( 'showBox', false );
 		}, 0 );
-	
+
 		setTimeout( function () {
 			tooLate = true;
 		}, 200 );
@@ -361,19 +361,19 @@ export default function() {
 			transitions: {
 				foo ( transition, params ) {
 					params = transition.processParams( params );
-	
+
 					// Test that the duration param is present
 					t.equal( params.duration, 1000 );
 				}
 			}
 		});
 	});
-	
+
 	test( 'Conditional sections that become truthy are not rendered if a parent simultaneously becomes falsy (#1483)', t => {
 		let transitionRan = false;
 		const done = t.async();
 		t.expect(1);
-	
+
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -415,6 +415,26 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '' );
 		r.set( 'foo', true );
 		t.htmlEqual( fixture.innerHTML, '<span>baz</span>' );
+	});
+
+	test( 'Nodes not affected by a transition should be immediately handled (#2027)', t => {
+		const done = t.async();
+		t.expect( 3 );
+
+		function trans() {
+			t.ok( true, 'transition actually ran' );
+			return new Promise( ok => setTimeout( ok, 500 ) );
+		}
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#if foo}}<span outro="trans" id="span1" /><span id="span2" />{{/if}}`,
+			data: { foo: true },
+			transitions: { trans }
+		});
+
+		r.set( 'foo', false ).then( done, done );
+		t.ok( !fixture.querySelector( '#span2' ), 'span2 is gone immediately' );
+		t.ok( fixture.querySelector( '#span1', 'span1 hangs around until the transition is done' ) );
 	});
 
 	test( 'Context of transition function is current instance', t => {


### PR DESCRIPTION
**Description of the pull request:**
This adds a check at the beginning of the transition cycle for nodes that are not up- or downstream of a transitioning node and goes ahead and detaches them immediately.

I'm not entirely sure what this means for nested batches and transitions, but a quick run through looks like it won't release zalgo. I have a feeling ~~that to be 100% accurate this would have to also check parent (and child) manager nodes and transitions, but I also have the feeling that~~ there's no way to cover every corner as parent managers won't be able to check all of their children that may spring into existence.

Thoughts?

**Fixes the following issues:**
#2027

**Is breaking:**
I don't think so.