### PR TITLE
Warn in debug if inline style values do not match what is applied

### DIFF
--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -4,6 +4,7 @@ import { arrayContains } from '../../../../utils/array';
 import { isArray } from '../../../../utils/is';
 import noop from '../../../../utils/noop';
 import { readStyle, readClass } from '../../../helpers/specialAttrs';
+import { warnOnceIfDebug } from '../../../../utils/log';
 
 const textTypes = [ undefined, 'text', 'search', 'url', 'email', 'hidden', 'password', 'search', 'reset', 'submit' ];
 
@@ -197,7 +198,10 @@ function updateStyleAttribute () {
 
 	let i = 0;
 	while ( i < keys.length ) {
-		if ( keys[i] in style ) style[ keys[i] ] = props[ keys[i] ];
+		if ( keys[i] in style ) {
+			style[ keys[i] ] = props[ keys[i] ];
+			if ( style[ keys[i] ] !== props[ keys[i] ] ) warnOnceIfDebug( `Inline style property '${keys[i]}' new value '${props[ keys[i] ]}' does not match the applied value '${style[ keys[i] ]}'.` );
+		}
 		i++;
 	}
 
@@ -215,8 +219,11 @@ function updateInlineStyle () {
 	if ( !this.styleName ) {
 		this.styleName = this.name.substr( 6 ).replace( camelize, s => s.charAt( 1 ).toUpperCase() );
 	}
+	const key = this.styleName;
+	const value = this.getValue();
 
-	this.node.style[ this.styleName ] = this.getValue();
+	this.node.style[ key ] = value;
+	if ( this.node.style[ key ] !== value ) warnOnceIfDebug( `Inline style attribute '${key}' new value '${value}' does not match the applied value '${this.node.style[ key ]}'.` );
 }
 
 function updateClassName () {

--- a/test/browser-tests/attributes.js
+++ b/test/browser-tests/attributes.js
@@ -1,5 +1,5 @@
 import { test } from 'qunit';
-import { initModule } from './test-config';
+import { initModule, hasUsableConsole, onWarn } from './test-config';
 
 export default function () {
 	initModule( 'attributes.js' );
@@ -59,6 +59,44 @@ export default function () {
 		r.set( 'color', 'green' );
 		t.equal( span.style.color, 'green' );
 	});
+
+	if ( hasUsableConsole ) {
+		test( `invalid inline style attributes warn in debug mode`, t => {
+			t.expect( 1 );
+
+			onWarn( msg => {
+				t.ok( /inline style attribute.*color.*gren.*not match.*green/i.test( msg ), 'warns informatively' );
+			});
+
+			const r = new Ractive({
+				el: fixture,
+				template: `<span style-color="{{foo}}" />`,
+				data: { foo: 'green' }
+			});
+
+			r.set( 'foo', 'gren' );
+			r.set( 'foo', 'green' );
+			r.set( 'foo', 'gren' );
+		});
+
+		test( `invalid inline style properties warn in debug mode`, t => {
+			t.expect( 1 );
+
+			onWarn( msg => {
+				t.ok( /inline style property.*color.*gren.*not match.*green/i.test( msg ), 'warns informatively' );
+			});
+
+			const r = new Ractive({
+				el: fixture,
+				template: `<span style="color: {{foo}};" />`,
+				data: { foo: 'green' }
+			});
+
+			r.set( 'foo', 'gren' );
+			r.set( 'foo', 'green' );
+			r.set( 'foo', 'gren' );
+		});
+	}
 
 	test( `class attributes can be inline directives`, t => {
 		const r = new Ractive({

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -1,6 +1,5 @@
 import { test } from 'qunit';
-import { hasUsableConsole, onWarn } from './test-config';
-import { initModule } from './test-config';
+import { initModule, hasUsableConsole, onWarn } from './test-config';
 
 export default function() {
 	initModule( 'computations.js' );


### PR DESCRIPTION
**Description of the pull request:**
As mentioned by @paulie4 in https://github.com/ractivejs/ractive/issues/2522#issuecomment-213570140, invalid inline style values no longer stand out because ractive now sets them from the style node rather than as a text attribute. This adds a warning (once) for each inline style that does not have a matching accepted value.

Note that some shorthand values get expanded and will therefore not match exactly what was set. These will also trigger a warning.

**Is breaking:**
Nope.
