### PR TITLE
Use a reference resolver to allow observers on mappings to be initially ambiguous - #2142

### DIFF
--- a/test/browser-tests/components/data-and-mappings.js
+++ b/test/browser-tests/components/data-and-mappings.js
@@ -1260,4 +1260,25 @@ export default function() {
 		r.set( 'thing', 'hey' );
 		t.htmlEqual( fixture.innerHTML, 'hey is yep' );
 	});
+
+	test( `observers and ambiguous mappings play nicely together (#2142)`, t => {
+		t.expect( 2 );
+
+		const cmp = Ractive.extend({
+			template: '{{test}}',
+			onrender () {
+				this.observe( 'test', () => t.ok( true ), { init: false } );
+			}
+		});
+
+		const r = new Ractive({
+			el: fixture,
+			template: '{{#with dummy}}<cmp />{{/with}}',
+			data: { dummy: { x: 1 } },
+			components: { cmp }
+		});
+
+		r.set( 'test', 'foo' );
+		t.htmlEqual( fixture.innerHTML, 'foo' );
+	});
 }

--- a/test/browser-tests/components/data-and-mappings.js
+++ b/test/browser-tests/components/data-and-mappings.js
@@ -1262,12 +1262,12 @@ export default function() {
 	});
 
 	test( `observers and ambiguous mappings play nicely together (#2142)`, t => {
-		t.expect( 2 );
+		t.expect( 3 );
 
 		const cmp = Ractive.extend({
 			template: '{{test}}',
 			onrender () {
-				this.observe( 'test', () => t.ok( true ), { init: false } );
+				this.observe( 'test', ( n, o ) => t.equal( n, 'foo' ) || t.equal( o, undefined ), { init: false } );
 			}
 		});
 


### PR DESCRIPTION
**Description of the pull request:**
Instead of making observers automatically branch to get a model upon creation, this lets them create a resolver to wait around on a model to grow organically (possibly grass-fed and shade-grown) through the unresolved process.

**Fixes the following issues:**
fixes #2142 

**Is breaking:**
Don't think so.