### PR TITLE
First pass at slightly smarter (and much faster) shuffling - RFC

### DIFF
--- a/perf/tests/jsweb.js
+++ b/perf/tests/jsweb.js
@@ -14,6 +14,7 @@ var tests = [
 						template:
 `<table>
 	<tr><th>name</th><th>index</th><th>remove</th></tr>
+	{{#if show}}
 	{{#rows:i}}
 	<tr class="{{#selected === .id}}selected{{/}}">
 		<td>{{.id}}</td>
@@ -22,8 +23,9 @@ var tests = [
 		<td><button on-click="remove:{{i}}">remove</button></td>
 	</tr>
 	{{/rows}}
+	{{/if}}
 </table>`,
-						data: { rows: [] }
+						data: { rows: [], show: true }
 					});
 
 					var id = 0;
@@ -53,12 +55,21 @@ var tests = [
 			},
 
 			{
-				name: 'add 100 rows',
+				name: 'add 100 rows (accumulates)',
 				test() {
 					/* global ractive, gen */
-					ractive.push( 'rows', gen( 100 ) );
-				},
-				maxCount: 5
+					const rows = gen( 100 );
+					rows.unshift( 'rows' );
+					ractive.push.apply( ractive, rows );
+				}
+			},
+
+			{
+				name: 'reset to 1000 rows',
+				test() {
+					/* global ractive, gen */
+					ractive.set( 'rows', gen() );
+				}
 			},
 
 			{
@@ -71,6 +82,14 @@ var tests = [
 			},
 
 			{
+				name: 'reset to 1000 rows',
+				test() {
+					/* global ractive, gen */
+					ractive.set( 'rows', gen() );
+				}
+			},
+
+			{
 				name: 'remove first row',
 				test() {
 					/* global ractive */
@@ -80,12 +99,64 @@ var tests = [
 			},
 
 			{
+				name: 'reset to 1000 rows',
+				test() {
+					/* global ractive, gen */
+					ractive.set( 'rows', gen() );
+				}
+			},
+
+			{
 				name: 'remove last row',
 				test() {
 					/* global ractive */
 					ractive.pop( 'rows' );
 				},
 				maxCount: 100
+			},
+
+			{
+				name: 'reset to 1000 rows',
+				test() {
+					/* global ractive, gen */
+					ractive.set( 'rows', gen() );
+				}
+			},
+
+			{
+				name: 'hide rows',
+				test() {
+					/* global ractive */
+					ractive.set( 'show', false );
+				},
+				maxCount: 1
+			},
+
+			{
+				name: 'show rows',
+				test() {
+					/* global ractive */
+					ractive.set( 'show', true );
+				},
+				maxCount: 1
+			},
+
+			{
+				name: 'hide rows again',
+				test() {
+					/* global ractive */
+					ractive.set( 'show', false );
+				},
+				maxCount: 1
+			},
+
+			{
+				name: 'show rows again',
+				test() {
+					/* global ractive */
+					ractive.set( 'show', true );
+				},
+				maxCount: 1
 			},
 
 			{
@@ -108,6 +179,24 @@ var tests = [
 					const rows = ractive.get( 'rows' );
 					const row = rows[ random( rows.length - 1 ) ];
 					ractive.set( 'selected', row.id );
+				}
+			},
+
+			{
+				name: 'generate 10,000 rows',
+				test() {
+					/* global ractive, gen */
+					ractive.set( 'rows', gen( 10000 ) );
+				}
+			},
+
+			{
+				name: 'add 1000 more rows to the 10,000 (accumulates)',
+				test() {
+					/* global ractive, gen */
+					const rows = gen();
+					rows.unshift( 'rows' );
+					ractive.push.apply( ractive, rows );
 				}
 			}
 		]

--- a/src/model/ComputationChild.js
+++ b/src/model/ComputationChild.js
@@ -30,11 +30,6 @@ export default class ComputationChild extends Model {
 		return this.childByKey[ key ];
 	}
 
-	// TODO: this should probably just work off of the parent
-	tryRebind () {
-		return;
-	}
-
 	// TODO this causes problems with inter-component mappings
 	// set () {
 	// 	throw new Error( `Cannot set read-only property of computed value (${this.getKeypath()})` );

--- a/src/model/ComputationChild.js
+++ b/src/model/ComputationChild.js
@@ -30,6 +30,11 @@ export default class ComputationChild extends Model {
 		return this.childByKey[ key ];
 	}
 
+	// TODO: this should probably just work off of the parent
+	tryRebind () {
+		return;
+	}
+
 	// TODO this causes problems with inter-component mappings
 	// set () {
 	// 	throw new Error( `Cannot set read-only property of computed value (${this.getKeypath()})` );

--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -179,6 +179,11 @@ export default class RootModel extends Model {
 		super.teardown();
 	}
 
+	// root models don't shuffle
+	tryRebind () {
+		return this;
+	}
+
 	update () {
 		// noop
 	}

--- a/src/model/specials/GlobalModel.js
+++ b/src/model/specials/GlobalModel.js
@@ -16,6 +16,11 @@ class GlobalModel extends Model {
 
 	// global model doesn't contribute changes events because it has no instance
 	registerChange () {}
+
+	// the global model doesn't shuffle
+	tryRebind () {
+		return false;
+	}
 }
 
 export default new GlobalModel();

--- a/src/model/specials/KeyModel.js
+++ b/src/model/specials/KeyModel.js
@@ -1,12 +1,14 @@
 import { removeFromArray } from '../../utils/array';
 import { handleChange } from '../../shared/methodCallers';
 import { unescapeKey } from '../../shared/keypaths';
+import runloop from '../../global/runloop';
 
 export default class KeyModel {
-	constructor ( key ) {
+	constructor ( key, parent ) {
 		this.value = key;
 		this.isReadonly = true;
 		this.dependants = [];
+		this.parent = parent;
 	}
 
 	get () {
@@ -24,6 +26,32 @@ export default class KeyModel {
 
 	register ( dependant ) {
 		this.dependants.push( dependant );
+	}
+
+	tryRebind () {
+		const shuffle = runloop.findShuffle( this.parent.getKeypath() );
+
+		if ( shuffle === false ) return;
+		else if ( !shuffle ) return false;
+
+		const path = [];
+		let model = this.parent;
+		while ( model && model.parent !== shuffle.model ) {
+			path.unshift( model.key );
+			model = model.parent;
+		}
+
+		if ( !model ) return false;
+		if ( typeof path[0] !== 'number' || shuffle.indicies[ path[0] ] === -1 ) return;
+
+		// parent is shuffling
+		if ( path.length === 1 ) {
+			return this.parent.parent.getIndexModel( shuffle.indices[ this.value ] );
+		} else {
+			path[0] = shuffle.indices[ path[0] ];
+			if ( typeof this.value === 'number' ) return model.joinAll( path ).getIndexModel( this.value );
+			else return model.joinAll( path ).join( this.value ).getKeyModel();
+		}
 	}
 
 	unregister ( dependant ) {

--- a/src/model/specials/KeypathModel.js
+++ b/src/model/specials/KeypathModel.js
@@ -45,6 +45,12 @@ export default class KeypathModel {
 		this.children.forEach( teardown );
 	}
 
+	tryRebind () {
+		const next = this.parent.tryRebind();
+		if ( next ) return next.getKeypathModel( this.ractive );
+		return next;
+	}
+
 	unregister ( dependant ) {
 		removeFromArray( this.dependants, dependant );
 	}

--- a/src/model/specials/RactiveModel.js
+++ b/src/model/specials/RactiveModel.js
@@ -14,4 +14,9 @@ export default class RactiveModel extends Model {
 	getKeypath() {
 		return '@this';
 	}
+
+	// root models don't shuffle
+	tryRebind () {
+		return false;
+	}
 }

--- a/src/view/items/component/Mapping.js
+++ b/src/view/items/component/Mapping.js
@@ -71,6 +71,7 @@ export default class Mapping extends Item {
 			if ( viewmodel.unmap( this.name ) ) {
 				if ( !this.element.rebinding ) {
 					this.element.rebinding = true;
+					runloop.forceRebind();
 					runloop.scheduleTask( () => {
 						this.element.rebind();
 						this.element.rebinding = false;
@@ -112,6 +113,7 @@ function createMapping ( item, check ) {
 			const remapped = viewmodel.map( item.name, item.model );
 			if ( remapped !== item.model && item.element.bound && !item.element.rebinding ) {
 				item.element.rebinding = true;
+				runloop.forceRebind();
 				runloop.scheduleTask( () => {
 					item.element.rebind();
 					item.element.rebinding = false;

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -190,8 +190,21 @@ export default class EventDirective {
 	}
 
 	rebind () {
-		this.unbind();
-		this.bind();
+		if ( this.args && this.args.rebind ) this.args.rebind();
+		if ( this.action && this.action.rebind ) this.action.rebind();
+		if ( this.models ) {
+			this.models.forEach( ( m, i ) => {
+				if ( m && m.tryRebind ) {
+					const next = m.tryRebind();
+
+					if ( next === false ) return;
+					if ( next ) {
+						this.models.splice( i, 1, next );
+					} else {
+					}
+				}
+			});
+		}
 	}
 
 	render () {

--- a/src/view/items/shared/Mustache.js
+++ b/src/view/items/shared/Mustache.js
@@ -1,5 +1,6 @@
 import Item from './Item';
 import resolve from '../../resolvers/resolve';
+import runloop from '../../../global/runloop';
 
 export default class Mustache extends Item {
 	constructor ( options ) {
@@ -45,9 +46,14 @@ export default class Mustache extends Item {
 	}
 
 	rebind () {
-		if ( this.isStatic ) return;
+		const force = runloop.isForceRebinding();
+		if ( this.isStatic || ( !force && !this.model ) ) return;
 
-		const model = resolve( this.parentFragment, this.template );
+		let model;
+		if ( this.model ) model = this.model.tryRebind();
+
+		if ( model === false ) return;
+		else if ( !model ) model = resolve( this.parentFragment, this.template );
 
 		if ( model === this.model ) return;
 

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -124,6 +124,27 @@ export default class ExpressionProxy extends Model {
 		super.teardown();
 	}
 
+	tryRebind () {
+		let dirty = false;
+		this.models.forEach( ( m, i ) => {
+			if ( m ) {
+				let next = m.tryRebind();
+				if ( next === false ) return;
+				if ( next ) {
+					this.models.splice( i, 1, next );
+				} else {
+					dirty = true;
+				}
+			}
+		});
+
+		if ( dirty ) {
+			return;
+		}
+
+		return this;
+	}
+
 	unregister( dep ) {
 		super.unregister( dep );
 		if ( !this.deps.length ) this.teardown();

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -152,10 +152,5 @@ export default class ExpressionProxy extends Model {
 
 	unbind () {
 		this.resolvers.forEach( unbind );
-
-		let i = this.models.length;
-		while ( i-- ) {
-			if ( this.models[i] ) this.models[i].unregister( this );
-		}
 	}
 }

--- a/src/view/resolvers/ReferenceExpressionProxy.js
+++ b/src/view/resolvers/ReferenceExpressionProxy.js
@@ -218,6 +218,11 @@ export default class ReferenceExpressionProxy extends Model {
 		this.model.set( value );
 	}
 
+	// TODO: this should really shuffle
+	tryRebind () {
+		return;
+	}
+
 	unbind () {
 		this.resolvers.forEach( unbind );
 		if ( this.model ) {

--- a/test/browser-tests/shuffling.js
+++ b/test/browser-tests/shuffling.js
@@ -285,6 +285,45 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '211' );
 	});
 
+	test( 'children of shuffled reference expressions survive the shuffle', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: '{{#each lists[name]}}{{.foo}}{{/each}}',
+			data: {
+				lists: {
+					list: [ { foo: 'bar' } ]
+				},
+				name: 'list'
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'bar' );
+		r.unshift( 'lists.list', { foo: 'foo' } );
+		t.htmlEqual( fixture.innerHTML, 'foobar' );
+		r.set( 'lists.list.1.foo', 'baz' );
+		t.htmlEqual( fixture.innerHTML, 'foobaz' );
+	});
+
+	test( 'reference expression members shuffle safely', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: '{{#each lists[name.0]}}{{.foo}}{{/each}}',
+			data: {
+				lists: {
+					list: [ { foo: 'bar' } ],
+					other: [ { foo: 'baz' } ]
+				},
+				name: [ 'list', 'other' ]
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'bar' );
+		r.shift( 'name' );
+		t.htmlEqual( fixture.innerHTML, 'baz' );
+		r.set( 'lists.other.0.foo', 'bat' );
+		t.htmlEqual( fixture.innerHTML, 'bat' );
+	});
+
 	// TODO reinstate this in some form. Commented out for purposes of #1740
 	// test( `Array shuffling only adjusts context and doesn't tear stuff down to rebuild it`, t => {
 	// 	let ractive = new Ractive({

--- a/test/browser-tests/shuffling.js
+++ b/test/browser-tests/shuffling.js
@@ -269,6 +269,22 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '4' );
 	});
 
+	test( 'shuffled computations are updated with their shuffled member', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each list as item:i}}{{item + i}}{{/each}}`,
+			data: {
+				list: [ 1 ]
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, '1' );
+		r.unshift( 'list', 2 );
+		t.htmlEqual( fixture.innerHTML, '22' );
+		r.set( 'list.1', 10 );
+		t.htmlEqual( fixture.innerHTML, '211' );
+	});
+
 	// TODO reinstate this in some form. Commented out for purposes of #1740
 	// test( `Array shuffling only adjusts context and doesn't tear stuff down to rebuild it`, t => {
 	// 	let ractive = new Ractive({


### PR DESCRIPTION
**Description of the pull request:**
Shuffling is one of the last things that is somewhat slow in edge, primarily because when an array shuffles, everything downstream from that array re-resolves all of its references, which is a pretty slow process. This attempts to make that process slightly smarter by assuming that there are roughly three states for a shuffling rebind: not affected by the shuffle, shuffled, and unknown. The unknown state is kind of a special case that is also used by unmapping and remapping in components to get updates propagated correctly.

When a shuffle kicks off, it registers with the runloop. Then when a rebind fires, if it already has a model, it checks to with the model to see if there is a known new model. If there is, it uses it. If it is known that the model is not affected by a shuffle, then it stops there. If it is unknown, then the usual re-resolve process takes place.

Since keypaths are used a ton in this, it also adds keypath caching to avoid a pretty good bit of keypath re-calc. Substitution is still done if the path is mapped, but it doesn't have to start by walking up to the root model.

I have all of the tests passing, but I'm not positive that the test suite covers 100% of the corner cases involved in shuffling. I had to add actual rebind handlers in a few places because there were/are a few items that just unbind/bind on rebind.

There are still a few models and model-like things that do not participate in the tryRebind process, but there shouldn't be any reason why everything wouldn't be covered. Notably, I haven't looked at reference expressions and children of those and computations at all yet. At this point, I think everything in the jsweb perf suite is covered, and I'm seeing this take roughly 35% of the time that edge does for removing the first row (out of 1000) and 20% of the time for the last. Splicing the last row is still not quite as fast as 0.7.3, but everything else is considerably faster.

**Fixes**
#2366 - to the extent that it can... edge is already considerably faster than 0.7.3 in most of the perf suite.

**Is breaking:**
Doesn't look like it, but the test suite may be lacking.

**Reviewers:**
Yes please! If you have a little time to look over the implementation or try out this PR, by all means, please do, and feel free to leave some feedback!