### PR TITLE
Make sure observers on implicit mappings resolve correctly - #2572

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -67,9 +67,12 @@ function createObserver ( ractive, keypath, callback, options ) {
 		// if not the root model itself, check if viewmodel has key.
 		if ( key !== '' && !viewmodel.has( key ) ) {
 			// if this is an inline component, we may need to create an implicit mapping
-			if ( ractive.component ) {
+			if ( ractive.component && !ractive.isolated ) {
 				model = resolveReference( ractive.component.parentFragment, key );
-				if ( model ) viewmodel.map( key, model );
+				if ( model ) {
+					viewmodel.map( key, model );
+					model = viewmodel.joinAll( keys );
+				}
 			}
 		} else {
 			model = viewmodel.joinAll( keys );

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -1088,4 +1088,33 @@ export default function() {
 
 		t.equal( ractive._observers.length, 0 );
 	});
+
+	test( 'observers on implicit mappings should resolve correctly (#2572)', t => {
+		t.expect( 2 );
+
+		let count = 0;
+		const cmp = Ractive.extend({
+			oninit () {
+				this.observe( this.get( 'target' ), n => {
+					if ( count ) {
+						t.equal( n, 1 );
+					} else {
+						count++;
+						t.equal( n, 0 );
+					}
+				});
+			}
+		});
+
+		const r = new Ractive({
+			el: fixture,
+			template: '<cmp target="foo.bar" />',
+			data: {
+				foo: { bar: 0 }
+			},
+			components: { cmp }
+		});
+
+		r.add( 'foo.bar' );
+	});
 }

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -1117,4 +1117,25 @@ export default function() {
 
 		r.add( 'foo.bar' );
 	});
+
+	test( 'observing in an isolated component should not create implicit mappings', t => {
+		t.expect( 0 );
+
+		const cmp = Ractive.extend({
+			oninit () {
+				this.observe( 'foo.bar', () => t.ok( false ) );
+			},
+			isolated: true
+		});
+
+		const r = new Ractive({
+			el: fixture,
+			data: {
+				foo: { bar: 0 }
+			},
+			components: { cmp }
+		});
+
+		r.add( 'foo.bar' );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
Missed a step when handling ambiguity for mapped observers. This adds back the join on implicitly mapped values that are being observer and also plugs a hole that would allow implicit mappings in isolated components if you used an observer.

**Fixes the following issues:**
#2572

**Is breaking:**
Nope.