### PR TITLE
Check check for binding updates before the observer phase to unlock the attr - #2427

### DIFF
--- a/src/view/items/element/binding/Binding.js
+++ b/src/view/items/element/binding/Binding.js
@@ -74,7 +74,11 @@ export default class Binding {
 		runloop.start( this.root );
 		this.attribute.locked = true;
 		this.model.set( this.getValue() );
-		runloop.scheduleTask( () => this.attribute.locked = false );
+
+		// if the value changes before observers fire, unlock to be updatable cause something weird and potentially freezy is up
+		if ( this.model.get() !== this.getValue() ) this.attribute.locked = false;
+		else runloop.scheduleTask( () => this.attribute.locked = false );
+
 		runloop.end();
 	}
 

--- a/src/view/items/element/binding/Binding.js
+++ b/src/view/items/element/binding/Binding.js
@@ -71,12 +71,14 @@ export default class Binding {
 	}
 
 	handleChange () {
+		const value = this.getValue();
+
 		runloop.start( this.root );
 		this.attribute.locked = true;
-		this.model.set( this.getValue() );
+		this.model.set( value );
 
 		// if the value changes before observers fire, unlock to be updatable cause something weird and potentially freezy is up
-		if ( this.model.get() !== this.getValue() ) this.attribute.locked = false;
+		if ( this.model.get() !== value ) this.attribute.locked = false;
 		else runloop.scheduleTask( () => this.attribute.locked = false );
 
 		runloop.end();

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -421,6 +421,31 @@ export default function() {
 		t.ok( !inputs[1].checked );
 	});
 
+
+	test (`bindings that trigger their own immediate update via computation should not get stuck (#2427)`, t => {
+		const r = new Ractive({
+			el: fixture,
+			data: {
+				list: [ { v: 'a', o: 0 }, { v: 'a', o: 1 }, { v: 'b', o: 2 }, { v: 'c', o: 3 } ]
+			},
+			computed: {
+				rows() {
+					var list = this.get( 'list' ).slice(0);
+					return list.sort( ( a, b ) => a.v.localeCompare( b.v ) ).map( o => o.o );
+				}
+			},
+			template: `{{#each rows}}{{#with list[.]}}<input value="{{.v}}" />{{/with}}{{/each}}`
+		});
+		const inputs = r.findAll( 'input' );
+		inputs[0].value = 'z';
+		fire( inputs[0], 'change' );
+
+		t.equal( inputs[0].value, 'a' );
+		t.equal( inputs[1].value, 'b' );
+		t.equal( inputs[2].value, 'c' );
+		t.equal( inputs[3].value, 'z' );
+	});
+
 	test( 'Post-blur validation works (#771)', t => {
 		const ractive = new Ractive({
 			el: fixture,


### PR DESCRIPTION
**Description of the pull request:**
This is a weird one that is caused by behavior that should probably be dropped since laziness is available to help with input validation. At any rate, this checks the see if a binding's model changes to something not set immediately after it is set and before any observers get a chance to fire. If the value is not the same, then the attribute is unlocked so that the binding doesn't get stuck on the old value.

One side effect is that as soon as you press a key that triggers a re-sort on the underlying list, your current box is shuffled off and the new one (actually the same one with a new value, but you get the idea) is sitting there with focus. I think that's better behavior than getting one value stuck in the old box while the new one appears correctly in the new destination. Again, `lazy` can resolve that entirely. 

A further potential side-effect would be that binding to a computation that morphs inputs would get cursor resets while typing. And again, I believe `lazy` is the solution.

Thoughts?

**Fixes the following issues:**
#2427

**Is breaking:**
Maybe? It wasn't really well-defined behavior to begin with...

**Reviewers:**
@martypdx @fskreuz please