### PR TITLE
(Partially) fix bindings that cause themselves to be updated - #2427

### DIFF
--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -15,6 +15,7 @@ const runloop = {
 			promise = new Promise( f => ( fulfilPromise = f ) );
 		}
 
+		// TODO: this is a temporary hack that needs to go away with a probably breaking change
 		if ( batch ) batch.children++;
 
 		batch = {

--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -15,6 +15,8 @@ const runloop = {
 			promise = new Promise( f => ( fulfilPromise = f ) );
 		}
 
+		if ( batch ) batch.children++;
+
 		batch = {
 			previousBatch: batch,
 			transitionManager: new TransitionManager( fulfilPromise, batch && batch.transitionManager ),
@@ -23,7 +25,8 @@ const runloop = {
 			immediateObservers: [],
 			deferredObservers: [],
 			ractives: [],
-			instance: instance
+			instance: instance,
+			children: 0
 		};
 
 		return promise;
@@ -45,6 +48,8 @@ const runloop = {
 	addObserver ( observer, defer ) {
 		addToArray( defer ? batch.deferredObservers : batch.immediateObservers, observer );
 	},
+
+	children () { return batch.children; },
 
 	registerTransition ( transition ) {
 		transition._manager = batch.transitionManager;

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -78,7 +78,6 @@ export default class Attribute extends Item {
 	}
 
 	rebind () {
-		if ( this.binding && this.binding.locked ) this.binding.locked = false;
 		if ( this.fragment ) this.fragment.rebind();
 	}
 

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -78,7 +78,8 @@ export default class Attribute extends Item {
 	}
 
 	rebind () {
-		if (this.fragment) this.fragment.rebind();
+		if ( this.binding && this.binding.locked ) this.binding.locked = false;
+		if ( this.fragment ) this.fragment.rebind();
 	}
 
 	render () {

--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -4,6 +4,7 @@ import { arrayContains } from '../../../../utils/array';
 import { isArray } from '../../../../utils/is';
 import noop from '../../../../utils/noop';
 import { readStyle, readClass } from '../../../helpers/specialAttrs';
+import runloop from '../../../../global/runloop';
 
 const textTypes = [ undefined, 'text', 'search', 'url', 'email', 'hidden', 'password', 'search', 'reset', 'submit' ];
 
@@ -120,7 +121,7 @@ function updateSelectValue () {
 function updateContentEditableValue () {
 	const value = this.getValue();
 
-	if ( !this.locked ) {
+	if ( !this.locked || ( !runloop.children() && this.node.innerHTML !== ( value || '' ) ) ) {
 		this.node.innerHTML = value === undefined ? '' : value;
 	}
 }
@@ -145,8 +146,8 @@ function updateRadioValue () {
 }
 
 function updateValue () {
-	if ( !this.locked ) {
-		const value = this.getValue();
+	const value = this.getValue();
+	if ( !this.locked || ( !runloop.children() && value !== this.node.value ) ) {
 
 		this.node.value = this.node._ractive.value = value;
 		this.node.setAttribute( 'value', value );
@@ -154,9 +155,8 @@ function updateValue () {
 }
 
 function updateStringValue () {
-	if ( !this.locked ) {
-		const value = this.getValue();
-
+	const value = this.getValue();
+	if ( !this.locked || ( !runloop.children() && safeToStringValue( value ) !== this.node.value ) ) {
 		this.node._ractive.value = value;
 
 		this.node.value = safeToStringValue( value );

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -419,6 +419,30 @@ export default function() {
 		t.ok( !inputs[1].checked );
 	});
 
+	test( `bindings that trigger their own immediate should not get stuck (#2427)`, t => {
+		const r = new Ractive({
+			el: fixture,
+			data: {
+				list: [ { v: 'a', o: 0 }, { v: 'a', o: 1 }, { v: 'b', o: 2 }, { v: 'c', o: 3 } ]
+			},
+			computed: {
+				rows() {
+					var list = this.get( 'list' ).slice(0);
+					return list.sort( ( a, b ) => a.v.localeCompare( b.v ) ).map( o => o.o );
+				}
+			},
+			template: `{{#each rows}}{{#with list[.]}}<input value="{{.v}}" />{{/with}}{{/each}}`
+		});
+		const inputs = r.findAll( 'input' );
+		inputs[0].value = 'z';
+		fire( inputs[0], 'change' );
+
+		t.equal( inputs[0].value, 'a' );
+		t.equal( inputs[1].value, 'b' );
+		t.equal( inputs[2].value, 'c' );
+		t.equal( inputs[3].value, 'z' );
+	});
+
 	test( 'Post-blur validation works (#771)', t => {
 		const ractive = new Ractive({
 			el: fixture,

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -419,7 +419,7 @@ export default function() {
 		t.ok( !inputs[1].checked );
 	});
 
-	test( `bindings that trigger their own immediate should not get stuck (#2427)`, t => {
+	test( `bindings that trigger their own immediate update via computation should not get stuck (#2427)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			data: {
@@ -675,7 +675,6 @@ export default function() {
 			},
 			onrender () {
 				inputs = this.findAll( 'input' );
-				whatever: { x: 1 }
 			}
 		});
 


### PR DESCRIPTION
**Description of the pull request:**
Attributes with bindings currently get locked while the binding is updating to avoid input jitter (cursor jumping home) that would be caused as the value updated itself. Unfortunately, if the attribute has a legitimate reason to change while the binding updates, like the binding causing a computed to update and change the underlying value for the attribute, then the wrong value gets stuck in the attribute because it is locked.

The locking is also in place to allow observers to do validation on a value as it is being updated while also not breaking the input by overwriting its value should the validation observer make changes. I think this behavior should be removed because a lazy binding skirt that particular issue without doing weird things like having the input value and its underlying model have two different values. This seems to have originated in #771, and I think individual binding laziness should make that mostly unnecessary now. That would be breaking though.

In order to avoid breaking changes, this attempts to mostly handle both cases by checking to see if an observer may have done an update if the attribute is locked. If there is no chance that an observer has caused an update (the current batch has had no children) and the model value is not equal to the input value, then change is allowed through. This will fall over if there happens to be an observer that makes a change while a computed also causes a change, but ¯\_(ツ)_/¯

**Fixes the following issues:**
#2427 excepting the corner-case

**Is breaking:**
No