### PR TITLE
Make sure reference expressions capture - #2550

### DIFF
--- a/src/view/resolvers/ReferenceExpressionProxy.js
+++ b/src/view/resolvers/ReferenceExpressionProxy.js
@@ -141,8 +141,8 @@ export default class ReferenceExpressionProxy extends Model {
 		this.bubble();
 	}
 
-	get () {
-		return this.model ? this.model.get() : undefined;
+	get ( shouldCapture ) {
+		return this.model ? this.model.get( shouldCapture ) : undefined;
 	}
 
 	// indirect two-way bindings

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -728,6 +728,27 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '-ok' );
 	});
 
+	test( 'reference expression proxy should play nicely with capture (#2550)', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#with wat[idx]}}{{ident(.)}}{{/with}}`,
+			computed: {
+				wat() {
+					return this.get('arr');
+				}
+			},
+			data: {
+				arr: [ 1, 2, 3 ],
+				idx: 0,
+				ident( v ) { return v; }
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, '1' );
+		r.set( 'arr', [ 4, 5, 6 ]);
+		t.htmlEqual( fixture.innerHTML, '4' );
+	});
+
 	test( 'computations should not recompute when spliced out', t => {
 		let count = 0;
 


### PR DESCRIPTION
**Description of the pull request:**
In certain interesting scenarios, a reference expression proxy can become a model in another computation, notably with the reference expression is used as context. Turns out reference expressions where not paying attention to capture flags, which makes for sadness when dependencies in the context update. This just adds the capture flag on `ReferenceExpressionProxy.get` to pass along.

**Fixes the following issues:**
#2550

**Is breaking:**
Nerp.

**Reviewers**
@JonDum, if you have a bit of time, could you try this out? I'mma merge it once it goes green, but I want to be sure it handles your more complex case too.