### PR TITLE
Wrap animateStyle css transitions in a timeout in case transitionend doesn't fire - #2463

### DIFF
--- a/src/view/items/element/transitions/createTransitions.js
+++ b/src/view/items/element/transitions/createTransitions.js
@@ -53,6 +53,7 @@ if ( !isClient ) {
 		setTimeout( () => {
 			let jsTransitionsComplete;
 			let cssTransitionsComplete;
+			let cssTimeout;
 
 			function checkComplete () {
 				if ( jsTransitionsComplete && cssTransitionsComplete ) {
@@ -79,6 +80,8 @@ if ( !isClient ) {
 			style[ TRANSITION_DURATION ] = ( options.duration / 1000 ) + 's';
 
 			function transitionEndHandler ( event ) {
+				clearTimeout( cssTimeout );
+
 				const index = changedProperties.indexOf( camelCase( unprefix( event.propertyName ) ) );
 
 				if ( index !== -1 ) {
@@ -90,6 +93,10 @@ if ( !isClient ) {
 					return;
 				}
 
+				cssTransitionsDone();
+			}
+
+			function cssTransitionsDone () {
 				style[ TRANSITION_PROPERTY ] = previous.property;
 				style[ TRANSITION_TIMING_FUNCTION ] = previous.duration;
 				style[ TRANSITION_DURATION ] = previous.timing;
@@ -101,6 +108,12 @@ if ( !isClient ) {
 			}
 
 			t.node.addEventListener( TRANSITIONEND, transitionEndHandler, false );
+
+			// safety net in case transitionend never fires
+			cssTimeout = setTimeout( () => {
+				changedProperties = [];
+				cssTransitionsDone();
+			}, options.duration + ( options.delay || 0 ) + 10 );
 
 			setTimeout( () => {
 				let i = changedProperties.length;

--- a/src/view/items/element/transitions/createTransitions.js
+++ b/src/view/items/element/transitions/createTransitions.js
@@ -80,8 +80,6 @@ if ( !isClient ) {
 			style[ TRANSITION_DURATION ] = ( options.duration / 1000 ) + 's';
 
 			function transitionEndHandler ( event ) {
-				clearTimeout( cssTimeout );
-
 				const index = changedProperties.indexOf( camelCase( unprefix( event.propertyName ) ) );
 
 				if ( index !== -1 ) {
@@ -93,6 +91,7 @@ if ( !isClient ) {
 					return;
 				}
 
+				clearTimeout( cssTimeout );
 				cssTransitionsDone();
 			}
 


### PR DESCRIPTION
**Description of the pull request:**
This adds a timeout of `duration + (delay || 0) + 10` to css transitions in `animateStyle` to force the transition to complete within 10ms of its target. `transitionend` events appear to not be particularly reliable in scenarios where you trigger transitions like a madman.

After aiming the fiddle from #2463 at a build of this branch and about 5 minutes of vigorous mouse wiggling, I'm reasonably confident that this will take care of transition-event-related orphan nodes. I'll probably go ahead and merge this later this afternoon (once it goes green) so that others can get their wiggle on as well to make sure I'm not experiencing the placebo effect.

Side note: I have an idea for a subscription-based software shake weight competitor...

**Fixes the following issues:**
Hopefully #2463

**Is breaking:**
No