### PR TITLE
Computeds should have a value when being updated - #2520

### DIFF
--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -14,7 +14,7 @@ export default function Ractive$update ( keypath ) {
 	const promise = runloop.start( this, true );
 
 	model.mark();
-	model.registerChange( model.getKeypath(), model.retrieve() );
+	model.registerChange( model.getKeypath(), model.get() );
 
 	if ( keypath ) {
 		// there may be unresolved refs that are now resolvable up the context tree

--- a/test/browser-tests/init/hooks/misc.js
+++ b/test/browser-tests/init/hooks/misc.js
@@ -122,6 +122,29 @@ export default function() {
 		r.update( 'bar' );
 	});
 
+	test( 'change event fires with correct value if the key is computed (#2520)', t => {
+		t.expect( 1 );
+
+		let foo = 'hello';
+		const r = new Ractive({
+			computed: {
+				foo: {
+					get() { return foo; },
+					set( value ) {
+						foo = value;
+						this.update( 'foo' );
+					}
+				}
+			}
+		});
+
+		r.on( 'change', ( changes ) => {
+			t.equal( changes.foo, 'yep' );
+		});
+
+		r.set( 'foo', 'yep' );
+	});
+
 	test( 'correct behaviour of deprecated beforeInit hook (#1395)', t => {
 		t.expect( 6 );
 


### PR DESCRIPTION
**Description of the pull request:**
Use `get` rather than `retrieve` when registering update changes to ensure computeds actually have a value.

**Fixes the following issues:**
#2520

**Is breaking:**
Nope.