### PR TITLE
merge class and style attributes and directives in toString output

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -141,8 +141,25 @@ function detachNode ( node ) {
 	return node;
 }
 
-function safeToStringValue( value ) {
+function safeToStringValue ( value ) {
 	return ( value == null || !value.toString ) ? '' : '' + value;
 }
 
-export { createElement, detachNode, getElement, matches, safeToStringValue };
+function safeAttributeString ( string ) {
+	return safeToStringValue( string )
+		.replace( /&/g, '&amp;' )
+		.replace( /"/g, '&quot;' )
+		.replace( /'/g, '&#39;' );
+}
+
+const camel = /(-.)/g;
+function camelize ( string ) {
+	return string.replace( camel, s => s.charAt( 1 ).toUpperCase() );
+}
+
+const decamel = /[A-Z]/g;
+function decamelize ( string ) {
+	return string.replace( decamel, s => `-${s.toLowerCase()}` );
+}
+
+export { createElement, detachNode, getElement, matches, safeToStringValue, safeAttributeString, camelize, decamelize };

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -13,7 +13,7 @@ import updateLiveQueries from './element/updateLiveQueries';
 import { toArray } from '../../utils/array';
 import { escapeHtml, voidElementNames } from '../../utils/html';
 import { bind, rebind, render, unbind, unrender, update } from '../../shared/methodCallers';
-import { createElement, detachNode, matches } from '../../utils/dom';
+import { createElement, detachNode, matches, safeAttributeString, decamelize } from '../../utils/dom';
 import { html, svg } from '../../config/namespaces';
 import { defineProperty } from '../../utils/object';
 import selectBinding from './element/binding/selectBinding';
@@ -21,6 +21,8 @@ import selectBinding from './element/binding/selectBinding';
 function makeDirty ( query ) {
 	query.makeDirty();
 }
+
+const endsWithSemi = /;\s*$/;
 
 export default class Element extends Item {
 	constructor ( options ) {
@@ -306,6 +308,24 @@ export default class Element extends Item {
 		if ( this.name === 'input' && inputIsCheckedRadio( this ) ) {
 			attrs += ' checked';
 		}
+
+		// Special case style and class attributes and directives
+		let style, cls;
+		this.attributes.forEach( attr => {
+			if ( attr.name === 'class' ) {
+				cls = ( cls || '' ) + ( cls ? ' ' : '' ) + safeAttributeString( attr.getString() );
+			} else if ( attr.name === 'style' ) {
+				style = ( style || '' ) + ( style ? ' ' : '' ) + safeAttributeString( attr.getString() );
+				if ( style && !endsWithSemi.test( style ) ) style += ';';
+			} else if ( attr.styleName ) {
+				style = ( style || '' ) + ( style ? ' ' : '' ) +  `${decamelize( attr.styleName )}: ${safeAttributeString( attr.getString() )};`;
+			} else if ( attr.inlineClass ) {
+				cls = ( cls || '' ) + ( cls ? ' ' : '' ) + attr.inlineClass;
+			}
+		});
+		// put classes first, then inline style
+		if ( style !== undefined ) attrs = ' style' + ( style ? `="${style}"` : '' ) + attrs;
+		if ( cls !== undefined ) attrs = ' class' + (cls ? `="${cls}"` : '') + attrs;
 
 		let str = `<${tagName}${attrs}>`;
 

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -319,7 +319,7 @@ export default class Element extends Item {
 				if ( style && !endsWithSemi.test( style ) ) style += ';';
 			} else if ( attr.styleName ) {
 				style = ( style || '' ) + ( style ? ' ' : '' ) +  `${decamelize( attr.styleName )}: ${safeAttributeString( attr.getString() )};`;
-			} else if ( attr.inlineClass ) {
+			} else if ( attr.inlineClass && attr.getValue() ) {
 				cls = ( cls || '' ) + ( cls ? ' ' : '' ) + attr.inlineClass;
 			}
 		});

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -5,7 +5,7 @@ import Item from '../shared/Item';
 import getUpdateDelegate from './attribute/getUpdateDelegate';
 import propertyNames from './attribute/propertyNames';
 import { isArray } from '../../../utils/is';
-import { safeToStringValue } from '../../../utils/dom';
+import { safeAttributeString } from '../../../utils/dom';
 import { booleanAttributes } from '../../../utils/html';
 
 function lookupNamespace ( node, prefix ) {
@@ -131,14 +131,15 @@ export default class Attribute extends Item {
 			return `name="{{${this.interpolator.model.getKeypath()}}}"`;
 		}
 
+		// Special case - style and class attributes and directives
+		if ( this.name === 'style' || this.name === 'class' || this.styleName || this.inlineClass ) {
+			return;
+		}
+
 		if ( booleanAttributes.test( this.name ) ) return value ? this.name : '';
 		if ( value == null ) return '';
 
-		const str = safeToStringValue( this.getString() )
-			.replace( /&/g, '&amp;' )
-			.replace( /"/g, '&quot;' )
-			.replace( /'/g, '&#39;' );
-
+		const str = safeAttributeString( this.getString() );
 		return str ?
 			`${this.name}="${str}"` :
 			this.name;

--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -1,5 +1,5 @@
 import { html } from '../../../../config/namespaces';
-import { safeToStringValue } from '../../../../utils/dom';
+import { safeToStringValue, camelize } from '../../../../utils/dom';
 import { arrayContains } from '../../../../utils/array';
 import { isArray } from '../../../../utils/is';
 import noop from '../../../../utils/noop';
@@ -210,10 +210,9 @@ function updateStyleAttribute () {
 	this.previous = keys;
 }
 
-const camelize = /(-.)/g;
 function updateInlineStyle () {
 	if ( !this.styleName ) {
-		this.styleName = this.name.substr( 6 ).replace( camelize, s => s.charAt( 1 ).toUpperCase() );
+		this.styleName = camelize( this.name.substr( 6 ) );
 	}
 
 	this.node.style[ this.styleName ] = this.getValue();
@@ -248,6 +247,8 @@ function updateInlineClass () {
 	const name = this.name.substr( 6 );
 	const attr = readClass( this.node.className );
 	const value = this.getValue();
+
+	if ( !this.inlineClass ) this.inlineClass = name;
 
 	if ( value && !~attr.indexOf( name ) ) attr.push( name );
 	else if ( !value && ~attr.indexOf( name ) ) attr.splice( attr.indexOf( name ), 1 );

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -134,7 +134,7 @@ const renderTests = [
 		name: 'Attribute with sections',
 		template: '<ul>{{#todos:i}}<li data-index="{{i}}" class="{{#completed}}completed{{/completed}}{{^completed}}view{{/completed}}">{{desc}}</li>{{/todos}}</ul>',
 		data: { todos: [{ desc: 'debug Ractive', completed: false }, { desc: 'release Ractive', completed: false }, { desc: 'make cup of tea', completed: true }]},
-		result: '<ul><li data-index="0" class="view">debug Ractive</li><li data-index="1" class="view">release Ractive</li><li data-index="2" class="completed">make cup of tea</li></ul>'
+		result: '<ul><li class="view" data-index="0">debug Ractive</li><li class="view" data-index="1">release Ractive</li><li class="completed" data-index="2">make cup of tea</li></ul>'
 	},
 	{
 		name: 'Conditional section with true condition',

--- a/test/browser-tests/attributes.js
+++ b/test/browser-tests/attributes.js
@@ -93,4 +93,22 @@ export default function () {
 		r.toggle( 'foo' );
 		t.equal( span.className, 'bar baz foo' );
 	});
+
+	test( `class directives and class attributes both contribute to toHTML (#2537)`, t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `<span class-bip="{{true}}" class="foo bar" class-bop="{{true}}" /><span class-foo="{{true}}" class-bar-baz="{{true}}" />`
+		});
+
+		t.equal( r.toHTML(), `<span class="bip foo bar bop"></span><span class="foo bar-baz"></span>` );
+	});
+
+	test( `style directives and style attributes both contribute to toHTML (#2537)`, t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `<span style-text-decoration="underline" style="color: green" style-fontSize="12pt" /><span style-text-decoration="underline" style-fontSize="12pt" />`
+		});
+
+		t.equal( r.toHTML(), `<span style="text-decoration: underline; color: green; font-size: 12pt;"></span><span style="text-decoration: underline; font-size: 12pt;"></span>` );
+	});
 }

--- a/test/browser-tests/attributes.js
+++ b/test/browser-tests/attributes.js
@@ -97,7 +97,7 @@ export default function () {
 	test( `class directives and class attributes both contribute to toHTML (#2537)`, t => {
 		const r = new Ractive({
 			el: fixture,
-			template: `<span class-bip="{{true}}" class="foo bar" class-bop="{{true}}" /><span class-foo="{{true}}" class-bar-baz="{{true}}" />`
+			template: `<span class-bip="{{true}}" class-nope="{{false}}" class="foo bar" class-bop="{{true}}" /><span class-foo="{{true}}" class-bar-baz="{{true}}" />`
 		});
 
 		t.equal( r.toHTML(), `<span class="bip foo bar bop"></span><span class="foo bar-baz"></span>` );


### PR DESCRIPTION
**Description of the pull request:**
This skips `toString` of class and style attributes and moves them the the element level so that the element can aggregate any class and style directives along with the attributes if they exist.

**Fixes the following issues:**
#2537

**Is breaking:**
Sort of... if you depend on exact ordering of attributes in elements. This ends up making classes always come first and styles always come second.