### PR TITLE
Transition regression fixes

### DIFF
--- a/src/Ractive/prototype/transition.js
+++ b/src/Ractive/prototype/transition.js
@@ -30,8 +30,12 @@ export default function Ractive$transition ( name, node, params ) {
 	params = params || {};
 	const owner = node._ractive.proxy;
 	const transition = new Transition({ owner, parentFragment: owner.parentFragment, name, params });
+	transition.bind();
+
 	const promise = runloop.start( this, true );
 	runloop.registerTransition( transition );
 	runloop.end();
+
+	promise.then( () => transition.unbind() );
 	return promise;
 }

--- a/src/global/TransitionManager.js
+++ b/src/global/TransitionManager.js
@@ -46,6 +46,10 @@ export default class TransitionManager {
 		this.children.forEach( _detachNodes );
 	}
 
+	ready () {
+		detachImmediate( this );
+	}
+
 	remove ( transition ) {
 		var list = transition.isIntro ? this.intros : this.outros;
 		removeFromArray( list, transition );
@@ -53,7 +57,7 @@ export default class TransitionManager {
 	}
 
 	start () {
-		detachImmediate( this );
+		this.children.forEach( c => c.start() );
 		this.intros.concat( this.outros ).forEach( t => t.start() );
 		this.ready = true;
 		check( this );

--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -31,6 +31,9 @@ const runloop = {
 
 	end () {
 		flushChanges();
+
+		if ( !batch.previousBatch ) batch.transitionManager.start();
+
 		batch = batch.previousBatch;
 	},
 
@@ -127,7 +130,7 @@ function flushChanges () {
 		ractive.viewmodel.changes = {};
 	}
 
-	batch.transitionManager.start();
+	batch.transitionManager.ready();
 
 	which = batch.deferredObservers;
 	batch.deferredObservers = [];

--- a/src/shared/getNewIndices.js
+++ b/src/shared/getNewIndices.js
@@ -69,6 +69,8 @@ function getSpliceEquivalent ( length, methodName, args ) {
 				args[0] = length + Math.max( args[0], -length );
 			}
 
+			if ( args[0] === undefined ) args[0] = 0;
+
 			while ( args.length < 2 ) {
 				args.push( length - args[0] );
 			}

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -189,7 +189,7 @@ export default class Fragment {
 	findRepeatingFragment () {
 		let fragment = this;
 		// TODO better check than fragment.parent.iterations
-		while ( fragment.parent && !fragment.isIteration ) {
+		while ( ( fragment.parent || fragment.componentParent ) && !fragment.isIteration ) {
 			fragment = fragment.parent || fragment.componentParent;
 		}
 

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -275,7 +275,7 @@ export default class Fragment {
 	}
 
 	resolve ( template, callback ) {
-		if ( !this.context ) {
+		if ( !this.context && this.parent.resolve ) {
 			return this.parent.resolve( template, callback );
 		}
 

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -124,7 +124,8 @@ export default class Element extends Item {
 	}
 
 	detach () {
-		this.attributes.forEach( unrender );
+		// if this element is no longer rendered, the transitinos are complete and the attributes can be torn down
+		if ( !this.rendered ) this.attributes.forEach( unrender );
 
 		return detachNode( this.node );
 	}

--- a/src/view/items/element/Transition.js
+++ b/src/view/items/element/Transition.js
@@ -33,69 +33,7 @@ export default class Transition {
 		this.ractive = this.owner.ractive;
 		this.template = options.template;
 		this.parentFragment = options.parentFragment;
-
-		if ( options.template ) {
-			if ( options.template.v === 't0' || options.template.v == 't1' ) this.element._introTransition = this;
-			if ( options.template.v === 't0' || options.template.v == 't2' ) this.element._outroTransition = this;
-			this.eventName = names[ options.template.v ];
-		}
-
-		const ractive = this.owner.ractive;
-
-		if ( options.name ) {
-			this.name = options.name;
-		} else {
-			let name = options.template.f;
-			if ( typeof name.n === 'string' ) name = name.n;
-
-			if ( typeof name !== 'string' ) {
-				const fragment = new Fragment({
-					owner: this.owner,
-					template: name.n
-				}).bind(); // TODO need a way to capture values without bind()
-
-				name = fragment.toString();
-				fragment.unbind();
-
-				if ( name === '' ) {
-					// empty string okay, just no transition
-					return;
-				}
-			}
-
-			this.name = name;
-		}
-
-		if ( options.params ) {
-			this.params = options.params;
-		} else {
-			if ( options.template.f.a && !options.template.f.a.s ) {
-				this.params = options.template.f.a;
-			}
-
-			else if ( options.template.f.d ) {
-				// TODO is there a way to interpret dynamic arguments without all the
-				// 'dependency thrashing'?
-				const fragment = new Fragment({
-					owner: this.owner,
-					template: options.template.f.d
-				}).bind();
-
-				this.params = fragment.getArgsList();
-				fragment.unbind();
-			}
-		}
-
-		if ( typeof this.name === 'function' ) {
-			this._fn = this.name;
-			this.name = this._fn.name;
-		} else {
-			this._fn = findInViewHierarchy( 'transitions', ractive, this.name );
-		}
-
-		if ( !this._fn ) {
-			warnOnceIfDebug( missingPlugin( this.name, 'transition' ), { ractive });
-		}
+		this.options = options;
 	}
 
 	animateStyle ( style, value, options ) {
@@ -176,8 +114,72 @@ export default class Transition {
 	}
 
 	bind () {
+		const options = this.options
+		if ( options.template ) {
+			if ( options.template.v === 't0' || options.template.v == 't1' ) this.element._introTransition = this;
+			if ( options.template.v === 't0' || options.template.v == 't2' ) this.element._outroTransition = this;
+			this.eventName = names[ options.template.v ];
+		}
+
+		const ractive = this.owner.ractive;
+
+		if ( options.name ) {
+			this.name = options.name;
+		} else {
+			let name = options.template.f;
+			if ( typeof name.n === 'string' ) name = name.n;
+
+			if ( typeof name !== 'string' ) {
+				const fragment = new Fragment({
+					owner: this.owner,
+					template: name.n
+				}).bind(); // TODO need a way to capture values without bind()
+
+				name = fragment.toString();
+				fragment.unbind();
+
+				if ( name === '' ) {
+					// empty string okay, just no transition
+					return;
+				}
+			}
+
+			this.name = name;
+		}
+
+		if ( options.params ) {
+			this.params = options.params;
+		} else {
+			if ( options.template.f.a && !options.template.f.a.s ) {
+				this.params = options.template.f.a;
+			}
+
+			else if ( options.template.f.d ) {
+				// TODO is there a way to interpret dynamic arguments without all the
+				// 'dependency thrashing'?
+				const fragment = new Fragment({
+					owner: this.owner,
+					template: options.template.f.d
+				}).bind();
+
+				this.params = fragment.getArgsList();
+				fragment.unbind();
+			}
+		}
+
+		if ( typeof this.name === 'function' ) {
+			this._fn = this.name;
+			this.name = this._fn.name;
+		} else {
+			this._fn = findInViewHierarchy( 'transitions', ractive, this.name );
+		}
+
+		if ( !this._fn ) {
+			warnOnceIfDebug( missingPlugin( this.name, 'transition' ), { ractive });
+		}
+
 		// TODO: dry up after deprecation is done
-		if ( this.template.f.a && this.template.f.a.s ) {
+		if ( options.template && this.template.f.a && this.template.f.a.s ) {
 			this.resolvers = [];
 			this.models = this.template.f.a.r.map( ( ref, i ) => {
 				let resolver;

--- a/test/browser-tests/methods/splice.js
+++ b/test/browser-tests/methods/splice.js
@@ -133,4 +133,17 @@ export default function() {
 		r.unshift( 'arr' );
 		fire( r.findAll( 'span' )[1], 'click' );
 	});
+
+	test( 'splicing with an undefined index should be equivalent to 0', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each arr}}{{.}}{{/each}}`,
+			data: { arr: [ 1, 2, 3, 4 ] }
+		});
+
+		r.splice( 'arr', undefined, 1 );
+		t.htmlEqual( fixture.innerHTML, '234' );
+		r.splice( 'arr', undefined, 2, 6, 5 );
+		t.htmlEqual( fixture.innerHTML, '654' );
+	});
 }

--- a/test/browser-tests/methods/transition.js
+++ b/test/browser-tests/methods/transition.js
@@ -24,9 +24,9 @@ export default function() {
 		t.equal( div.style.opacity, '' );
 
 		// string name of transition
-		ractive.transition( 'fade', div, { opacity: .5 } )
+		ractive.transition( 'fade', div, { opacity: 0.5 } )
 			.then( () => {
-				t.equal( div.style.opacity, .5 );
+				t.equal( div.style.opacity, 0.5 );
 				// function
 				return ractive.transition( fade, div, { opacity: 1 } );
 			})

--- a/test/browser-tests/plugins/transitions.js
+++ b/test/browser-tests/plugins/transitions.js
@@ -71,6 +71,7 @@ export default function() {
 		const done = t.async();
 
 		let shouldHaveCompleted;
+		let p;
 
 		const Widget = Ractive.extend({
 			template: '<p outro="test">foo</p>',
@@ -89,7 +90,7 @@ export default function() {
 			data: { foo: true }
 		});
 
-		const p = ractive.find( 'p' );
+		p = ractive.find( 'p' );
 
 		ractive.set( 'foo', false ).then( function () {
 			t.ok( shouldHaveCompleted, 'promise was fulfilled before transition had completed' );
@@ -222,6 +223,8 @@ export default function() {
 		// we're using line height for testing because it's a numerical CSS property that IE8 supports
 		const done = t.async();
 
+		let div;
+
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div intro="changeLineHeight"></div>',
@@ -245,7 +248,7 @@ export default function() {
 			}
 		});
 
-		const div = ractive.find( 'div' );
+		div = ractive.find( 'div' );
 		t.equal( div.style.lineHeight, 0 );
 	});
 
@@ -280,7 +283,7 @@ export default function() {
 	test( 'Parameter objects are not polluted (#1239)', t => {
 		const done = t.async();
 
-		t.expect(3)
+		t.expect(3);
 
 		let uid = 0;
 		let objects = [];
@@ -339,7 +342,7 @@ export default function() {
 			}
 		});
 
-		ractive.set( 'showBox', true ).then( function ( t ) {
+		ractive.set( 'showBox', true ).then( function () {
 			if ( !tooLate ) {
 				done();
 			}
@@ -392,7 +395,7 @@ export default function() {
 				foo: '',
 				bar: ''
 			},
-			oncomplete () { done() }
+			oncomplete () { done(); }
 		});
 
 		ractive.set( 'foo', 'x' );
@@ -614,5 +617,26 @@ export default function() {
 		});
 
 		t.equal( count, 1 );
+	});
+
+	test( 'old-style transition args bind correctly in an iterative section', t => {
+		t.expect( 1 );
+		const done = t.async();
+
+		const r = new Ractive({
+			el: fixture,
+			template: '{{#each foo:i}}<div intro-outro="go:{ delay: {{ delay * 10 + i }} }" />{{/each}}',
+			data: {
+				delay: 10
+			},
+			transitions: {
+				go ( trans, opts ) {
+					t.equal( opts.delay, 100 );
+					trans.complete();
+				}
+			}
+		});
+
+		r.push( 'foo', true ).then( done, done );
 	});
 }

--- a/test/browser-tests/render/components.js
+++ b/test/browser-tests/render/components.js
@@ -88,4 +88,20 @@ export default function() {
 		r.set( 'bar', 'still' );
 		t.htmlEqual( fixture.innerHTML, 'still' );
 	});
+
+	test( 'components should be able to resolve @index refs from their context', t => {
+		const cmp = Ractive.extend({
+			template: '{{@index}}'
+		});
+		new Ractive({
+			el: fixture,
+			template: '{{#each list}}<cmp />{{/each}}',
+			data: {
+				list: [ 0, 0, 0 ]
+			},
+			components: { cmp }
+		});
+
+		t.htmlEqual( fixture.innerHTML, '012' );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This _should_ fix three outstanding transition issues, one of which was fixed and then broken again in a slightly different way by the recent conditional merge. I say _should_ because transition-related issues are, shall we say, challenging to test.

1. #2463 - this is the one that was fixed and re-broken. This one was caused by some binding happening during transition construction, a time at which parts of the virtual dom are not in place to do resolution. Part II of this issue is dom sticking around past its due date. I did manage to kinda reproduce two or three times it (a tiny percentage) by shaking the crap out of the mouse over the hover trigger. It's not particularly consistent and I couldn't reproduce it with a test rapidly triggering transitions. I think this may be more a bug with `animateStyle` not always resolving its promise, but I'm not positive. I think a longer term solution to would be to set an adjustable timeout on the transition and force completion after that timeout. I think the transition completion dom event may be most of the issue.

2. #2415 - this is one is caused by a component rendering into a document fragment and having its transitions kicked off before it's actually attached to the dom. To work around that, this makes the transition managers in the batch stack wait until the root batch is done before kicking off transitions. Since non-transitioning nodes need to be removed before deferred observers, this adds another transition manager stage `ready` which is fired where `start` was before. I couldn't come up with a decent/reliable test for this.

3. #2435 - I _think_ this one is caused by removed fragments being dropped immediately from the top of the list. Again, I couldn't come up with a decent/reliable test for this. This sort of reverts some performance optimization in `RepeatedFragment.updatePostShuffle` so that exiting fragments can be more easily re-attached as near their old position as possible and transition out from there instead of popping up to the top of the section. There may be something component-related to this issue too, but I'd like to see if this addresses the issue before I add yet more to the runloop. As for the de-optimization, I have another avenue that should more than make up for the 5-10% slowdown removing the optimization introduced (looking like a 70% improvement, but there are still many failing tests).

I love that ractive has pretty great transition support, but man are they a pita to debug.

**Fixes the following issues:**
Definitely #2415, at least most of #2463, and hopefully #2435 

**Is breaking:**
Don't think so.

**Reviewers:**
Yes, please.