### PR TITLE
Notify upstream during shuffle if array length changes - #2541

### DIFF
--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -177,6 +177,9 @@ export default class Model {
 		this.notifyUpstream();
 
 		originatingModel = previousOriginatingModel;
+
+		// keep track of array length
+		if ( isArray( value ) ) this.length = value.length;
 	}
 
 	clearUnresolveds ( specificKey ) {
@@ -365,6 +368,9 @@ export default class Model {
 			// make sure the wrapper stays in sync
 			if ( old !== value || this.rewrap ) this.adapt();
 
+			// keep track of array lengths
+			if ( isArray( value ) ) this.length = value.length;
+
 			this.children.forEach( mark );
 
 			this.deps.forEach( handleChange );
@@ -485,6 +491,7 @@ export default class Model {
 			if ( dep.shuffle ) dep.shuffle( newIndices );
 		});
 
+		const upstream = this.length !== this.value.length;
 		this.updateKeypathDependants();
 		this.mark();
 
@@ -492,6 +499,9 @@ export default class Model {
 		this.deps.forEach( dep => {
 			if ( !dep.shuffle ) dep.handleChange();
 		});
+
+		// if the length has changed, notify upstream
+		if ( upstream ) this.notifyUpstream();
 	}
 
 	shuffled () {

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -772,4 +772,19 @@ export default function() {
 		r.set( 'foo', [] );
 		t.equal( count, 3 );
 	});
+
+	test( 'computations with a reference expression should update with the full reference too', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{foo[v].wat + '!'}}`,
+			data: {
+				foo: { bar: { wat: 'nope' } },
+				v: 'bar'
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'nope!' );
+		r.set( 'foo.bar.wat', 'yep' );
+		t.htmlEqual( fixture.innerHTML, 'yep!' );
+	});
 }

--- a/test/browser-tests/shuffling.js
+++ b/test/browser-tests/shuffling.js
@@ -254,6 +254,21 @@ export default function() {
 		for ( let i = 0; i < spans.length; i++ ) t.equal( spans[i].getAttribute( 'data-wat' ), spans[i].innerHTML );
 	});
 
+	test( 'computations with reference expressions that resolve to an array length should be marked on shuffle (#2541)', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: '{{foo[v].length + 1}}',
+			data: {
+				foo: { bar: [ 1, 2 ] },
+				v: 'bar'
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, '3' );
+		r.push( 'foo.bar', 3 );
+		t.htmlEqual( fixture.innerHTML, '4' );
+	});
+
 	// TODO reinstate this in some form. Commented out for purposes of #1740
 	// test( `Array shuffling only adjusts context and doesn't tear stuff down to rebuild it`, t => {
 	// 	let ractive = new Ractive({


### PR DESCRIPTION
**Description of the pull request:**
In certain scenarios where array length is modified by a shuffle, things not _directly_ referencing the length don't get notified that the array has changed, and thus, do not update. This adds tracking for array length (see below) and a check to see if length changes at shuffle in order to notify upstream as `applyValue` would.

For the array length tracking, I plan to use this to allow merging an array into itself. This would make grabbing an array, modifying it in some way _without_ the array wrapper, and getting the changes back into Ractive much simpler. The length is needed to see which children are actually relevant to the merge, since, as it's the same array, there's no way to compare the new and old lengths to build a newIndices object.

**Fixes the following issues:**
#2541

**Is breaking:**
Nerp.
