### PR TITLE
Check oneway bindings during updateModel if there are no twoways - #1963

### DIFF
--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -546,6 +546,12 @@ export default class Model {
 			if ( value !== this.value ) this.set( value );
 		}
 
+		// check for one-way bindings if there are no two-ways
+		if ( !this.bindings.length ) {
+			const oneway = findBoundValue( this.deps );
+			if ( oneway && oneway.value !== this.value ) this.set( oneway.value );
+		}
+
 		if ( cascade ) {
 			this.children.forEach( updateFromBindings );
 		}
@@ -554,5 +560,20 @@ export default class Model {
 	updateKeypathDependants () {
 		this.children.forEach( updateKeypathDependants );
 		if ( this.keypathModel ) this.keypathModel.handleChange();
+	}
+}
+
+export function findBoundValue( list ) {
+	let i = list.length;
+	while ( i-- ) {
+		if ( list[i].bound ) {
+			const owner = list[i].owner;
+			if ( owner ) {
+				const value = owner.name === 'checked' ?
+					owner.node.checked :
+					owner.node.value;
+				return { value };
+			}
+		}
 	}
 }

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -54,6 +54,8 @@ export default class Attribute extends Item {
 			this.fragment.items.length === 1 &&
 			this.fragment.items[0].type === INTERPOLATOR &&
 			this.fragment.items[0];
+
+		if ( this.interpolator ) this.interpolator.owner = this;
 	}
 
 	bind () {

--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -13,6 +13,8 @@ export default function getUpdateDelegate ( attribute ) {
 	if ( name === 'id' ) return updateId;
 
 	if ( name === 'value' ) {
+		if ( attribute.interpolator ) attribute.interpolator.bound = true;
+
 		// special case - selects
 		if ( element.name === 'select' && name === 'value' ) {
 			return element.getAttribute( 'multiple' ) ? updateMultipleSelectValue : updateSelectValue;
@@ -56,7 +58,11 @@ export default function getUpdateDelegate ( attribute ) {
 
 	if ( name.indexOf( 'class-' ) === 0 ) return updateInlineClass;
 
-	if ( attribute.isBoolean ) return updateBoolean;
+	if ( attribute.isBoolean ) {
+		const type = element.getAttribute( 'type' );
+		if ( attribute.interpolator && name === 'checked' && ( type === 'checkbox' || type === 'radio' ) ) attribute.interpolator.bound = true;
+		return updateBoolean;
+	}
 
 	if ( attribute.namespace && attribute.namespace !== attribute.node.namespaceURI ) return updateNamespacedAttribute;
 

--- a/src/view/resolvers/ReferenceExpressionProxy.js
+++ b/src/view/resolvers/ReferenceExpressionProxy.js
@@ -1,5 +1,4 @@
-import { capture } from '../../global/capture';
-import Model from '../../model/Model';
+import Model, { findBoundValue } from '../../model/Model';
 import { REFERENCE } from '../../config/types';
 import ExpressionProxy from './ExpressionProxy';
 import resolveReference from './resolveReference';
@@ -172,6 +171,10 @@ export default class ReferenceExpressionProxy extends Model {
 			const value = this.bindings[i].getValue();
 			if ( value !== this.value ) return value;
 		}
+
+		// check one-way bindings
+		const oneway = findBoundValue( this.deps );
+		if ( oneway ) return oneway.value;
 
 		return this.value;
 	}

--- a/test/browser-tests/methods/updateModel.js
+++ b/test/browser-tests/methods/updateModel.js
@@ -29,4 +29,38 @@ export default function() {
 		t.equal( fixture.innerHTML, '<input value="changed">changed' );
 		t.equal( ractive.findComponent( 'widget' ).get( 'bar' ), 'changed' );
 	});
+
+	test( 'one-way bindings can be used to update the model (#1963)', t => {
+		const cmp = Ractive.extend({
+			twoway: false,
+			template: '<input value="{{obj.foo}}" /><input value="{{obj[obj.key]}}" /><input type="checkbox" checked="{{obj.bar.baz}}" />'
+		});
+		const r = new Ractive({
+			el: fixture,
+			template: '<cmp obj="{{some.thing}}" />',
+			data: {
+				some: {
+					thing: {
+						key: 'test',
+						test: 'wat',
+						foo: 'str',
+						bar: { baz: false }
+					}
+				}
+			},
+			components: { cmp }
+		});
+
+		const [ larry, curly, moe ] = r.findAll( 'input' );
+
+		larry.value = 'larry';
+		curly.value = 'curly';
+		moe.checked = true;
+
+		r.updateModel();
+
+		t.equal( r.get( 'some.thing.foo' ), 'larry' );
+		t.equal( r.get( 'some.thing.test' ), 'curly' );
+		t.equal( r.get( 'some.thing.bar.baz' ), true );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This adds some tracking info to attribute interpolators, if they appear to be relevant and on form elements, that lets `updateFromBindings` iterate the model's list of deps to find any "oneway" bindings from which to update. This is only a fallthrough in the case that there are no twoway bindings.

This covers:
* any element with a `value` attribute (as found in `getUpdateDelegate`)
* `input[type=checkbox|radio]` if the attribute is `checked`

Did I miss any cases?

**Fixes the following issues:**
#1963

**Is breaking:**
No?
