### PR TITLE
<select> comparator attribute

### DIFF
--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -133,7 +133,7 @@ function updateRadioValue () {
 
 	//node.value = this.element.getAttribute( 'value' );
 	node.value = this.node._ractive.value = value;
-	node.checked = value === this.element.getAttribute( 'name' );
+	node.checked = this.element.compare ( value, this.element.getAttribute( 'name' ) );
 
 	// This is a special case - if the input was checked, and the value
 	// changed so that it's no longer checked, the twoway binding is
@@ -165,7 +165,7 @@ function updateStringValue () {
 }
 
 function updateRadioName () {
-	this.node.checked = ( this.getValue() == this.node._ractive.value );
+	this.node.checked = this.element.compare ( this.getValue(), this.element.getAttribute('value') );
 }
 
 function updateCheckboxName () {
@@ -176,11 +176,11 @@ function updateCheckboxName () {
 	const valueAttribute = element.getAttribute( 'value' );
 
 	if ( !isArray( value ) ) {
-		binding.isChecked = node.checked = ( value == valueAttribute );
+		binding.isChecked = node.checked = ( element.compare( value, valueAttribute ) );
 	} else {
 		let i = value.length;
 		while ( i-- ) {
-			if ( valueAttribute == value[i] ) {
+			if ( element.compare ( valueAttribute, value[i] ) ) {
 				binding.isChecked = node.checked = true;
 				return;
 			}

--- a/src/view/items/element/binding/CheckboxNameBinding.js
+++ b/src/view/items/element/binding/CheckboxNameBinding.js
@@ -9,7 +9,8 @@ const push = [].push;
 function getValue() {
 	const all = this.bindings.filter(b => b.node && b.node.checked).map(b => b.element.getAttribute( 'value' ));
 	let res = [];
-	all.forEach(v => { if ( !arrayContains( res, v ) ) res.push( v ); });
+	const binding = this.bindings[0];
+	all.forEach(v => { if ( !binding.arrayContains( res, v ) ) res.push( v ); });
 	return res;
 }
 
@@ -35,7 +36,7 @@ export default class CheckboxNameBinding extends Binding {
 			const existingValue = this.model.get();
 			const bindingValue = this.element.getAttribute( 'value' );
 
-			if ( !arrayContains( existingValue, bindingValue ) ) {
+			if ( !this.arrayContains( existingValue, bindingValue ) ) {
 				push.call( existingValue, bindingValue ); // to avoid triggering runloop with array adaptor
 			}
 		}
@@ -73,10 +74,10 @@ export default class CheckboxNameBinding extends Binding {
 		this.isChecked = this.element.node.checked;
 		this.group.value = this.model.get();
 		const value = this.element.getAttribute( 'value' );
-		if ( this.isChecked && !arrayContains( this.group.value, value ) ) {
+		if ( this.isChecked && !this.arrayContains( this.group.value, value ) ) {
 			this.group.value.push( value );
-		} else if ( !this.isChecked && arrayContains( this.group.value, value ) ) {
-			removeFromArray( this.group.value, value );
+		} else if ( !this.isChecked && this.arrayContains( this.group.value, value ) ) {
+			this.removeFromArray( this.group.value, value );
 		}
 		super.handleChange();
 	}
@@ -90,11 +91,10 @@ export default class CheckboxNameBinding extends Binding {
 		const bindingValue = this.element.getAttribute( 'value' );
 
 		if ( isArray( existingValue ) ) {
-			this.isChecked = arrayContains( existingValue, bindingValue );
+			this.isChecked = this.arrayContains( existingValue, bindingValue );
 		} else {
-			this.isChecked = existingValue == bindingValue;
+			this.isChecked = this.element.compare( existingValue, bindingValue );
 		}
-
 		node.name = '{{' + this.model.getKeypath() + '}}';
 		node.checked = this.isChecked;
 
@@ -126,5 +126,25 @@ export default class CheckboxNameBinding extends Binding {
 
 		node.removeEventListener( 'change', handleDomEvent, false );
 		node.removeEventListener( 'click', handleDomEvent, false );
+	}
+
+	arrayContains ( selectValue, optionValue ) {
+		let i = selectValue.length;
+		const compare = this.element.compare;
+		while ( i-- ) {
+			if ( this.element.compare( optionValue, selectValue[i] ) ) return true;
+		}
+		return false;
+	}
+
+	removeFromArray( array, item ) {
+		if (!array) return;
+		let i = array.length;
+		const compare = this.element.compare;
+		while( i-- ) {
+			if ( this.element.compare ( item, array[i] ) ) {
+				array.splice( i, 1 );
+			}
+		}
 	}
 }

--- a/src/view/items/element/binding/CheckboxNameBinding.js
+++ b/src/view/items/element/binding/CheckboxNameBinding.js
@@ -130,19 +130,17 @@ export default class CheckboxNameBinding extends Binding {
 
 	arrayContains ( selectValue, optionValue ) {
 		let i = selectValue.length;
-		const compare = this.element.compare;
 		while ( i-- ) {
 			if ( this.element.compare( optionValue, selectValue[i] ) ) return true;
 		}
 		return false;
 	}
 
-	removeFromArray( array, item ) {
+	removeFromArray ( array, item ) {
 		if (!array) return;
 		let i = array.length;
-		const compare = this.element.compare;
 		while( i-- ) {
-			if ( this.element.compare ( item, array[i] ) ) {
+			if ( this.element.compare( item, array[i] ) ) {
 				array.splice( i, 1 );
 			}
 		}

--- a/src/view/items/element/binding/RadioNameBinding.js
+++ b/src/view/items/element/binding/RadioNameBinding.js
@@ -59,7 +59,7 @@ export default class RadioNameBinding extends Binding {
 		const node = this.node;
 
 		node.name = `{{${this.model.getKeypath()}}}`;
-		node.checked = this.model.get() == this.element.getAttribute( 'value' );
+		node.checked = this.element.compare ( this.model.get(), this.element.getAttribute( 'value' ) );
 
 		node.addEventListener( 'change', handleDomEvent, false );
 

--- a/src/view/items/element/specials/Input.js
+++ b/src/view/items/element/specials/Input.js
@@ -7,9 +7,9 @@ export default class Input extends Element {
 	}
 	compare ( value, attrValue ) {
 		const comparator = this.getAttribute( 'value-comparator' );
-		if (comparator) {
-			if (typeof comparator === 'function') {
-				return comparator(value, attrValue);
+		if ( comparator ) {
+			if ( typeof comparator === 'function' ) {
+				return comparator( value, attrValue );
 			}
 			if (value && attrValue) {
 				return value[comparator] == attrValue[comparator];

--- a/src/view/items/element/specials/Input.js
+++ b/src/view/items/element/specials/Input.js
@@ -5,4 +5,16 @@ export default class Input extends Element {
 		super.render( target, occupants );
 		this.node.defaultValue = this.node.value;
 	}
+	compare ( value, attrValue ) {
+		const comparator = this.getAttribute( 'value-comparator' );
+		if (comparator) {
+			if (typeof comparator === 'function') {
+				return comparator(value, attrValue);
+			}
+			if (value && attrValue) {
+				return value[comparator] == attrValue[comparator];
+			}
+		}
+		return value == attrValue;
+	}
 }

--- a/src/view/items/element/specials/Option.js
+++ b/src/view/items/element/specials/Option.js
@@ -53,14 +53,14 @@ export default class Option extends Element {
 
 		const selectValue = this.select.getAttribute( 'value' );
 
-		if ( selectValue == optionValue ) {
+		if ( this.select.isSelected( selectValue, optionValue ) ) {
 			return true;
 		}
 
 		if ( this.select.getAttribute( 'multiple' ) && isArray( selectValue ) ) {
 			let i = selectValue.length;
 			while ( i-- ) {
-				if ( selectValue[i] == optionValue ) {
+				if ( this.select.isSelected( selectValue[i], optionValue ) ) {
 					return true;
 				}
 			}

--- a/src/view/items/element/specials/Option.js
+++ b/src/view/items/element/specials/Option.js
@@ -53,14 +53,14 @@ export default class Option extends Element {
 
 		const selectValue = this.select.getAttribute( 'value' );
 
-		if ( this.select.isSelected( selectValue, optionValue ) ) {
+		if ( this.select.compare( selectValue, optionValue ) ) {
 			return true;
 		}
 
 		if ( this.select.getAttribute( 'multiple' ) && isArray( selectValue ) ) {
 			let i = selectValue.length;
 			while ( i-- ) {
-				if ( this.select.isSelected( selectValue[i], optionValue ) ) {
+				if ( this.select.compare( selectValue[i], optionValue ) ) {
 					return true;
 				}
 			}

--- a/src/view/items/element/specials/Select.js
+++ b/src/view/items/element/specials/Select.js
@@ -2,13 +2,6 @@ import Element from '../../Element';
 import { toArray } from '../../../../utils/array';
 import getSelectedOptions from '../../../../utils/getSelectedOptions';
 
-function valueContains ( selectValue, optionValue ) {
-	let i = selectValue.length;
-	while ( i-- ) {
-		if ( selectValue[i] == optionValue ) return true;
-	}
-}
-
 export default class Select extends Element {
 	constructor ( options ) {
 		super( options );
@@ -65,8 +58,15 @@ export default class Select extends Element {
 			let optionWasSelected;
 
 			options.forEach( o => {
+				let shouldSelect = false;
 				const optionValue = o._ractive ? o._ractive.value : o.value;
-				const shouldSelect = this.compare(optionValue, selectValue);
+				const isMultiple = this.getAttribute( 'multiple' );
+
+				if (isMultiple) {
+					shouldSelect = this.valueContains ( selectValue, optionValue );
+				} else {
+					shouldSelect = this.compare(optionValue, selectValue);
+				}
 
 				if ( shouldSelect ) {
 					optionWasSelected = true;
@@ -88,13 +88,14 @@ export default class Select extends Element {
 			this.binding.forceUpdate();
 		}
 	}
-	compare (optionValue, selectValue) {
-		const isMultiple = this.getAttribute( 'multiple' );
-		const comparator = this.getAttribute( 'value-comparator' );
-
-		if (isMultiple) {
-			return valueContains( selectValue, optionValue );
+	valueContains ( selectValue, optionValue ) {
+		let i = selectValue.length;
+		while ( i-- ) {
+			if ( this.compare( optionValue, selectValue[i] ) ) return true;
 		}
+	}
+	compare (optionValue, selectValue) {
+		const comparator = this.getAttribute( 'value-comparator' );
 		if (comparator) {
 			if (typeof comparator === 'function') {
 				return comparator(selectValue, optionValue);

--- a/src/view/items/element/specials/Select.js
+++ b/src/view/items/element/specials/Select.js
@@ -65,7 +65,7 @@ export default class Select extends Element {
 			let optionWasSelected;
 
 			options.forEach( o => {
-				const shouldSelect = this.isSelected(o, selectValue);
+				const shouldSelect = this.compare(o, selectValue);
 
 				if ( shouldSelect ) {
 					optionWasSelected = true;
@@ -87,7 +87,7 @@ export default class Select extends Element {
 			this.binding.forceUpdate();
 		}
 	}
-	isSelected (o, selectValue) {
+	compare (o, selectValue) {
 		const isMultiple = this.getAttribute( 'multiple' );
 		const comparator = this.getAttribute( 'value-comparator' );
 		const optionValue = o._ractive ? o._ractive.value : o.value;

--- a/src/view/items/element/specials/Select.js
+++ b/src/view/items/element/specials/Select.js
@@ -65,7 +65,8 @@ export default class Select extends Element {
 			let optionWasSelected;
 
 			options.forEach( o => {
-				const shouldSelect = this.compare(o, selectValue);
+				const optionValue = o._ractive ? o._ractive.value : o.value;
+				const shouldSelect = this.compare(optionValue, selectValue);
 
 				if ( shouldSelect ) {
 					optionWasSelected = true;
@@ -87,10 +88,10 @@ export default class Select extends Element {
 			this.binding.forceUpdate();
 		}
 	}
-	compare (o, selectValue) {
+	compare (optionValue, selectValue) {
 		const isMultiple = this.getAttribute( 'multiple' );
 		const comparator = this.getAttribute( 'value-comparator' );
-		const optionValue = o._ractive ? o._ractive.value : o.value;
+
 		if (isMultiple) {
 			return valueContains( selectValue, optionValue );
 		}
@@ -98,7 +99,9 @@ export default class Select extends Element {
 			if (typeof comparator === 'function') {
 				return comparator(selectValue, optionValue);
 			}
-			return selectValue[comparator] == optionValue[comparator];
+			if (selectValue && optionValue) {
+				return selectValue[comparator] == optionValue[comparator];
+			}
 		}
 		return selectValue == optionValue;
 	}

--- a/src/view/items/element/specials/Select.js
+++ b/src/view/items/element/specials/Select.js
@@ -65,8 +65,7 @@ export default class Select extends Element {
 			let optionWasSelected;
 
 			options.forEach( o => {
-				const optionValue = o._ractive ? o._ractive.value : o.value;
-				const shouldSelect = isMultiple ? valueContains( selectValue, optionValue ) : selectValue == optionValue;
+				const shouldSelect = this.isSelected(o, selectValue);
 
 				if ( shouldSelect ) {
 					optionWasSelected = true;
@@ -88,7 +87,21 @@ export default class Select extends Element {
 			this.binding.forceUpdate();
 		}
 	}
-
+	isSelected (o, selectValue) {
+		const isMultiple = this.getAttribute( 'multiple' );
+		const comparator = this.getAttribute( 'value-comparator' );
+		const optionValue = o._ractive ? o._ractive.value : o.value;
+		if (isMultiple) {
+			return valueContains( selectValue, optionValue );
+		}
+		if (comparator) {
+			if (typeof comparator === 'function') {
+				return comparator(selectValue, optionValue);
+			}
+			return selectValue[comparator] == optionValue[comparator];
+		}
+		return selectValue == optionValue;
+	}
 	update () {
 		super.update();
 		this.sync();

--- a/src/view/items/element/specials/Select.js
+++ b/src/view/items/element/specials/Select.js
@@ -58,15 +58,11 @@ export default class Select extends Element {
 			let optionWasSelected;
 
 			options.forEach( o => {
-				let shouldSelect = false;
 				const optionValue = o._ractive ? o._ractive.value : o.value;
 				const isMultiple = this.getAttribute( 'multiple' );
 
-				if (isMultiple) {
-					shouldSelect = this.valueContains ( selectValue, optionValue );
-				} else {
-					shouldSelect = this.compare(optionValue, selectValue);
-				}
+				let shouldSelect = isMultiple? this.valueContains( selectValue, optionValue )
+				                             : this.compare( optionValue, selectValue );
 
 				if ( shouldSelect ) {
 					optionWasSelected = true;
@@ -96,11 +92,11 @@ export default class Select extends Element {
 	}
 	compare (optionValue, selectValue) {
 		const comparator = this.getAttribute( 'value-comparator' );
-		if (comparator) {
+		if ( comparator ) {
 			if (typeof comparator === 'function') {
-				return comparator(selectValue, optionValue);
+				return comparator( selectValue, optionValue );
 			}
-			if (selectValue && optionValue) {
+			if ( selectValue && optionValue ) {
 				return selectValue[comparator] == optionValue[comparator];
 			}
 		}

--- a/test/browser-tests/select.js
+++ b/test/browser-tests/select.js
@@ -4,6 +4,52 @@ import { initModule } from './test-config';
 export default function() {
 	initModule( 'select.js' );
 
+	test( 'Use as a string to compare', t => {
+		const ractive = new Ractive({
+			el: fixture,
+			comparatorFn: function(option, value) {
+				return option.id == value.id;
+			},
+			template: `
+				<select id="select" value-comparator="id" value="{{selected}}">
+					{{#options}}
+						<option value="{{.}}">{{.}}</option>
+					{{/options}}
+				</select>`
+		});
+
+		ractive.set({
+			selected: { id: 2 },
+			options: [ { id: 1 }, { id: 2 }, { id: 3 } ]
+		});
+
+		t.equal( ractive.get( 'selected.id' ), '2' );
+		t.equal( ractive.nodes.select.value, { id: 2 } );
+	});
+
+	test( 'Use as a function to compare', t => {
+		const ractive = new Ractive({
+			el: fixture,
+			comparatorFn: function(option, value) {
+				return option.id == value.id;
+			},
+			template: `
+				<select id="select" value-comparator="{{@ractive.comparatorFn}}" value="{{selected}}">
+					{{#options}}
+						<option value="{{.}}">{{.}}</option>
+					{{/options}}
+				</select>`
+		});
+
+		ractive.set({
+			selected: { id: 2 },
+			options: [ { id: 1 }, { id: 2 }, { id: 3 } ]
+		});
+
+		t.equal( ractive.get( 'selected.id' ), '2' );
+		t.equal( ractive.nodes.select.value, { id: 2 } );
+	});
+
 	test( 'If a select\'s value attribute is updated at the same time as the available options, the correct option will be selected', t => {
 		const ractive = new Ractive({
 			el: fixture,

--- a/test/browser-tests/select.js
+++ b/test/browser-tests/select.js
@@ -34,7 +34,7 @@ export default function() {
 				return option.id == value.id;
 			},
 			template: `
-				<select id="select" value-comparator="{{@ractive.comparatorFn}}" value="{{selected}}">
+				<select id="select" value-comparator="{{@this.comparatorFn}}" value="{{selected}}">
 					{{#options}}
 						<option value="{{.}}">{{.}}</option>
 					{{/options}}

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -219,6 +219,125 @@ export default function() {
 		t.ok( !ractive.nodes.green.checked );
 	});
 
+	test( 'Checkbox Name bindings use property attributes to determined if checked or not', t => {
+		let ractive = new Ractive({
+			el: fixture,
+			data: {
+				selected: [ { id: 'green' } ],
+				colors: [ { id: 'red', name: 'Red' }, { id: 'green', name: 'Green' }, { id: 'blue', name: 'Blue' } ]
+			},
+			template: '{{#each colors}}<input id="{{id}}" type="checkbox" name="{{selected}}" value-comparator="id" value="{{.}}">{{/each}}'
+		});
+		t.deepEqual( ractive.get( 'selected' ), [ { id: 'green' } ] );
+		t.ok( !ractive.nodes.red.checked );
+		t.ok( !ractive.nodes.blue.checked );
+		t.ok( ractive.nodes.green.checked );
+
+		ractive = new Ractive({
+			el: fixture,
+			data: {
+				selected: [ { id: 'green' }, { id: 'red' } ],
+				colors: [ { id: 'red', name: 'Red' }, { id: 'green', name: 'Green' }, { id: 'blue', name: 'Blue' } ]
+			},
+			template: '{{#each colors}}<input id="{{id}}" type="checkbox" name="{{selected}}" value-comparator="id" value="{{.}}">{{/each}}'
+		});
+		t.deepEqual( ractive.get( 'selected' ), [ { id: 'green' }, { id: 'red' } ] );
+		t.ok( ractive.nodes.red.checked );
+		t.ok( !ractive.nodes.blue.checked );
+		t.ok( ractive.nodes.green.checked );
+
+		// using function as comparator
+		ractive = new Ractive({
+			el: fixture,
+			comparatorFn: function( v, a ) {
+				return v.id === a.id;
+			},
+			data: {
+				selected: [ { id: 'green' } ],
+				colors: [ { id: 'red', name: 'Red' }, { id: 'green', name: 'Green' }, { id: 'blue', name: 'Blue' } ]
+			},
+			template: '{{#each colors}}<input id="{{id}}" type="checkbox" name="{{selected}}" value-comparator="{{@this.comparatorFn}}" value="{{.}}">{{/each}}'
+		});
+		t.deepEqual( ractive.get( 'selected' ), [ { id: 'green' } ] );
+		t.ok( !ractive.nodes.red.checked );
+		t.ok( !ractive.nodes.blue.checked );
+		t.ok( ractive.nodes.green.checked );
+
+		ractive = new Ractive({
+			el: fixture,
+			data: {
+				selected: [],
+				colors: [ { id: 'red', name: 'Red' }, { id: 'green', name: 'Green' }, { id: 'blue', name: 'Blue' } ]
+			},
+			template: '{{#each colors}}<input id="{{id}}" type="checkbox" name="{{selected}}" value-comparator="id" value="{{.}}">{{/each}}'
+		});
+		t.deepEqual( ractive.get( 'selected' ), [] );
+		t.ok( !ractive.nodes.red.checked );
+		t.ok( !ractive.nodes.blue.checked );
+		t.ok( !ractive.nodes.green.checked );
+
+		fire( ractive.find( '#blue' ), 'click' );
+
+		t.deepEqual( ractive.get( 'selected' ), [ { id: 'blue', name: "Blue" } ] );
+
+		fire( ractive.find( '#green' ), 'click' );
+
+		t.deepEqual( ractive.get( 'selected' ), [ { id: 'blue', name: "Blue" }, { id: 'green', name: 'Green'} ] );
+	});
+
+	test( 'Radio Name bindings use value-comparator to determined if checked or not', t => {
+		let ractive = new Ractive({
+			el: fixture,
+			data: {
+				selected: { id: 'green' },
+				colors: [ { id: 'red', name: 'Red' }, { id: 'green', name: 'Green' }, { id: 'blue', name: 'Blue' } ]
+			},
+			template: '{{#each colors}}<input id="{{id}}" type="radio" name="{{selected}}" value-comparator="id" value="{{.}}">{{/each}}'
+		});
+		t.deepEqual( ractive.get( 'selected' ), { id: 'green' } );
+		t.ok( !ractive.nodes.red.checked );
+		t.ok( !ractive.nodes.blue.checked );
+		t.ok( ractive.nodes.green.checked );
+
+		// using function as comparator
+		ractive = new Ractive({
+			el: fixture,
+			comparatorFn: function( v, a ) {
+				return v.id === a.id;
+			},
+			data: {
+				selected: { id: 'green' },
+				colors: [ { id: 'red', name: 'Red' }, { id: 'green', name: 'Green' }, { id: 'blue', name: 'Blue' } ]
+			},
+			template: '{{#each colors}}<input id="{{id}}" type="radio" name="{{selected}}" value-comparator="{{@this.comparatorFn}}" value="{{.}}">{{/each}}'
+		});
+		t.deepEqual( ractive.get( 'selected' ), { id: 'green' } );
+		t.ok( !ractive.nodes.red.checked );
+		t.ok( !ractive.nodes.blue.checked );
+		t.ok( ractive.nodes.green.checked );
+
+		ractive = new Ractive({
+			el: fixture,
+			data: {
+				selected: undefined,
+				colors: [ { id: 'red', name: 'Red' }, { id: 'green', name: 'Green' }, { id: 'blue', name: 'Blue' } ]
+			},
+			template: '{{#each colors}}<input id="{{id}}" type="radio" name="{{selected}}" value-comparator="id" value="{{.}}">{{/each}}'
+		});
+		t.deepEqual( ractive.get( 'selected' ), undefined );
+		t.ok( !ractive.nodes.red.checked );
+		t.ok( !ractive.nodes.blue.checked );
+		t.ok( !ractive.nodes.green.checked );
+
+		fire( ractive.find( '#blue' ), 'click' );
+
+		t.deepEqual( ractive.get( 'selected' ), { id: 'blue', name: "Blue" } );
+
+		fire( ractive.find( '#green' ), 'click' );
+
+		t.deepEqual( ractive.get( 'selected' ), { id: 'green', name: 'Green'} );
+	});
+
 	test( 'The model overrides which checkbox inputs are checked at render time', t => {
 		const ractive = new Ractive({
 			el: fixture,


### PR DESCRIPTION
**NOT READY TO MERGE**
It's just to see if that's the right way to go. It needs to work for radios and checkboxes too.

**Description of the pull request:**
This tries to fix the problem when binding objects in your <select> and the two objects that it compares are different using a simple '==' but for the developer perspective they are the same. So the developer is able to define `<select value-comparator=X">`, X being a string or a function reference to compare the two objects.

**Fixes the following issues:**
#2545

**Is breaking:**
NO
