### PR TITLE
Style attributes shouldn't try to use a boolean value - #2522

### DIFF
--- a/src/view/helpers/specialAttrs.js
+++ b/src/view/helpers/specialAttrs.js
@@ -9,6 +9,8 @@ const value = /\0(\d+)/g;
 export function readStyle ( css ) {
     let values = [];
 
+    if ( typeof css !== 'string' ) return {};
+
     return css.replace( escape, match => `\0${values.push( match ) - 1}`)
         .replace( remove, '' )
         .split( ';' )

--- a/test/browser-tests/attributes.js
+++ b/test/browser-tests/attributes.js
@@ -34,6 +34,19 @@ export default function () {
 		t.equal( span.style.height, '87.5%' );
 	});
 
+	test( `style attributes don't try to use a boolean value (#2522)`, t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `<span style="{{#if foo}}{{else}}color: red{{/if}}" />`,
+			data: { foo: false }
+		});
+		const span = r.find( 'span' );
+
+		t.equal( span.style.color, 'red' );
+		r.set( 'foo', true );
+		t.equal( span.style.color, '' );
+	});
+
 	test( `style attributes can be inline directives`, t => {
 		const r = new Ractive({
 			el: fixture,


### PR DESCRIPTION
**Description of the pull request:**
Adds a check on style parsing to make sure it's a string.

**Fixes the following issues:**
#2522

**Is breaking:**
Nope.
