### PR TITLE
Fix #2551

### DIFF
--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -221,7 +221,7 @@ function updateInlineStyle () {
 function updateClassName () {
 	const value = readClass( safeToStringValue( this.getValue() ) );
 	const attr = readClass( this.node.className );
-	const prev = this.previous || [];
+	const prev = this.previous || attr.slice( 0 );
 
 	let i = 0;
 	while ( i < value.length ) {

--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -238,7 +238,11 @@ function updateClassName () {
 		}
 	}
 
-	this.node.className = attr.join( ' ' );
+	const className = attr.join( ' ' );
+
+	if ( className !== this.node.className ) {
+		this.node.className = className;
+	}
 
 	this.previous = value;
 }

--- a/test/browser-tests/render/enhance.js
+++ b/test/browser-tests/render/enhance.js
@@ -128,6 +128,20 @@ export default function() {
 		t.ok( !button.disabled );
 	});
 
+	test( 'redundant classes are removed', t => {
+		fixture.innerHTML = '<div class="someCls someClsToRemove">foo</div>';
+		const div = fixture.querySelector( 'div' );
+
+		const ractive = new Ractive({
+			el: fixture,
+			template: '<div class="someCls someClsToAdd">foo</div>',
+			enhance: true
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div class="someCls someClsToAdd">foo</div>' );
+		t.strictEqual( div, ractive.find( 'div' ) );
+	});
+
 	test( 'conditional sections inherit existing DOM', t => {
 		fixture.innerHTML = '<p></p>';
 		const p = fixture.querySelector( 'p' );


### PR DESCRIPTION
**Description of the pull request:**
This pull request fixes #2551. As I said [here](https://github.com/ractivejs/ractive/issues/2551#issuecomment-222802281), using a copy of `attr` instead of an empty array ensures all redundant classes are removed.

**Fixes the following issues:**
#2551

**Is breaking:**
It shouldn't break anything.
