### PR TITLE
Add a complete queue to transitions to clean up listeners on aborted transitions

### DIFF
--- a/src/view/items/element/Transition.js
+++ b/src/view/items/element/Transition.js
@@ -1,7 +1,7 @@
 import { win } from '../../../config/environment';
 import legacy from '../../../legacy';
 import { isArray } from '../../../utils/is';
-import { removeFromArray } from '../../../utils/array';
+import { addToArray, removeFromArray } from '../../../utils/array';
 import findElement from '../shared/findElement';
 import prefix from './transitions/prefix';
 import { warnOnceIfDebug } from '../../../utils/log';
@@ -34,6 +34,7 @@ export default class Transition {
 		this.template = options.template;
 		this.parentFragment = options.parentFragment;
 		this.options = options;
+		this.onComplete = [];
 	}
 
 	animateStyle ( style, value, options ) {
@@ -114,7 +115,7 @@ export default class Transition {
 	}
 
 	bind () {
-		const options = this.options
+		const options = this.options;
 		if ( options.template ) {
 			if ( options.template.v === 't0' || options.template.v == 't1' ) this.element._introTransition = this;
 			if ( options.template.v === 't0' || options.template.v == 't2' ) this.element._outroTransition = this;
@@ -250,6 +251,10 @@ export default class Transition {
 		this.bind();
 	}
 
+	registerCompleteHandler ( fn ) {
+		addToArray( this.onComplete, fn );
+	}
+
 	render () {}
 
 	setStyle ( style, value ) {
@@ -284,6 +289,7 @@ export default class Transition {
 				return;
 			}
 
+			this.onComplete.forEach( fn => fn() );
 			if ( !noReset && this.eventName === 'intro' ) {
 				resetStyle( node, originalStyle);
 			}
@@ -317,6 +323,10 @@ export default class Transition {
 
 	unbind () {
 		if ( this.resolvers ) this.resolvers.forEach( unbind );
+	}
+
+	unregisterCompleteHandler ( fn ) {
+		removeFromArray( this.onComplete, fn );
 	}
 
 	unrender () {}

--- a/src/view/items/element/transitions/createTransitions.js
+++ b/src/view/items/element/transitions/createTransitions.js
@@ -55,8 +55,11 @@ if ( !isClient ) {
 			let cssTransitionsComplete;
 			let cssTimeout;
 
+			function transitionDone () { clearTimeout( cssTimeout ); }
+
 			function checkComplete () {
 				if ( jsTransitionsComplete && cssTransitionsComplete ) {
+					t.unregisterCompleteHandler( transitionDone );
 					// will changes to events and fire have an unexpected consequence here?
 					t.ractive.fire( t.name + ':end', t.node, t.isIntro );
 					resolve();
@@ -112,7 +115,8 @@ if ( !isClient ) {
 			cssTimeout = setTimeout( () => {
 				changedProperties = [];
 				cssTransitionsDone();
-			}, options.duration + ( options.delay || 0 ) + 10 );
+			}, options.duration + ( options.delay || 0 ) + 50 );
+			t.registerCompleteHandler( transitionDone );
 
 			setTimeout( () => {
 				let i = changedProperties.length;


### PR DESCRIPTION
**Description of the pull request:**
The timeout safety net on transitions to catch missing transition end (now tested here!) can apparently interfere with quick render/unrender cycles, which kinda makes sense. This adds a complete queue to the transition that cancels the net should the transition complete early because the element is quickly unrendered.

**Fixes the following issues:**
Comment in #2585 by @sabob 

**Is breaking:**
Don't think so.
