### PR TITLE
Make magic mode not break 'this' for the underlying object's getters and setters

### DIFF
--- a/src/Ractive/static/adaptors/magic.js
+++ b/src/Ractive/static/adaptors/magic.js
@@ -30,16 +30,16 @@ function createOrWrapDescriptor ( originalDescriptor, ractive, keypath ) {
 	let dependants = [{ ractive, keypath }];
 
 	const descriptor = {
-		get: () => {
-			return 'value' in originalDescriptor ? originalDescriptor.value : originalDescriptor.get();
+		get: function () {
+			return 'value' in originalDescriptor ? originalDescriptor.value : originalDescriptor.get.call( this );
 		},
-		set: value => {
+		set: function (value) {
 			if ( setting ) return;
 
 			if ( 'value' in originalDescriptor ) {
 				originalDescriptor.value = value;
 			} else {
-				originalDescriptor.set( value );
+				originalDescriptor.set.call( this, value );
 			}
 
 			setting = true;

--- a/test/browser-tests/plugins/adaptors/magic.js
+++ b/test/browser-tests/plugins/adaptors/magic.js
@@ -148,6 +148,36 @@ export default function() {
 			t.htmlEqual( fixture.innerHTML, 'baz' );
 		});
 
+		test( 'Magic mode preserves "this" for existing accessors', t => {
+			let data = {};
+			var thisObservedInGetter = undefined;
+			var thisObservedInSetter = undefined;
+
+			Object.defineProperty( data, 'propertyLoggingObservedThisOnCall', {
+				get () {
+					thisObservedInGetter = this;
+					return 'foo';
+				},
+				set ( value ) {
+					thisObservedInSetter = this;
+				},
+				configurable: true,
+				enumerable: true
+			});
+
+			new MagicRactive({
+				el: fixture,
+				template: '{{foo}}',
+				data
+			});
+
+			let foo = data.propertyLoggingObservedThisOnCall;
+			t.strictEqual( thisObservedInGetter, data );
+
+			data.propertyLoggingObservedThisOnCall = 'foo';
+			t.strictEqual( thisObservedInSetter, data );
+		});
+
 		test( 'Setting properties in magic mode triggers change events', t => {
 			t.expect( 1 );
 


### PR DESCRIPTION
**Description of the pull request:**
 - preserve `this` by using `.call(this, ...)`

**Fixes the following issues:**
When your model has getters/setters that use `this`, applying magic mode to the model will break them.

**Is breaking:**
None 

**Reviewers:**
Any
