### PR TITLE
Add a temporary extra runloop layer to handle fragments that trigger an update on themselves - #2554

### DIFF
--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -38,6 +38,18 @@ const runloop = {
 		addToArray( batch.fragments, fragment );
 	},
 
+	// TODO: come up with a better way to handle fragments that trigger their own update
+	addFragmentToRoot ( fragment ) {
+		if ( !batch ) return;
+
+		let b = batch;
+		while ( b.previousBatch ) {
+			b = b.previousBatch;
+		}
+
+		addToArray( b.fragments, fragment );
+	},
+
 	addInstance ( instance ) {
 		if ( batch ) addToArray( batch.ractives, instance );
 	},

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -305,11 +305,15 @@ export default class Fragment {
 	}
 
 	update () {
-		if ( this.dirty && !this.updating ) {
-			this.dirty = false;
-			this.updating = true;
-			this.items.forEach( update );
-			this.updating = false;
+		if ( this.dirty ) {
+			if ( !this.updating ) {
+				this.dirty = false;
+				this.updating = true;
+				this.items.forEach( update );
+				this.updating = false;
+			} else if ( this.isRoot ) {
+				runloop.addFragmentToRoot( this );
+			}
 		}
 	}
 

--- a/test/browser-tests/render/misc.js
+++ b/test/browser-tests/render/misc.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import { svg } from '../../config/environment';
 import { initModule } from '../test-config';
 
-/* globals window, document, navigator */
+/* globals window, document */
 
 export default function() {
 	initModule( 'render/misc' );
@@ -282,6 +282,34 @@ export default function() {
 
 		r.set( 'bar', [] );
 		r.set( 'foo', 2 );
+	});
+
+	test( 'instances that are made dirty while updating should not get stuck (#2554)', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `<span>{{bar}}</span>{{#if foo}}<input type="checkbox" checked="{{baf}}" />{{bar}}{{/if}}`,
+			computed: {
+				foo () {
+					this.set( 'bar', 'yep' );
+					return this.get( 'cond' );
+				},
+				baf () {
+					this.set( 'bar', 'hmm' );
+					return this.get( 'cond' );
+				}
+			},
+			data: {
+				cond: false,
+				bar: '???'
+			}
+		});
+
+		const span = r.find( 'span' );
+
+		t.htmlEqual( span.innerHTML, 'yep' );
+		r.set( 'cond', true );
+		r.set( 'bar', 'y' );
+		t.htmlEqual( span.innerHTML, 'y' );
 	});
 
 	test( 'space entity refs should not be consumed during trimming (#2327)', t => {


### PR DESCRIPTION
**Description of the pull request:**
In certain circumstances, bindings and computations can conspire to cause a fragment to be updated while it is updating in a nested batch, which causes issues. This adds a handler that schedules the fragment to be updated again in the base batch so that it doesn't get out of sync. This is hopefully temporary measure, as I think I can refactor the runloop some to simplify this and the other special handling for self-updating observers, bindings, and computations.

**Fixes the following issues:**
#2554

**Is breaking:**
No.