### PR TITLE
Return bubble status from fire for better default fire expression behavior - #2556

### DIFF
--- a/src/Ractive/prototype/fire.js
+++ b/src/Ractive/prototype/fire.js
@@ -1,5 +1,5 @@
 import fireEvent from '../../events/fireEvent';
 
 export default function Ractive$fire ( eventName, ...args ) {
-	fireEvent( this, eventName, { args });
+	return fireEvent( this, eventName, { args });
 }

--- a/src/events/fireEvent.js
+++ b/src/events/fireEvent.js
@@ -18,7 +18,7 @@ export default function fireEvent ( ractive, eventName, options = {} ) {
 
 	var eventNames = getWildcardNames( eventName );
 
-	fireEventAs( ractive, eventNames, options.event, options.args, true );
+	return fireEventAs( ractive, eventNames, options.event, options.args, true );
 }
 
 function getWildcardNames ( eventName ) {
@@ -58,6 +58,8 @@ function fireEventAs  ( ractive, eventNames, event, args, initialFire = false ) 
 
 		fireEventAs( ractive.parent, eventNames, event, args );
 	}
+
+	return bubble;
 }
 
 function notifySubscribers ( ractive, subscribers, event, args ) {

--- a/test/browser-tests/events/bubbling.js
+++ b/test/browser-tests/events/bubbling.js
@@ -217,4 +217,18 @@ export default function() {
 		fire( component.nodes.test, 'click' );
 		t.ok( true );
 	});
+
+	test( 'firing an event from an event directive cancels bubble if the sub-event also cancels', t => {
+		t.expect( 0 );
+
+		const r = new Ractive({
+			el: fixture,
+			template: `<div on-click="@this.fire('no')"><button on-click="@this.fire('go')">click</button></div>`,
+		});
+
+		r.on( 'no', () => t.ok( false, 'the event bubbled' ) );
+		r.on( 'go', () => false );
+
+		fire( r.find( 'button' ), 'click' );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This makes `fire` return its bubble/cancel status so that `<button on-click="@this.fire('someEvent')">` behaves a bit more intuitively. The current workaround is to just add a false expression to the end e.g. `@this.fire('someEvent'), false`. So after this, if you want the event to bubble regardless of the result of the fire, you'd just have to add a true expression e.g. `@this.fire('someEvent'), true`.

**Fixes the following issues:**
#2556 

**Is breaking:**
No

**Reviewers:**
@martypdx