### PR TITLE
Don't export attributes that are namespace definitions

### DIFF
--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -4,6 +4,7 @@ import { arrayContains } from '../../../../utils/array';
 import { isArray } from '../../../../utils/is';
 import noop from '../../../../utils/noop';
 import { readStyle, readClass } from '../../../helpers/specialAttrs';
+import { xmlns } from '../../../../config/namespaces';
 
 const textTypes = [ undefined, 'text', 'search', 'url', 'email', 'hidden', 'password', 'search', 'reset', 'submit' ];
 
@@ -287,5 +288,8 @@ function updateAttribute () {
 }
 
 function updateNamespacedAttribute () {
-	this.node.setAttributeNS( this.namespace, this.name.slice( this.name.indexOf( ':' ) + 1 ), safeToStringValue( this.getString() ) );
+	// don't output xmlns attrs
+	if ( this.namespace !== xmlns ) {
+		this.node.setAttributeNS( this.namespace, this.name.slice( this.name.indexOf( ':' ) + 1 ), safeToStringValue( this.getString() ) );
+	}
 }

--- a/test/browser-tests/attributes.js
+++ b/test/browser-tests/attributes.js
@@ -120,4 +120,13 @@ export default function () {
 
 		t.equal( r.toHTML(), `<span style="text-decoration: underline; color: green; font-size: 12pt;"></span><span style="text-decoration: underline; font-size: 12pt;"></span>` );
 	});
+
+	test( 'attribute namespaces declared next to the attribute should render (#2560)', t => {
+		new Ractive({
+			el: fixture,
+			template: '<svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://foo.com/bar#baz" /></svg>'
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://foo.com/bar#baz"></use></svg>' );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
Currently if you drop an xmlns:whatever in an element, the whatever portion will also show up as a regular attribute. This checks for the xmlns namespace and skips popping those out into the dom.

I've no idea why behavior would be different in a fiddle than run locally. Maybe something to do with jsfiddle declarations?

**Fixes the following issues:**
sort #2560

**Is breaking:**
Shouldn't be.

**Reviewers:**
Anyone familiar with xmlns?