### PR TITLE
Pop to the first actual context when resolving rootpath - fixes #2026

### DIFF
--- a/src/view/resolvers/resolveReference.js
+++ b/src/view/resolvers/resolveReference.js
@@ -19,6 +19,11 @@ export default function resolveReference ( fragment, ref ) {
 		return context.getKeypathModel( fragment.ractive );
 	}
 	if ( ref.indexOf( '@rootpath' ) === 0 ) {
+		// check to see if this is an empty component root
+		while ( context.isRoot && context.ractive.component ) {
+			context = context.ractive.component.parentFragment.findContext();
+		}
+
 		const match = keypathExpr.exec( ref );
 		if ( match && match[1] ) {
 			const model = resolveReference( fragment, match[1] );

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -1035,4 +1035,21 @@ export default function() {
 
 		fire( r.find( 'button' ), 'click' );
 	});
+
+	test( '@rootpath should be accurate in a yielder', t => {
+		const end = Ractive.extend({
+			template: '{{#with other.path}}{{yield}}{{/with}}',
+			data: { other: { path: { yep: true } } }
+		});
+		new Ractive({
+			el: fixture,
+			template: '{{#with root.next.next.next.next}}<end>{{@rootpath}} {{.stop}}</end>{{/with}}',
+			data: {
+				root: { next: { next: { next: { next: { stop: true } } } } }
+			},
+			components: { end }
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'root.next.next.next.next true' );
+	});
 }

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -1,5 +1,6 @@
 import { test } from 'qunit';
 import { initModule, hasUsableConsole, onWarn } from '../test-config';
+import { fire } from 'simulant';
 
 // TODO tidy up, move some of these tests into separate files
 
@@ -991,5 +992,47 @@ export default function() {
 		t.equal( outer.rootpath, 'baz' );
 		t.equal( inner.keypath, 'foo.bar' );
 		t.equal( inner.rootpath, 'baz.bat.bar' );
+	});
+
+	test( 'component @rootpaths should skip root contexts (#2026)', t => {
+		const end = Ractive.extend({
+			template: '{{@rootpath}}'
+		});
+		const middle = Ractive.extend({
+			template: '{{#if middle}}{{#with middle}}<middle middle="{{.next}}" />{{/with}}{{else}}<end />{{/if}}'
+		});
+		new Ractive({
+			el: fixture,
+			template: '{{#with root.next.next.next.next}}<end />{{/with}} <middle middle="{{root}}" />',
+			data: {
+				root: { next: { next: { next: { next: { stop: true } } } } }
+			},
+			components: { middle, end }
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'root.next.next.next.next root.next.next.next.next' );
+	});
+
+	test( '@rootpath should be accurate in events fired from within components (#2026)', t => {
+		const end = Ractive.extend({
+			template: '<button on-click="go">click me</button>'
+		});
+		const middle = Ractive.extend({
+			template: '{{#if middle}}{{#with middle}}<middle middle="{{.next}}" />{{/with}}{{else}}<end />{{/if}}'
+		});
+		const r = new Ractive({
+			el: fixture,
+			template: '<middle middle="{{root}}" />',
+			data: {
+				root: { next: { next: { next: { next: { stop: true } } } } }
+			},
+			components: { middle, end }
+		});
+
+		r.on( '*.go', ev => {
+			t.ok( ev.resolve( '@rootpath' ), 'root.next.next.next.next' );
+		});
+
+		fire( r.find( 'button' ), 'click' );
 	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This adds a step to `@rootpath` resolution that pops to the first non-empty (keypath-wise) context to get the keypath. Here's the example:

```handlebars
{{#with foo.bar.baz.bat}}<cmp>{{@rootpath}}</cmp>{{/with}}
```

Without this, the result is an empty string, and with it, the result is `foo.bar.baz.bat`. So, with node info helpers on the event object, you can get the root path to the event context with `event.resolve('@rootpath')`.

**Fixes the following issues:**
#2026

**Is breaking:**
Shouldn't be.
