### PR TITLE
Make reference expression proxies lazy - #2461

### DIFF
--- a/src/view/resolvers/ReferenceExpressionProxy.js
+++ b/src/view/resolvers/ReferenceExpressionProxy.js
@@ -42,6 +42,11 @@ class ReferenceExpressionChild extends Model {
 
 		return this.childByKey[ key ];
 	}
+
+	retrieve () {
+		const parent = this.parent.get();
+		return parent && this.key in parent ? parent[ this.key ] : undefined;
+	}
 }
 
 export default class ReferenceExpressionProxy extends Model {

--- a/src/view/resolvers/ReferenceExpressionProxy.js
+++ b/src/view/resolvers/ReferenceExpressionProxy.js
@@ -137,7 +137,7 @@ export default class ReferenceExpressionProxy extends Model {
 
 		if ( this.keypathModel ) this.keypathModel.handleChange();
 
-		this.handleChange();
+		if ( !this.dirty ) this.handleChange();
 	}
 
 	forceResolution () {

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -787,4 +787,86 @@ export default function() {
 		r.set( 'foo.bar.wat', 'yep' );
 		t.htmlEqual( fixture.innerHTML, 'yep!' );
 	});
+
+	test( 'computations should not recompute when parent section is destroyed', t => {
+		let count = 0;
+
+		const ractive = new Ractive({
+			el: fixture,
+
+			template: `
+			{{#if foo}}
+			{{map[key]}}
+			{{/if}}
+			`,
+
+			data: { key: 'x' },
+
+			computed: {
+				map () {
+					this.get( 'foo' );
+					count += 1;
+
+					return { x: 'test' };
+				}
+			}
+		});
+
+		ractive.set( 'foo', true );
+		t.equal( count, 1 );
+
+		ractive.set( 'foo', false );
+		t.equal( count, 1 );
+
+		ractive.set( 'foo', true );
+		t.equal( count, 2 );
+
+		ractive.set( 'foo', false );
+		t.equal( count, 2 );
+	});
+
+	test( 'computations should not recompute when parent component is destroyed', t => {
+		let count = 0;
+
+		const Foo = Ractive.extend({
+			template: `{{map[key]}}`,
+
+			data: () => ({
+				key: 'x'
+			}),
+
+			computed: {
+				map () {
+					this.get( 'foo' );
+					count += 1;
+
+					return { x: 'test' };
+				}
+			}
+		});
+
+		const ractive = new Ractive({
+			el: fixture,
+
+			template: `
+			{{#if foo}}
+			<Foo foo='{{foo}}'/>
+			{{/if}}
+			`,
+
+			components: { Foo }
+		});
+
+		ractive.set( 'foo', true );
+		t.equal( count, 1 );
+
+		ractive.set( 'foo', false );
+		t.equal( count, 1 );
+
+		ractive.set( 'foo', true );
+		t.equal( count, 2 );
+
+		ractive.set( 'foo', false );
+		t.equal( count, 2 );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This updates `ReferenceExpressionProxy` such that instead of triggering an immediate get on all of its models, it waits until the value is actually needed by setting a dirty flag and deferring the actual pull to its own `get`.

**Fixes the following issues:**
#2461

**Is breaking:**
No
