### PR TITLE
Attach/Detach/Map external instances - kinda like ractive-ractive but with view too - RFC

### DIFF
--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -145,6 +145,13 @@ function initialiseProperties ( ractive ) {
 	// links
 	ractive._links = {};
 
+	// external children
+	ractive._children = [];
+	ractive._anchors = [];
+
+	// manual mappings
+	ractive._mappings = [];
+
 	if(!ractive.component){
 		ractive.root = ractive;
 		ractive.parent = ractive.container = null; // TODO container still applicable?

--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -150,7 +150,7 @@ function initialiseProperties ( ractive ) {
 	ractive._anchors = [];
 
 	// manual mappings
-	ractive._mappings = [];
+	ractive._mappings = {};
 
 	if(!ractive.component){
 		ractive.root = ractive;

--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -24,26 +24,9 @@ export default function initialise ( ractive, userOptions, options ) {
 	configHook.fire( ractive );
 	initHook.begin( ractive );
 
-	let fragment;
-
 	// Render virtual DOM
-	if ( ractive.template ) {
-		let cssIds;
-
-		if ( options.cssIds || ractive.cssId ) {
-			cssIds = options.cssIds ? options.cssIds.slice() : [];
-
-			if ( ractive.cssId ) {
-				cssIds.push( ractive.cssId );
-			}
-		}
-
-		ractive.fragment = fragment = new Fragment({
-			owner: ractive,
-			template: ractive.template,
-			cssIds
-		}).bind( ractive.viewmodel );
-	}
+	let fragment = ractive.fragment = createFragment( ractive, options );
+	if ( fragment ) fragment.bind( ractive.viewmodel );
 
 	initHook.end( ractive );
 
@@ -63,5 +46,25 @@ export default function initialise ( ractive, userOptions, options ) {
 				});
 			}
 		}
+	}
+}
+
+export function createFragment ( ractive, options = {} ) {
+	if ( ractive.template ) {
+		let cssIds;
+
+		if ( options.cssIds || ractive.cssId ) {
+			cssIds = options.cssIds ? options.cssIds.slice() : [];
+
+			if ( ractive.cssId ) {
+				cssIds.push( ractive.cssId );
+			}
+		}
+
+		return new Fragment({
+			owner: ractive,
+			template: ractive.template,
+			cssIds
+		});
 	}
 }

--- a/src/Ractive/prototype.js
+++ b/src/Ractive/prototype.js
@@ -1,4 +1,5 @@
 import add from './prototype/add';
+import addMapping from './prototype/addMapping';
 import animate from './prototype/animate';
 import attachChild from './prototype/attachChild';
 import detach from './prototype/detach';
@@ -14,7 +15,6 @@ import get from './prototype/get';
 import getNodeInfo from './prototype/getNodeInfo';
 import insert from './prototype/insert';
 import link from './prototype/link';
-import mapPath from './prototype/mapPath';
 import merge from './prototype/merge';
 import observe from './prototype/observe';
 import observeList from './prototype/observeList';
@@ -24,6 +24,7 @@ import on from './prototype/on';
 import once from './prototype/once';
 import pop from './prototype/pop';
 import push from './prototype/push';
+import removeMapping from './prototype/removeMapping';
 import render from './prototype/render';
 import reset from './prototype/reset';
 import resetPartial from './prototype/resetPartial';
@@ -40,7 +41,6 @@ import toCSS from './prototype/toCSS';
 import toHTML from './prototype/toHTML';
 import transition from './prototype/transition';
 import unlink from './prototype/unlink';
-import unmapPath from './prototype/unmapPath';
 import unrender from './prototype/unrender';
 import unshift from './prototype/unshift';
 import update from './prototype/update';
@@ -48,6 +48,7 @@ import updateModel from './prototype/updateModel';
 
 export default {
 	add,
+	addMapping,
 	animate,
 	attachChild,
 	detach,
@@ -63,7 +64,6 @@ export default {
 	getNodeInfo,
 	insert,
 	link,
-	mapPath,
 	merge,
 	observe,
 	observeList,
@@ -75,6 +75,7 @@ export default {
 	once,
 	pop,
 	push,
+	removeMapping,
 	render,
 	reset,
 	resetPartial,
@@ -93,7 +94,6 @@ export default {
 	toHtml: toHTML,
 	transition,
 	unlink,
-	unmapPath,
 	unrender,
 	unshift,
 	update,

--- a/src/Ractive/prototype.js
+++ b/src/Ractive/prototype.js
@@ -1,6 +1,8 @@
 import add from './prototype/add';
 import animate from './prototype/animate';
+import attachChild from './prototype/attachChild';
 import detach from './prototype/detach';
+import detachChild from './prototype/detachChild';
 import find from './prototype/find';
 import findAll from './prototype/findAll';
 import findAllComponents from './prototype/findAllComponents';
@@ -12,6 +14,7 @@ import get from './prototype/get';
 import getNodeInfo from './prototype/getNodeInfo';
 import insert from './prototype/insert';
 import link from './prototype/link';
+import mapPath from './prototype/mapPath';
 import merge from './prototype/merge';
 import observe from './prototype/observe';
 import observeList from './prototype/observeList';
@@ -37,6 +40,7 @@ import toCSS from './prototype/toCSS';
 import toHTML from './prototype/toHTML';
 import transition from './prototype/transition';
 import unlink from './prototype/unlink';
+import unmapPath from './prototype/unmapPath';
 import unrender from './prototype/unrender';
 import unshift from './prototype/unshift';
 import update from './prototype/update';
@@ -45,7 +49,9 @@ import updateModel from './prototype/updateModel';
 export default {
 	add,
 	animate,
+	attachChild,
 	detach,
+	detachChild,
 	find,
 	findAll,
 	findAllComponents,
@@ -57,6 +63,7 @@ export default {
 	getNodeInfo,
 	insert,
 	link,
+	mapPath,
 	merge,
 	observe,
 	observeList,
@@ -86,6 +93,7 @@ export default {
 	toHtml: toHTML,
 	transition,
 	unlink,
+	unmapPath,
 	unrender,
 	unshift,
 	update,

--- a/src/Ractive/prototype/addMapping.js
+++ b/src/Ractive/prototype/addMapping.js
@@ -2,7 +2,7 @@ import { splitKeypath } from '../../shared/keypaths';
 import runloop from '../../global/runloop';
 import resolveReference from '../../view/resolvers/resolveReference';
 
-export default function mapPath ( dest, src, opts = {} ) {
+export default function addMapping ( dest, src, opts = {} ) {
 	if ( splitKeypath( dest ).length !== 1 ) throw new Error( `Mappings must be a single top-level key. ${dest} is invalid.` );
 	const keys = splitKeypath( src );
 

--- a/src/Ractive/prototype/attachChild.js
+++ b/src/Ractive/prototype/attachChild.js
@@ -1,0 +1,75 @@
+import Hook from '../../events/Hook';
+import runloop from '../../global/runloop';
+
+const attachHook = new Hook( 'attachchild' );
+
+export default function attachChild ( child, options = {} ) {
+	// options
+	// what to do on unrender
+	// what to do on teardown
+	// target anchor to render
+	// mappings
+
+	const children = this._children;
+
+	let i = children.length;
+	while ( i-- ) {
+		if ( children[i].ractive === child ) {
+			if ( child.parent !== this ) throw new Error( `Instance ${child._guid} is already attached to a different parent ${child.parent._guid}. Please detach it from the other instance using detachChild first.` );
+			else throw new Error( `Instance ${child._guid} is already attached to this instance.` );
+		}
+	}
+
+	const anchors = this._anchors;
+	const meta = {
+		ractive: child,
+		name: options.name || child.constructor.name || 'Ractive',
+		liveQueries: [],
+		target: options.target,
+		bubble () { runloop.addFragment( this.ractive.fragment ); }
+	};
+
+	// child should be rendered to an anchor
+	if ( options.target ) {
+		let i = anchors.length;
+		while ( i-- ) {
+			if ( anchors[i].name === options.target ) {
+				meta.anchor = anchors[i];
+				break;
+			}
+		}
+	}
+
+	// child is managing itself
+	else {
+		meta.parentFragment = this.fragment;
+	}
+
+	child.parent = this;
+	child.component = meta;
+	children.push( meta );
+
+	attachHook.fire( child );
+
+	const promise = runloop.start( child, true );
+
+	if ( meta.target ) {
+		if ( child.fragment.rendered ) {
+			meta.shouldDestroy = true;
+			child.unrender();
+		}
+		child.el = null;
+	} else {
+		runloop.forceRebind();
+		runloop.scheduleTask( () => child.fragment.rebind() );
+
+		// TODO: update live queries
+	}
+
+	if ( meta.anchor ) meta.anchor.addChild( meta );
+
+	runloop.end();
+
+	promise.ractive = child;
+	return promise.then( () => child );
+}

--- a/src/Ractive/prototype/attachChild.js
+++ b/src/Ractive/prototype/attachChild.js
@@ -4,21 +4,10 @@ import runloop from '../../global/runloop';
 const attachHook = new Hook( 'attachchild' );
 
 export default function attachChild ( child, options = {} ) {
-	// options
-	// what to do on unrender
-	// what to do on teardown
-	// target anchor to render
-	// mappings
-
 	const children = this._children;
 
-	let i = children.length;
-	while ( i-- ) {
-		if ( children[i].ractive === child ) {
-			if ( child.parent !== this ) throw new Error( `Instance ${child._guid} is already attached to a different parent ${child.parent._guid}. Please detach it from the other instance using detachChild first.` );
-			else throw new Error( `Instance ${child._guid} is already attached to this instance.` );
-		}
-	}
+	if ( child.parent && child.parent !== this ) throw new Error( `Instance ${child._guid} is already attached to a different instance ${child.parent._guid}. Please detach it from the other instance using detachChild first.` );
+	else if ( child.parent ) throw new Error( `Instance ${child._guid} is already attached to this instance.` );
 
 	const anchors = this._anchors;
 	const meta = {

--- a/src/Ractive/prototype/attachChild.js
+++ b/src/Ractive/prototype/attachChild.js
@@ -61,7 +61,7 @@ export default function attachChild ( child, options = {} ) {
 		child.el = null;
 	} else {
 		runloop.forceRebind();
-		runloop.scheduleTask( () => child.fragment.rebind() );
+		runloop.scheduleTask( () => child.fragment.rebind( child.viewmodel ) );
 
 		// TODO: update live queries
 	}

--- a/src/Ractive/prototype/detachChild.js
+++ b/src/Ractive/prototype/detachChild.js
@@ -1,0 +1,39 @@
+import Hook from '../../events/Hook';
+import runloop from '../../global/runloop';
+
+const detachHook = new Hook( 'detachchild' );
+
+export default function detachChild ( child ) {
+	const children = this._children;
+	let meta, index;
+
+	let i = children.length;
+	while ( i-- ) {
+		if ( children[i].ractive === child ) {
+			index = i;
+			meta = children[i];
+			break;
+		}
+	}
+
+	if ( !meta || child.parent !== this ) throw new Error( `Instance ${child._guid} is not attached to this instance.` );
+
+	const promise = runloop.start( child, true );
+
+	if ( meta.anchor ) meta.anchor.removeChild( meta );
+	child.viewmodel.resetMappings();
+
+	runloop.forceRebind();
+	child.fragment.rebind();
+
+	runloop.end();
+
+	children.splice( index, 1 );
+	child.parent = null;
+	child.component = null;
+
+	detachHook.fire( child );
+
+	promise.ractive = child;
+	return promise.then( () => child );
+}

--- a/src/Ractive/prototype/detachChild.js
+++ b/src/Ractive/prototype/detachChild.js
@@ -34,7 +34,7 @@ export default function detachChild ( child ) {
 
 	detachHook.fire( child );
 
-	if ( !meta.anchor ) {
+	if ( !meta.anchor && child.fragment.rendered ) {
 		// keep live queries up to date
 		child.findAll( '*' ).forEach( el => {
 			el._ractive.proxy.liveQueries.forEach( q => {
@@ -62,6 +62,4 @@ function isParent ( target, check ) {
 		if ( target === check ) return true;
 		target = target.parent;
 	}
-
-	return false;
 }

--- a/src/Ractive/prototype/find.js
+++ b/src/Ractive/prototype/find.js
@@ -1,5 +1,14 @@
-export default function Ractive$find ( selector ) {
+export default function Ractive$find ( selector, options = {} ) {
 	if ( !this.el ) throw new Error( `Cannot call ractive.find('${selector}') unless instance is rendered to the DOM` );
 
-	return this.fragment.find( selector );
+	let node = this.fragment.find( selector, options );
+	if ( node ) return node;
+
+	if ( options.remote ) {
+		for ( let i = 0; i < this._children.length; i++ ) {
+			if ( !this._children[i].instance.fragment.rendered ) continue;
+			node = this._children[i].instance.find( selector, options );
+			if ( node ) return node;
+		}
+	}
 }

--- a/src/Ractive/prototype/findAll.js
+++ b/src/Ractive/prototype/findAll.js
@@ -25,6 +25,13 @@ export default function Ractive$findAll ( selector, options ) {
 
 	this.fragment.findAll( selector, query );
 
+	// seach non-fragment children
+	this._children.forEach( c => {
+		if ( !c.target && c.ractive.fragment && c.ractive.fragment.rendered ) {
+			c.ractive.fragment.findAll( selector, query );
+		}
+	});
+
 	query.init();
 	return query.result;
 }

--- a/src/Ractive/prototype/findAll.js
+++ b/src/Ractive/prototype/findAll.js
@@ -1,36 +1,44 @@
 import Query from './shared/Query';
+import { find } from '../../utils/array';
 
-export default function Ractive$findAll ( selector, options ) {
+export default function Ractive$findAll ( selector, options = {} ) {
 	if ( !this.el ) throw new Error( `Cannot call ractive.findAll('${selector}', ...) unless instance is rendered to the DOM` );
 
-	options = options || {};
-	let liveQueries = this._liveQueries;
+	let query = options._query;
 
-	// Shortcut: if we're maintaining a live query with this
-	// selector, we don't need to traverse the parallel DOM
-	let query = liveQueries[ selector ];
-	if ( query ) {
-		// Either return the exact same query, or (if not live) a snapshot
-		return ( options && options.live ) ? query : query.slice();
-	}
+	if ( !query ) {
+		let liveQueries = this._liveQueries;
 
-	query = new Query( this, selector, !!options.live, false );
+		// Shortcut: if we're maintaining a live query with this
+		// selector, we don't need to traverse the parallel DOM
+		query = find( liveQueries, q => q.selector === selector && q.remote === options.remote );
+		if ( query ) {
+			if ( options.live ) query.refs++;
+			// Either return the exact same query, or (if not live) a snapshot
+			return options.live ? query : query.slice();
+		}
 
-	// Add this to the list of live queries Ractive needs to maintain,
-	// if applicable
-	if ( query.live ) {
-		liveQueries.push( selector );
-		liveQueries[ '_' + selector ] = query;
+		query = new Query( this, selector, !!options.live, false );
+		options._query = query;
+		query.remote = options.remote;
+
+		// Add this to the list of live queries Ractive needs to maintain,
+		// if applicable
+		if ( query.live ) {
+			liveQueries.push( query );
+		}
 	}
 
 	this.fragment.findAll( selector, query );
 
-	// seach non-fragment children
-	this._children.forEach( c => {
-		if ( !c.target && c.instance.fragment && c.instance.fragment.rendered ) {
-			c.instance.fragment.findAll( selector, query );
-		}
-	});
+	if ( query.remote ) {
+		// seach non-fragment children
+		this._children.forEach( c => {
+			if ( !c.target && c.instance.fragment && c.instance.fragment.rendered ) {
+				c.instance.findAll( selector, options );
+			}
+		});
+	}
 
 	query.init();
 	return query.result;

--- a/src/Ractive/prototype/findAll.js
+++ b/src/Ractive/prototype/findAll.js
@@ -27,8 +27,8 @@ export default function Ractive$findAll ( selector, options ) {
 
 	// seach non-fragment children
 	this._children.forEach( c => {
-		if ( !c.target && c.ractive.fragment && c.ractive.fragment.rendered ) {
-			c.ractive.fragment.findAll( selector, query );
+		if ( !c.target && c.instance.fragment && c.instance.fragment.rendered ) {
+			c.instance.fragment.findAll( selector, query );
 		}
 	});
 

--- a/src/Ractive/prototype/findAllComponents.js
+++ b/src/Ractive/prototype/findAllComponents.js
@@ -1,6 +1,11 @@
 import Query from './shared/Query';
 
 export default function Ractive$findAllComponents ( selector, options ) {
+	if ( !options && typeof selector === 'object' ) {
+		options = selector;
+		selector = '';
+	}
+
 	options = options || {};
 	let liveQueries = this._liveComponentQueries;
 
@@ -25,10 +30,13 @@ export default function Ractive$findAllComponents ( selector, options ) {
 
 	// search non-fragment children
 	this._children.forEach( c => {
-		if ( !c.target && c.ractive.fragment && c.ractive.fragment.rendered ) {
-			if ( query.test( c ) ) query.add( c.ractive );
+		if ( !c.target && c.instance.fragment && c.instance.fragment.rendered ) {
+			if ( query.test( c ) ) {
+				query.add( c.instance );
+				c.liveQueries.push( query );
+			}
 
-			c.ractive.fragment.findAllComponents( selector, query );
+			c.instance.fragment.findAllComponents( selector, query );
 		}
 	});
 

--- a/src/Ractive/prototype/findAllComponents.js
+++ b/src/Ractive/prototype/findAllComponents.js
@@ -23,6 +23,15 @@ export default function Ractive$findAllComponents ( selector, options ) {
 
 	this.fragment.findAllComponents( selector, query );
 
+	// search non-fragment children
+	this._children.forEach( c => {
+		if ( !c.target && c.ractive.fragment && c.ractive.fragment.rendered ) {
+			if ( query.test( c ) ) query.add( c.ractive );
+
+			c.ractive.fragment.findAllComponents( selector, query );
+		}
+	});
+
 	query.init();
 	return query.result;
 }

--- a/src/Ractive/prototype/findAllComponents.js
+++ b/src/Ractive/prototype/findAllComponents.js
@@ -1,4 +1,5 @@
 import Query from './shared/Query';
+import { find } from '../../utils/array';
 
 export default function Ractive$findAllComponents ( selector, options ) {
 	if ( !options && typeof selector === 'object' ) {
@@ -7,38 +8,47 @@ export default function Ractive$findAllComponents ( selector, options ) {
 	}
 
 	options = options || {};
-	let liveQueries = this._liveComponentQueries;
 
-	// Shortcut: if we're maintaining a live query with this
-	// selector, we don't need to traverse the parallel DOM
-	let query = liveQueries[ selector ];
-	if ( query ) {
-		// Either return the exact same query, or (if not live) a snapshot
-		return ( options && options.live ) ? query : query.slice();
-	}
+	let query = options._query;
 
-	query = new Query( this, selector, !!options.live, true );
+	if ( !query ) {
+		let liveQueries = this._liveComponentQueries;
 
-	// Add this to the list of live queries Ractive needs to maintain,
-	// if applicable
-	if ( query.live ) {
-		liveQueries.push( selector );
-		liveQueries[ '_' + selector ] = query;
+		// Shortcut: if we're maintaining a live query with this
+		// selector, we don't need to traverse the parallel DOM
+		query = find( liveQueries, q => q.selector === selector && q.remote === options.remote );
+		if ( query ) {
+			if ( options.live ) query.refs++;
+			// Either return the exact same query, or (if not live) a snapshot
+			return ( options.live ) ? query : query.slice();
+		}
+
+		query = new Query( this, selector, !!options.live, true );
+		options._query = query;
+		query.remote = options.remote;
+
+		// Add this to the list of live queries Ractive needs to maintain,
+		// if applicable
+		if ( query.live ) {
+			liveQueries.push( query );
+		}
 	}
 
 	this.fragment.findAllComponents( selector, query );
 
-	// search non-fragment children
-	this._children.forEach( c => {
-		if ( !c.target && c.instance.fragment && c.instance.fragment.rendered ) {
-			if ( query.test( c ) ) {
-				query.add( c.instance );
-				c.liveQueries.push( query );
-			}
+	if ( query.remote ) {
+		// search non-fragment children
+		this._children.forEach( c => {
+			if ( !c.target && c.instance.fragment && c.instance.fragment.rendered ) {
+				if ( query.test( c ) ) {
+					query.add( c.instance );
+					c.liveQueries.push( query );
+				}
 
-			c.instance.fragment.findAllComponents( selector, query );
-		}
-	});
+				c.instance.findAllComponents( selector, options );
+			}
+		});
+	}
 
 	query.init();
 	return query.result;

--- a/src/Ractive/prototype/findComponent.js
+++ b/src/Ractive/prototype/findComponent.js
@@ -2,10 +2,10 @@ export default function Ractive$findComponent ( selector ) {
 	const child = this.fragment.findComponent( selector );
 	if ( child ) return child;
 
-	if ( !selector && this._children.length ) return this._children[0].ractive;
+	if ( !selector && this._children.length ) return this._children[0].instance;
 	for ( let i = 0; i < this._children.length; i++ ) {
 		// skip children that are or should be in an anchor
 		if ( this._children[i].target ) continue;
-		if ( this._children[i].name === selector ) return this._children[i].ractive;
+		if ( this._children[i].name === selector ) return this._children[i].instance;
 	}
 }

--- a/src/Ractive/prototype/findComponent.js
+++ b/src/Ractive/prototype/findComponent.js
@@ -1,11 +1,20 @@
-export default function Ractive$findComponent ( selector ) {
-	const child = this.fragment.findComponent( selector );
+export default function Ractive$findComponent ( selector, options = {} ) {
+	if ( typeof selector === 'object' ) {
+		options = selector;
+		selector = '';
+	}
+
+	let child = this.fragment.findComponent( selector, options );
 	if ( child ) return child;
 
-	if ( !selector && this._children.length ) return this._children[0].instance;
-	for ( let i = 0; i < this._children.length; i++ ) {
-		// skip children that are or should be in an anchor
-		if ( this._children[i].target ) continue;
-		if ( this._children[i].name === selector ) return this._children[i].instance;
+	if ( options.remote ) {
+		if ( !selector && this._children.length ) return this._children[0].instance;
+		for ( let i = 0; i < this._children.length; i++ ) {
+			// skip children that are or should be in an anchor
+			if ( this._children[i].target ) continue;
+			if ( this._children[i].name === selector ) return this._children[i].instance;
+			child = this._children[i].instance.findComponent( selector, options );
+			if ( child ) return child;
+		}
 	}
 }

--- a/src/Ractive/prototype/findComponent.js
+++ b/src/Ractive/prototype/findComponent.js
@@ -1,3 +1,11 @@
 export default function Ractive$findComponent ( selector ) {
-	return this.fragment.findComponent( selector );
+	const child = this.fragment.findComponent( selector );
+	if ( child ) return child;
+
+	if ( !selector && this._children.length ) return this._children[0].ractive;
+	for ( let i = 0; i < this._children.length; i++ ) {
+		// skip children that are or should be in an anchor
+		if ( this._children[i].target ) continue;
+		if ( this._children[i].name === selector ) return this._children[i].ractive;
+	}
 }

--- a/src/Ractive/prototype/getNodeInfo.js
+++ b/src/Ractive/prototype/getNodeInfo.js
@@ -1,8 +1,8 @@
 import staticInfo from '../static/getNodeInfo';
 
-export default function getNodeInfo( node ) {
+export default function getNodeInfo( node, options ) {
 	if ( typeof node === 'string' ) {
-		node = this.find( node );
+		node = this.find( node, options );
 	}
 
 	return staticInfo( node );

--- a/src/Ractive/prototype/mapPath.js
+++ b/src/Ractive/prototype/mapPath.js
@@ -1,0 +1,5 @@
+export default function mapPath ( dest, src, opts = {} ) {
+	// TODO: the source ractive instance should be an option
+	// TODO: map the path and trigger a rebind
+	//		 perferrably only for paths that overlap with the new mappings
+}

--- a/src/Ractive/prototype/mapPath.js
+++ b/src/Ractive/prototype/mapPath.js
@@ -1,5 +1,31 @@
+import { splitKeypath } from '../../shared/keypaths';
+import runloop from '../../global/runloop';
+import resolveReference from '../../view/resolvers/resolveReference';
+
 export default function mapPath ( dest, src, opts = {} ) {
-	// TODO: the source ractive instance should be an option
-	// TODO: map the path and trigger a rebind
-	//		 perferrably only for paths that overlap with the new mappings
+	if ( splitKeypath( dest ).length !== 1 ) throw new Error( `Mappings must be a single top-level key. ${dest} is invalid.` );
+	const keys = splitKeypath( src );
+
+	let model;
+
+	if ( opts.ractive ) model = opts.ractive.viewmodel.joinAll( keys );
+
+	if ( !model ) {
+		model = resolveReference( this.component.parentFragment || this.fragment.componentFragment || this.parent.fragment, src );
+	}
+
+	if ( !model ) throw new Error( `Mapping source '${src}' could not be resolved for '${dest}'.` );
+
+	this._mappings[ dest ] = model;
+
+	runloop.start();
+	if ( this.viewmodel.map( dest, model ) ) {
+		// this is a remapping, so a rebind is in order
+		// TODO: make this specific to the relevant keypath
+		runloop.forceRebind();
+		this.fragment.rebind( this.viewmodel );
+	} else {
+		this.viewmodel.clearUnresolveds();
+	}
+	runloop.end();
 }

--- a/src/Ractive/prototype/removeMapping.js
+++ b/src/Ractive/prototype/removeMapping.js
@@ -1,6 +1,6 @@
 import runloop from '../../global/runloop';
 
-export default function unmapPath ( dest ) {
+export default function removeMapping ( dest ) {
 	const model = this._mappings[ dest ];
 	if ( !model ) return;
 

--- a/src/Ractive/prototype/shared/Query.js
+++ b/src/Ractive/prototype/shared/Query.js
@@ -14,8 +14,16 @@ function sortByDocumentPosition ( node, otherNode ) {
 }
 
 function sortByItemPosition ( a, b ) {
-	const ancestryA = getAncestry( a.component || a._ractive.proxy );
-	const ancestryB = getAncestry( b.component || b._ractive.proxy );
+	const baseA = a.component || a._ractive.proxy;
+	const baseB = b.component || b._ractive.proxy;
+
+	// allow for attached childdren outside the template
+	if ( baseA.target === false && baseB.target === false ) return 0;
+	else if ( baseA.target === false ) return 1;
+	else if ( baseB.target === false ) return -1;
+
+	const ancestryA = getAncestry( baseA );
+	const ancestryB = getAncestry( baseB );
 
 	let oldestA = lastItem( ancestryA );
 	let oldestB = lastItem( ancestryB );
@@ -131,8 +139,8 @@ export default class Query {
 		}
 	}
 
-	remove ( nodeOrComponent ) {
-		const index = this.result.indexOf( this.isComponentQuery ? nodeOrComponent.instance : nodeOrComponent );
+	remove ( item ) {
+		const index = this.result.indexOf( item );
 		if ( index !== -1 ) this.result.splice( index, 1 );
 	}
 

--- a/src/Ractive/prototype/shared/Query.js
+++ b/src/Ractive/prototype/shared/Query.js
@@ -113,6 +113,8 @@ export default class Query {
 			liveQueries.splice( index, 1 );
 			liveQueries[ selector ] = null;
 		}
+
+		this.cancelled = true;
 	}
 
 	init () {

--- a/src/Ractive/prototype/unmapPath.js
+++ b/src/Ractive/prototype/unmapPath.js
@@ -1,0 +1,3 @@
+export default function unmapPath ( dest ) {
+	// TODO: clear out the mapping and trigger a rebind, preferably only on overlapping paths
+}

--- a/src/Ractive/prototype/unmapPath.js
+++ b/src/Ractive/prototype/unmapPath.js
@@ -1,3 +1,17 @@
+import runloop from '../../global/runloop';
+
 export default function unmapPath ( dest ) {
-	// TODO: clear out the mapping and trigger a rebind, preferably only on overlapping paths
+	const model = this._mappings[ dest ];
+	if ( !model ) return;
+
+	delete this._mappings[ dest ];
+
+	if ( this.viewmodel.mappings[ dest ] === model ) {
+		delete this.viewmodel.mappings[ dest ];
+		runloop.start();
+
+		runloop.forceRebind();
+		this.fragment.rebind( this.viewmodel );
+		runloop.end();
+	}
 }

--- a/src/Ractive/prototype/unrender.js
+++ b/src/Ractive/prototype/unrender.js
@@ -16,8 +16,11 @@ export default function Ractive$unrender () {
 
 	// If this is a component, and the component isn't marked for destruction,
 	// don't detach nodes from the DOM unnecessarily
-	const shouldDestroy = !this.component || this.component.shouldDestroy || this.shouldDestroy;
+	const shouldDestroy = !this.component || ( this.component.anchor || {} ).shouldDestroy || this.component.shouldDestroy || this.shouldDestroy;
 	this.fragment.unrender( shouldDestroy );
+	if ( shouldDestroy ) {
+		this.destroyed = true;
+	}
 
 	removeFromArray( this.el.__ractive_instances__, this );
 

--- a/src/Ractive/render.js
+++ b/src/Ractive/render.js
@@ -3,6 +3,7 @@ import { applyCSS } from '../global/css';
 import Hook from '../events/Hook';
 import { getElement } from '../utils/dom';
 import runloop from '../global/runloop';
+import { createFragment } from './initialise';
 
 const renderHook = new Hook( 'render' );
 const completeHook = new Hook( 'complete' );
@@ -17,6 +18,11 @@ export default function render ( ractive, target, anchor, occupants ) {
 
 	if ( ractive.fragment.rendered ) {
 		throw new Error( 'You cannot call ractive.render() on an already rendered instance! Call ractive.unrender() first' );
+	}
+
+	if ( ractive.destroyed ) {
+		ractive.destroyed = false;
+		ractive.fragment = createFragment( ractive ).bind( ractive.viewmodel );
 	}
 
 	anchor = getElement( anchor ) || ractive.anchor;

--- a/src/config/types.js
+++ b/src/config/types.js
@@ -8,6 +8,7 @@ export const ELEMENT           = 7;
 export const PARTIAL           = 8;
 export const COMMENT           = 9;
 export const DELIMCHANGE       = 10;
+export const ANCHOR            = 11;
 export const ATTRIBUTE         = 13;
 export const CLOSING_TAG       = 14;
 export const COMPONENT         = 15;

--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -142,7 +142,11 @@ export default class RootModel extends Model {
 		}
 		this.mappings = {};
 
-		// TODO: add the mapPaths back here
+		const external = this.ractive._mappings;
+		for ( let k in external ) {
+			this.mappings[ k ] = external[ k ];
+			external[ k ].register( this );
+		}
 	}
 
 	set ( value ) {

--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -116,8 +116,8 @@ export default class RootModel extends Model {
 		if ( key === '@this' ) return this.getRactiveModel();
 
 		return this.mappings.hasOwnProperty( key ) ? this.mappings[ key ] :
-		       this.computations.hasOwnProperty( key ) ? this.computations[ key ] :
-		       super.joinKey( key );
+			this.computations.hasOwnProperty( key ) ? this.computations[ key ] :
+			super.joinKey( key );
 	}
 
 	map ( localKey, origin ) {
@@ -141,6 +141,8 @@ export default class RootModel extends Model {
 			this.mappings[k].unregister( this );
 		}
 		this.mappings = {};
+
+		// TODO: add the mapPaths back here
 	}
 
 	set ( value ) {

--- a/src/parse/_parse.js
+++ b/src/parse/_parse.js
@@ -3,6 +3,7 @@ import Parser from './Parser';
 import readMustache from './converters/readMustache';
 import readTriple from './converters/mustache/readTriple';
 import readUnescaped from './converters/mustache/readUnescaped';
+import readAnchor from './converters/mustache/readAnchor';
 import readPartial from './converters/mustache/readPartial';
 import readMustacheComment from './converters/mustache/readMustacheComment';
 import readInterpolator from './converters/mustache/readInterpolator';
@@ -21,7 +22,7 @@ import { fromComputationString } from './utils/createFunction';
 // See https://github.com/ractivejs/template-spec for information
 // about the Ractive template specification
 
-let STANDARD_READERS = [ readPartial, readUnescaped, readSection, readYielder, readInterpolator, readMustacheComment ];
+let STANDARD_READERS = [ readAnchor, readPartial, readUnescaped, readSection, readYielder, readInterpolator, readMustacheComment ];
 let TRIPLE_READERS = [ readTriple ];
 let STATIC_READERS = [ readUnescaped, readSection, readInterpolator ]; // TODO does it make sense to have a static section?
 

--- a/src/parse/converters/mustache/readAnchor.js
+++ b/src/parse/converters/mustache/readAnchor.js
@@ -1,0 +1,30 @@
+import { ANCHOR } from '../../../config/types';
+
+const namePattern = /[-a-zA-Z0-9_$#]+/;
+
+export default function readPartial ( parser, tag ) {
+	if ( !parser.matchString( '>>' ) ) return null;
+
+	parser.allowWhitespace();
+
+	let multi = false;
+	const name = parser.matchPattern( namePattern );
+
+	if ( !name ) parser.error( `Expected a valid anchor name.` );
+
+	parser.allowWhitespace();
+
+	if ( parser.matchString( 'multi' ) ) multi = true;
+
+	parser.allowWhitespace();
+
+	if ( !parser.matchString( tag.close ) ) {
+		parser.error( `Expected closing delimiter '${tag.close}'` );
+	}
+
+	return {
+		t: ANCHOR,
+		n: name,
+		m: multi
+	};
+}

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -75,3 +75,10 @@ export function toArray ( arrayLike ) {
 
 	return array;
 }
+
+export function find ( array, fn ) {
+	const len = array.length;
+	for ( let i = 0; i < len; i++ ) {
+		if ( fn( array[i] ) ) return array[i];
+	}
+}

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -79,12 +79,12 @@ export default class Fragment {
 		return docFrag;
 	}
 
-	find ( selector ) {
+	find ( selector, options ) {
 		const len = this.items.length;
 		let i;
 
 		for ( i = 0; i < len; i += 1 ) {
-			const found = this.items[i].find( selector );
+			const found = this.items[i].find( selector, options );
 			if ( found ) return found;
 		}
 	}
@@ -106,12 +106,12 @@ export default class Fragment {
 		return query;
 	}
 
-	findComponent ( name ) {
+	findComponent ( name, options ) {
 		const len = this.items.length;
 		let i;
 
 		for ( i = 0; i < len; i += 1 ) {
-			const found = this.items[i].findComponent( name );
+			const found = this.items[i].findComponent( name, options );
 			if ( found ) return found;
 		}
 	}

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -96,12 +96,12 @@ export default class RepeatedFragment {
 		return docFrag;
 	}
 
-	find ( selector ) {
+	find ( selector, options ) {
 		const len = this.iterations.length;
 		let i;
 
 		for ( i = 0; i < len; i += 1 ) {
-			const found = this.iterations[i].find( selector );
+			const found = this.iterations[i].find( selector, options );
 			if ( found ) return found;
 		}
 	}
@@ -115,12 +115,12 @@ export default class RepeatedFragment {
 		}
 	}
 
-	findComponent ( name ) {
+	findComponent ( name, options ) {
 		const len = this.iterations.length;
 		let i;
 
 		for ( i = 0; i < len; i += 1 ) {
-			const found = this.iterations[i].findComponent( name );
+			const found = this.iterations[i].findComponent( name, options );
 			if ( found ) return found;
 		}
 	}

--- a/src/view/items/Alias.js
+++ b/src/view/items/Alias.js
@@ -34,9 +34,9 @@ export default class Alias extends Item {
 		return this.fragment ? this.fragment.detach() : createDocumentFragment();
 	}
 
-	find ( selector ) {
+	find ( selector, options ) {
 		if ( this.fragment ) {
-			return this.fragment.find( selector );
+			return this.fragment.find( selector, options );
 		}
 	}
 
@@ -46,9 +46,9 @@ export default class Alias extends Item {
 		}
 	}
 
-	findComponent ( name ) {
+	findComponent ( name, options ) {
 		if ( this.fragment ) {
-			return this.fragment.findComponent( name );
+			return this.fragment.findComponent( name, options );
 		}
 	}
 

--- a/src/view/items/Anchor.js
+++ b/src/view/items/Anchor.js
@@ -42,7 +42,7 @@ export default class Anchor extends Item {
 
 	detach () {
 		const docFrag = createDocumentFragment();
-		this.items.forEach( item => docFrag.appendChild( item.detach() ) );
+		this.activeItems.forEach( i => docFrag.appendChild( i.ractive.fragment.detach() ) );
 		return docFrag;
 	}
 
@@ -83,6 +83,17 @@ export default class Anchor extends Item {
 
 			i.ractive.fragment.findAllComponents( name, query );
 		});
+	}
+
+	firstNode () {
+		for ( let i = 0; i < this.activeItems.length; i++ ) {
+			const node = this.activeItems[i].ractive.fragment.firstNode();
+			if ( node ) return node;
+		}
+	}
+
+	rebind () {
+		this.items.forEach( i => i.ractive.fragment.rebind() );
 	}
 
 	removeChild ( meta ) {

--- a/src/view/items/Anchor.js
+++ b/src/view/items/Anchor.js
@@ -156,7 +156,7 @@ function renderItem ( anchor, meta ) {
 	if ( meta.lastBound !== anchor ) {
 		meta.lastBound = anchor;
 		runloop.forceRebind();
-		meta.ractive.fragment.rebind();
+		meta.ractive.fragment.rebind( meta.ractive.viewmodel );
 	}
 }
 

--- a/src/view/items/Anchor.js
+++ b/src/view/items/Anchor.js
@@ -1,0 +1,171 @@
+import Item from './shared/Item';
+import { createDocumentFragment } from '../../utils/dom';
+import { addToArray, removeFromArray } from '../../utils/array';
+import render from '../../Ractive/render';
+import runloop from '../../global/runloop';
+
+// when anchors appear, register and find children that want to be there
+// when achors disappear, unrender children and release them back to the pool
+
+export default class Anchor extends Item {
+	constructor ( options ) {
+		super( options );
+
+		this.name = options.template.n;
+		this.multi = options.template.m;
+
+		this.ractive = this.parentFragment.ractive;
+
+		this.items = [];
+		this.activeItems = [];
+
+		this.liveQueries = [];
+	}
+
+	addChild ( meta ) {
+		addToArray( this.items, meta );
+
+		meta.parentFragment = this.parentFragment;
+
+		// render/unrender as necessary
+		if ( this.multi || !this.activeItems.length ) {
+			renderItem( this, meta );
+		} else if ( !this.multi ) {
+			unrenderItem( this, this.activeItems[0] );
+			renderItem( this, meta );
+		}
+	}
+
+	bind () {
+		addToArray( this.ractive._anchors, this );
+	}
+
+	detach () {
+		const docFrag = createDocumentFragment();
+		this.items.forEach( item => docFrag.appendChild( item.detach() ) );
+		return docFrag;
+	}
+
+	find ( selector ) {
+		const items = this.activeItems;
+
+		for ( let i = 0; i < items.length; i++ ) {
+			const node = items[i].ractive.fragment.find( selector );
+			if ( node ) return node;
+		}
+	}
+
+	findAll ( selector, query ) {
+		const items = this.activeItems;
+
+		for ( let i = 0; i < items.length; i++ ) {
+			items[i].ractive.fragment.findAll( selector, query );
+		}
+
+		return query;
+	}
+
+	findComponent ( name ) {
+		if ( !name && this.items.length ) return this.items[0].ractive;
+
+		for ( let i = 0; i < this.items.length; i++ ) {
+			if ( this.items[i].name === name ) return this.items[i].ractive;
+			const child = this.items[i].ractive.findComponent( name );
+			if ( child ) return child;
+		}
+	}
+
+	findAllComponents ( name, query ) {
+		this.activeItems.forEach( i => {
+			if ( query.test( i ) ) query.add( i.ractive );
+
+			if ( query.live ) this.liveQueries.push( query );
+
+			i.ractive.fragment.findAllComponents( name, query );
+		});
+	}
+
+	removeChild ( meta ) {
+		removeFromArray( this.items, meta );
+
+		// unrender/render as necessary
+		if ( ~this.activeItems.indexOf( meta ) ) unrenderItem( this, meta );
+
+		if ( !this.multi && this.items.length ) {
+			renderItem( this, this.items[ this.items.length - 1 ] );
+		}
+	}
+
+	render ( target ) {
+		this.rendered = true;
+		this.target = target;
+
+		// collect children that should live here
+		const items = this.ractive._children;
+		items.forEach( i => {
+			if ( i.target === this.name ) {
+				this.items.push( i );
+				i.anchor = this;
+			}
+		});
+
+
+		if ( this.multi ) {
+			this.items.forEach( i => renderItem( this, i ) );
+		} else if ( this.items.length ) {
+			renderItem( this, this.items[ this.items.length - 1 ] );
+		}
+	}
+
+	unbind () {
+		removeFromArray( this.ractive._anchors, this );
+	}
+
+	update () {
+		this.dirty = false;
+		this.items.forEach( i => i.ractive.fragment.update() );
+	}
+
+	unrender ( shouldDestroy ) {
+		this.shouldDestroy = shouldDestroy;
+
+		this.activeItems.forEach( i => unrenderItem( this, i ) );
+
+		this.rendered = false;
+		this.target = null;
+
+		this.items.forEach( i => {
+			if ( i.anchor === this ) i.anchor = null;
+		});
+		this.items = [];
+	}
+}
+
+function renderItem ( anchor, meta ) {
+	if ( !anchor.rendered ) return;
+
+	meta.shouldDestroy = false;
+	meta.parentFragment = anchor.parentFragment;
+
+	anchor.activeItems.push( meta );
+	const nextNode = anchor.parentFragment.findNextNode( anchor );
+
+	if ( meta.ractive.fragment.rendered ) meta.ractive.unrender();
+	render( meta.ractive, anchor.target, anchor.target.contains( nextNode ) ? nextNode : null );
+
+	if ( meta.lastBound !== anchor ) {
+		meta.lastBound = anchor;
+		runloop.forceRebind();
+		meta.ractive.fragment.rebind();
+	}
+}
+
+function unrenderItem ( anchor, meta ) {
+	if ( !anchor.rendered ) return;
+
+	removeFromArray( anchor.activeItems, meta );
+	meta.shouldDestroy = true;
+	meta.ractive.unrender();
+	meta.ractive.el = meta.ractive.anchor = null;
+	meta.parentFragment = null;
+}

--- a/src/view/items/Anchor.js
+++ b/src/view/items/Anchor.js
@@ -42,12 +42,12 @@ export default class Anchor extends Item {
 		return docFrag;
 	}
 
-	find ( selector ) {
+	find ( selector, options ) {
 		const items = this.activeItems;
 
 		for ( let i = 0; i < items.length; i++ ) {
-			const node = items[i].instance.fragment.find( selector );
-			if ( node ) return node;
+			const found = items[i].instance.find( selector, options );
+			if ( found ) return found;
 		}
 	}
 
@@ -55,29 +55,34 @@ export default class Anchor extends Item {
 		const items = this.activeItems;
 
 		for ( let i = 0; i < items.length; i++ ) {
-			items[i].instance.fragment.findAll( selector, query );
+			items[i].instance.findAll( selector, { _query: query } );
 		}
 
 		return query;
 	}
 
-	findComponent ( name ) {
-		if ( !name && this.items.length ) return this.items[0].instance;
+	findComponent ( name, options ) {
+		const items = options.remote ? this.items : this.activeItems;
 
-		for ( let i = 0; i < this.items.length; i++ ) {
-			if ( this.items[i].name === name ) return this.items[i].instance;
-			const child = this.items[i].instance.findComponent( name );
-			if ( child ) return child;
+		if ( !name && items.length ) return items[0].instance;
+
+		for ( let i = 0; i < items.length; i++ ) {
+			if ( items[i].name === name ) return items[i].instance;
+			const found = items[i].instance.findComponent( name, options );
+			if ( found ) return found;
 		}
 	}
 
 	findAllComponents ( name, query ) {
-		this.activeItems.forEach( i => {
-			if ( query.test( i ) ) query.add( i.instance );
+		const items = query.remote ? this.items : this.activeItems;
 
-			if ( query.live ) i.liveQueries.push( query );
+		items.forEach( i => {
+			if ( query.test( i ) ) {
+				query.add( i.instance );
+				if ( query.live ) i.liveQueries.push( query );
+			}
 
-			i.instance.fragment.findAllComponents( name, query );
+			i.instance.findAllComponents( name, { _query: query } );
 		});
 	}
 

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -136,19 +136,19 @@ export default class Component extends Item {
 		return this.instance.fragment.detach();
 	}
 
-	find ( selector ) {
-		return this.instance.fragment.find( selector );
+	find ( selector, options ) {
+		return this.instance.find( selector, options );
 	}
 
 	findAll ( selector, query ) {
-		this.instance.fragment.findAll( selector, query );
+		this.instance.findAll( selector, { _query: query } );
 	}
 
-	findComponent ( name ) {
+	findComponent ( name, options ) {
 		if ( !name || this.name === name ) return this.instance;
 
 		if ( this.instance.fragment ) {
-			return this.instance.fragment.findComponent( name );
+			return this.instance.findComponent( name, options );
 		}
 	}
 
@@ -161,7 +161,7 @@ export default class Component extends Item {
 			}
 		}
 
-		this.instance.fragment.findAllComponents( name, query );
+		this.instance.findAllComponents( name, { _query: query } );
 	}
 
 	firstNode ( skipParent ) {

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -130,10 +130,10 @@ export default class Element extends Item {
 		return detachNode( this.node );
 	}
 
-	find ( selector ) {
+	find ( selector, options ) {
 		if ( matches( this.node, selector ) ) return this.node;
 		if ( this.fragment ) {
-			return this.fragment.find( selector );
+			return this.fragment.find( selector, options );
 		}
 	}
 
@@ -151,9 +151,9 @@ export default class Element extends Item {
 		}
 	}
 
-	findComponent ( name ) {
+	findComponent ( name, options ) {
 		if ( this.fragment ) {
-			return this.fragment.findComponent( name );
+			return this.fragment.findComponent( name, options );
 		}
 	}
 

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -4,7 +4,7 @@ import Item from './shared/Item';
 import Fragment from '../Fragment';
 import ConditionalAttribute from './element/ConditionalAttribute';
 import updateLiveQueries from './element/updateLiveQueries';
-import { toArray } from '../../utils/array';
+import { removeFromArray, toArray } from '../../utils/array';
 import { escapeHtml, voidElementNames } from '../../utils/html';
 import { bind, rebind, render, unbind, unrender, update } from '../../shared/methodCallers';
 import { createElement, detachNode, matches, safeAttributeString, decamelize } from '../../utils/dom';
@@ -197,6 +197,11 @@ export default class Element extends Item {
 		}
 	}
 
+	removeFromQuery( query ) {
+		removeFromArray( this.liveQueries, query );
+		query.remove( this.node );
+	}
+
 	render ( target, occupants ) {
 		// TODO determine correct namespace
 		this.namespace = getNamespace( this );
@@ -367,7 +372,8 @@ export default class Element extends Item {
 			runloop.registerTransition( this._outroTransition );
 		}
 
-		removeFromLiveQueries( this );
+		this.liveQueries.forEach( query => query.remove( this.node ) );
+		this.liveQueries = [];
 		// TODO forms are a special case
 	}
 
@@ -401,14 +407,6 @@ function inputIsCheckedRadio ( element ) {
 function stringifyAttribute ( attribute ) {
 	const str = attribute.toString();
 	return str ? ' ' + str : '';
-}
-
-function removeFromLiveQueries ( element ) {
-	let i = element.liveQueries.length;
-	while ( i-- ) {
-		const query = element.liveQueries[i];
-		query.remove( element.node );
-	}
 }
 
 function getNamespace ( element ) {

--- a/src/view/items/Partial.js
+++ b/src/view/items/Partial.js
@@ -44,16 +44,16 @@ export default class Partial extends Mustache {
 		return this.fragment.detach();
 	}
 
-	find ( selector ) {
-		return this.fragment.find( selector );
+	find ( selector, options ) {
+		return this.fragment.find( selector, options );
 	}
 
 	findAll ( selector, query ) {
 		this.fragment.findAll( selector, query );
 	}
 
-	findComponent ( name ) {
-		return this.fragment.findComponent( name );
+	findComponent ( name, options ) {
+		return this.fragment.findComponent( name, options );
 	}
 
 	findAllComponents ( name, query ) {

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -46,9 +46,9 @@ export default class Section extends Mustache {
 		return this.fragment ? this.fragment.detach() : createDocumentFragment();
 	}
 
-	find ( selector ) {
+	find ( selector, options ) {
 		if ( this.fragment ) {
-			return this.fragment.find( selector );
+			return this.fragment.find( selector, options );
 		}
 	}
 
@@ -58,9 +58,9 @@ export default class Section extends Mustache {
 		}
 	}
 
-	findComponent ( name ) {
+	findComponent ( name, options ) {
 		if ( this.fragment ) {
-			return this.fragment.findComponent( name );
+			return this.fragment.findComponent( name, options );
 		}
 	}
 

--- a/src/view/items/Yielder.js
+++ b/src/view/items/Yielder.js
@@ -53,16 +53,16 @@ export default class Yielder extends Item {
 		return this.fragment.detach();
 	}
 
-	find ( selector ) {
-		return this.fragment.find( selector );
+	find ( selector, options ) {
+		return this.fragment.find( selector, options );
 	}
 
 	findAll ( selector, queryResult ) {
 		this.fragment.find( selector, queryResult );
 	}
 
-	findComponent ( name ) {
-		return this.fragment.findComponent( name );
+	findComponent ( name, options ) {
+		return this.fragment.findComponent( name, options );
 	}
 
 	findAllComponents ( name, queryResult ) {

--- a/src/view/items/component/updateLiveQueries.js
+++ b/src/view/items/component/updateLiveQueries.js
@@ -3,20 +3,33 @@
 export default function updateLiveQueries ( component ) {
 	// Does this need to be added to any live queries?
 	let instance = component.ractive;
+	const queries = [], remotes = {};
+	let remote = component.target === false;
+	let i;
 
 	do {
 		const liveQueries = instance._liveComponentQueries;
 
-		let i = liveQueries.length;
+		i = liveQueries.length;
 		while ( i-- ) {
-			const name = liveQueries[i];
-			const query = liveQueries[ `_${name}` ];
+			const query = liveQueries[i];
 
 			if ( query.test( component ) ) {
-				query.add( component.instance );
-				// keep register of applicable selectors, for when we teardown
-				component.liveQueries.push( query );
+				queries.push( query );
 			}
 		}
+
+		if ( !remote && instance.component && instance.component.target === false ) remote = true;
+		remotes[ instance._guid ] = remote;
 	} while ( instance = instance.parent );
+
+	i = queries.length;
+	while ( i-- ) {
+		const query = queries[i];
+		if ( query.remote || !remotes[ query.ractive._guid ] ) {
+			query.add( component.instance );
+			// keep register of applicable selectors, for when we teardown
+			component.liveQueries.push( query );
+		}
+	}
 }

--- a/src/view/items/createItem.js
+++ b/src/view/items/createItem.js
@@ -1,6 +1,7 @@
-import { ALIAS, COMPONENT, DOCTYPE, ELEMENT, INTERPOLATOR, PARTIAL, SECTION, TRIPLE, YIELDER } from '../../config/types';
+import { ALIAS, ANCHOR, COMPONENT, DOCTYPE, ELEMENT, INTERPOLATOR, PARTIAL, SECTION, TRIPLE, YIELDER } from '../../config/types';
 import { ATTRIBUTE, BINDING_FLAG, DECORATOR, EVENT, TRANSITION } from '../../config/types';
 import Alias from './Alias';
+import Anchor from './Anchor';
 import Attribute from './element/Attribute';
 import BindingFlag from './element/BindingFlag';
 import Component from './Component';
@@ -26,6 +27,7 @@ import findElement from './shared/findElement';
 
 const constructors = {};
 constructors[ ALIAS ] = Alias;
+constructors[ ANCHOR ] = Anchor;
 constructors[ DOCTYPE ] = Doctype;
 constructors[ INTERPOLATOR ] = Interpolator;
 constructors[ PARTIAL ] = Partial;

--- a/src/view/items/element/updateLiveQueries.js
+++ b/src/view/items/element/updateLiveQueries.js
@@ -2,20 +2,33 @@ export default function updateLiveQueries ( element ) {
 	// Does this need to be added to any live queries?
 	const node = element.node;
 	let instance = element.ractive;
+	const queries = [], remotes = {};
+	let remote = instance.component && instance.component.target === false;
+	let i;
 
 	do {
 		const liveQueries = instance._liveQueries;
 
-		let i = liveQueries.length;
+		i = liveQueries.length;
 		while ( i-- ) {
-			const selector = liveQueries[i];
-			const query = liveQueries[ `_${selector}` ];
+			const query = liveQueries[i];
 
 			if ( query.test( node ) ) {
-				query.add( node );
-				// keep register of applicable selectors, for when we teardown
-				element.liveQueries.push( query );
+				queries.push( query );
 			}
 		}
+
+		if ( !remote && instance.component && instance.component.target === false ) remote = true;
+		remotes[ instance._guid ] = remote;
 	} while ( instance = instance.parent );
+
+	i = queries.length;
+	while ( i-- ) {
+		const query = queries[i];
+		if ( query.remote || !remotes[ query.ractive._guid ] ) {
+			query.add( node );
+			// keep register of applicable selectors, for when we teardown
+			element.liveQueries.push( query );
+		}
+	}
 }

--- a/src/view/resolvers/resolveAmbiguousReference.js
+++ b/src/view/resolvers/resolveAmbiguousReference.js
@@ -50,9 +50,10 @@ export default function resolveAmbiguousReference ( fragment, ref ) {
 			}
 		}
 
-		if ( fragment.componentParent && !fragment.ractive.isolated ) {
+		//if ( fragment.componentParent && !fragment.ractive.isolated ) {
+		if ( ( fragment.componentParent || ( !fragment.parent && fragment.ractive.component ) ) && !fragment.ractive.isolated ) {
 			// ascend through component boundary
-			fragment = fragment.componentParent;
+			fragment = fragment.componentParent || fragment.ractive.component.parentFragment;
 			crossedComponentBoundary = true;
 		} else {
 			fragment = fragment.parent;

--- a/test/browser-tests/events/method-calls.js
+++ b/test/browser-tests/events/method-calls.js
@@ -49,7 +49,9 @@ export default function() {
 		// is a world of facepalm http://jsfiddle.net/geoz2tks/
 		const onerror = window.onerror;
 		window.onerror = function ( err ) {
-			t.ok( /is not a function/.test( err ) );
+			// sometimes when Jupiter aligns with Mars and you're on a slow system, you just get the string 'Script error.'
+			// even though the actual error is a TypeError. See facepalm above.
+			t.ok( /is not a function|Script error/.test( err ), `${err.message} - ${err.toString()}` );
 			return true;
 		};
 

--- a/test/browser-tests/events/method-calls.js
+++ b/test/browser-tests/events/method-calls.js
@@ -37,6 +37,8 @@ export default function() {
 	});
 
 	test( 'Calling an unknown method', t => {
+		t.expect( 1 );
+
 		const Widget = Ractive.extend({
 			template: `<button on-click='activate()'>{{foo}}</button>`
 		});
@@ -49,9 +51,9 @@ export default function() {
 		// is a world of facepalm http://jsfiddle.net/geoz2tks/
 		const onerror = window.onerror;
 		window.onerror = function ( err ) {
-			// sometimes when Jupiter aligns with Mars and you're on a slow system, you just get the string 'Script error.'
-			// even though the actual error is a TypeError. See facepalm above.
-			t.ok( /is not a function|Script error/.test( err ), `${err.message} - ${err.toString()}` );
+			// since expression events, the exception varies based on browser
+			// so we'll say that if it throws, it was good
+			t.ok( true, `${err.message} - ${err.toString()}` );
 			return true;
 		};
 

--- a/test/browser-tests/methods/addMapping.js
+++ b/test/browser-tests/methods/addMapping.js
@@ -1,0 +1,59 @@
+import { test } from 'qunit';
+import { initModule } from '../test-config';
+
+export default function() {
+	initModule( 'methods/addMapping.js' );
+
+	test( 'addMapping adds a mapping', t => {
+		const cmp = Ractive.extend({
+			template: '{{foo}}'
+		});
+		const r = new Ractive({
+			el: fixture,
+			template: '<cmp />',
+			data: { bar: 'foo' },
+			components: { cmp }
+		});
+
+		t.equal( fixture.innerHTML, '' );
+		r.findComponent().addMapping( 'foo', 'bar' );
+		t.equal( fixture.innerHTML, 'foo' );
+	});
+
+	test( `addMapping resolves from surrounding context`, t => {
+		const cmp = Ractive.extend({
+			template: '{{foo}}'
+		});
+		const r = new Ractive({
+			el: fixture,
+			template: '{{#bar.baz}}<cmp />{{/}}',
+			data: { bar: { bar: 'outer', baz: { bar: 'inner' } } },
+			components: { cmp }
+		});
+
+		t.equal( fixture.innerHTML, '' );
+		r.findComponent().addMapping( 'foo', '.bar' );
+		t.equal( fixture.innerHTML, 'inner' );
+	});
+
+	test( `addMapping will use a given instance`, t => {
+		const cmp = Ractive.extend({
+			template: '{{foo}}'
+		});
+		const r = new Ractive({
+			el: fixture,
+			template: '<cmp />',
+			data: { bar: 'foo' },
+			components: { cmp }
+		});
+		const other = new Ractive({
+			data: { bar: 'hello' }
+		});
+
+		t.equal( fixture.innerHTML, '' );
+		r.findComponent().addMapping( 'foo', 'bar', { ractive: other } );
+		t.equal( fixture.innerHTML, 'hello' );
+		other.set( 'bar', 'yep' );
+		t.equal( fixture.innerHTML, 'yep' );
+	});
+}

--- a/test/browser-tests/methods/attachChild.js
+++ b/test/browser-tests/methods/attachChild.js
@@ -1,0 +1,175 @@
+import { test } from 'qunit';
+import { initModule } from '../test-config';
+
+export default function() {
+	initModule( 'methods/attachChild.js' );
+
+	test( 'child instances can be attached to parents to inherit data implicitly', t => {
+		const r1 = new Ractive({
+			data: {
+				foo: 'bar'
+			}
+		});
+		const r2 = new Ractive({
+			template: '{{foo}}'
+		});
+
+		t.equal( r2.toHTML(), '' );
+		r1.attachChild( r2 );
+		t.equal( r2.toHTML(), 'bar' );
+	});
+
+	test( 'child instances can be attached to an anchor', t => {
+		const r1 = new Ractive({
+			template: '{{>>foo}}',
+			el: fixture
+		});
+		const r2 = new Ractive({
+			template: 'hello'
+		});
+
+		t.equal( fixture.innerHTML, '' );
+		r1.attachChild( r2, { target: 'foo' } );
+		t.equal( fixture.innerHTML, 'hello' );
+	});
+
+	test( 'targeted child instances are rendered and unrendered with their anchor', t => {
+		const r1 = new Ractive({
+			template: '{{#if show}}{{>>foo}}{{/if}}',
+			el: fixture
+		});
+		const r2 = new Ractive({
+			template: 'hello'
+		});
+
+		t.equal( fixture.innerHTML, '' );
+		r1.attachChild( r2, { target: 'foo' } );
+		t.equal( fixture.innerHTML, '' );
+		r1.set( 'show', true );
+		t.equal( fixture.innerHTML, 'hello' );
+		r1.set( 'show', false );
+		t.equal( fixture.innerHTML, '' );
+	});
+
+	test( 'non-targeted instances stay where they are when attached', t => {
+		fixture.innerHTML = '<div id="r1"></div><div id="r2"></div>';
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: 'r1'
+		});
+		const r2 = new Ractive({
+			el: fixture.children[1],
+			template: 'r2'
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1</div><div id="r2">r2</div>' );
+		r1.attachChild( r2 );
+		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1</div><div id="r2">r2</div>' );
+	});
+
+	test( 'targeted instances are unrendered before being attached', t => {
+		fixture.innerHTML = '<div id="r1"></div><div id="r2"></div>';
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: 'r1{{>>foo}}'
+		});
+		const r2 = new Ractive({
+			el: fixture.children[1],
+			template: 'r2'
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1</div><div id="r2">r2</div>' );
+		r1.attachChild( r2, { target: 'foo' } );
+		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1r2</div><div id="r2"></div>' );
+	});
+
+	test( 'targeted instances are unrendered event if their anchor doesn\'t exist when attached', t => {
+		fixture.innerHTML = '<div id="r1"></div><div id="r2"></div>';
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: 'r1'
+		});
+		const r2 = new Ractive({
+			el: fixture.children[1],
+			template: 'r2'
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1</div><div id="r2">r2</div>' );
+		r1.attachChild( r2, { target: 'foo' } );
+		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1</div><div id="r2"></div>' );
+	});
+
+	test( 'single tenant anchors render the latest available child', t => {
+		const r1 = new Ractive({
+			template: '{{>>foo}}',
+			el: fixture
+		});
+		const r2 = new Ractive({
+			template: 'hello'
+		});
+		const r3 = new Ractive({
+			template: 'world'
+		});
+
+		t.equal( fixture.innerHTML, '' );
+		r1.attachChild( r2, { target: 'foo' } );
+		t.equal( fixture.innerHTML, 'hello' );
+		r1.attachChild( r3, { target: 'foo' } );
+		t.equal( fixture.innerHTML, 'world' );
+		r1.detachChild( r3 );
+		t.equal( fixture.innerHTML, 'hello' );
+		r1.detachChild( r2 );
+		t.equal( fixture.innerHTML, '' );
+	});
+
+	test( 'multitenant anchors render instances as they attach', t => {
+		const r1 = new Ractive({
+			template: '{{>>foo multi}}',
+			el: fixture
+		});
+		const r2 = new Ractive({
+			template: 'hello'
+		});
+		const r3 = new Ractive({
+			template: 'world'
+		});
+
+		t.equal( fixture.innerHTML, '' );
+		r1.attachChild( r2, { target: 'foo' } );
+		t.equal( fixture.innerHTML, 'hello' );
+		r1.attachChild( r3, { target: 'foo' } );
+		t.equal( fixture.innerHTML, 'helloworld' );
+		r1.detachChild( r2 );
+		t.equal( fixture.innerHTML, 'world' );
+		r1.detachChild( r3 );
+		t.equal( fixture.innerHTML, '' );
+	});
+
+	test( 'attached children\'s events bubble to the parent', t => {
+		fixture.innerHTML = '<div id="r1"></div><div id="r2"></div>';
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: 'r1{{>>foo}}'
+		});
+		const r2 = new Ractive({
+			el: fixture.children[1],
+			template: 'r2'
+		});
+
+		let count = 0;
+		r1.on( 'r2.test', () => count++ );
+
+		r1.attachChild( r2, { name: 'r2' } );
+		r2.fire( 'test' );
+		r1.detachChild( r2 );
+		r2.fire( 'test' );
+		r1.attachChild( r2, { target: 'foo', name: 'r2' } );
+		r2.fire( 'test' );
+
+		t.equal( count, 2 );
+	});
+
+	// TODO: tests involving transitions
+	// TODO: test for attaching the same child twice or attaching a child that is attached elsewhere
+}
+

--- a/test/browser-tests/methods/detachChild.js
+++ b/test/browser-tests/methods/detachChild.js
@@ -26,5 +26,14 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="r1"></div><div id="r2">r2</div>' );
 	});
 
-	// TODO: test for detaching a non-attached child
+	test( `detaching a non-attached child throws an error`, t => {
+		const r = new Ractive({
+			el: fixture
+		});
+		const other = new Ractive({});
+
+		t.throws( () => {
+			r.detachChild( other );
+		}, /not attached/ );
+	});
 }

--- a/test/browser-tests/methods/detachChild.js
+++ b/test/browser-tests/methods/detachChild.js
@@ -1,0 +1,30 @@
+import { test } from 'qunit';
+import { initModule } from '../test-config';
+
+export default function() {
+	initModule( 'methods/detachChild.js' );
+
+	test( `detached children are unrendered if they are targeted`, t => {
+		fixture.innerHTML = '<div id="r1"></div><div id="r2"></div>';
+		const r1 = new Ractive({
+			template: 'r1',
+			el: fixture.children[0]
+		});
+		const r2 = new Ractive({
+			template: 'r2{{>>foo}}',
+			el: fixture.children[1]
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1</div><div id="r2">r2</div>' );
+		r2.attachChild( r1 );
+		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1</div><div id="r2">r2</div>' );
+		r2.detachChild( r1 );
+		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1</div><div id="r2">r2</div>' );
+		r2.attachChild( r1, { target: 'foo' } );
+		t.htmlEqual( fixture.innerHTML, '<div id="r1"></div><div id="r2">r2r1</div>' );
+		r2.detachChild( r1 );
+		t.htmlEqual( fixture.innerHTML, '<div id="r1"></div><div id="r2">r2</div>' );
+	});
+
+	// TODO: test for detaching a non-attached child
+}

--- a/test/browser-tests/methods/find.js
+++ b/test/browser-tests/methods/find.js
@@ -107,12 +107,14 @@ export default function() {
 		t.ok( r2.find( 'div' ).id === 'r1' );
 	});
 
-	test( `find() doesn't find elements in non-targeted attached children`, t => {
+	test( `find() doesn't find elements in non-targeted attached children by default`, t => {
+		fixture.innerHTML = '<div></div><div></div>';
 		const r1 = new Ractive({
+			el: fixture.children[0],
 			template: '<div id="r1"></div>'
 		});
 		const r2 = new Ractive({
-			el: fixture,
+			el: fixture.children[1],
 			template: '{{#if show}}<div id="r2"></div>{{/if}}{{>>foo}}',
 			data: {
 				show: true
@@ -124,6 +126,27 @@ export default function() {
 		t.ok( r2.find( 'div' ).id === 'r2' );
 		r2.set( 'show', false );
 		t.ok( r2.find( 'div' ) === undefined );
+	});
+
+	test( `find() finds elements in non-targeted attached children when asked to`, t => {
+		fixture.innerHTML = '<div></div><div></div>';
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: '<div id="r1"></div>'
+		});
+		const r2 = new Ractive({
+			el: fixture.children[1],
+			template: '{{#if show}}<div id="r2"></div>{{/if}}{{>>foo}}',
+			data: {
+				show: true
+			}
+		});
+
+		r2.attachChild( r1 );
+
+		t.ok( r2.find( 'div', { remote: true } ).id === 'r2' );
+		r2.set( 'show', false );
+		t.ok( r2.find( 'div', { remote: true } ).id === 'r1' );
 	});
 
 	// TODO add tests (and add the functionality)...

--- a/test/browser-tests/methods/find.js
+++ b/test/browser-tests/methods/find.js
@@ -88,6 +88,43 @@ export default function() {
 		}, /Cannot call ractive\.find\('p'\) unless instance is rendered to the DOM/ );
 	});
 
+	test( `find() finds elements in targeted attached children`, t => {
+		const r1 = new Ractive({
+			template: '<div id="r1"></div>'
+		});
+		const r2 = new Ractive({
+			el: fixture,
+			template: '{{#if show}}<div id="r2"></div>{{/if}}{{>>foo}}',
+			data: {
+				show: true
+			}
+		});
+
+		r2.attachChild( r1, { target: 'foo' } );
+
+		t.ok( r2.find( 'div' ).id === 'r2' );
+		r2.set( 'show', false );
+		t.ok( r2.find( 'div' ).id === 'r1' );
+	});
+
+	test( `find() doesn't find elements in non-targeted attached children`, t => {
+		const r1 = new Ractive({
+			template: '<div id="r1"></div>'
+		});
+		const r2 = new Ractive({
+			el: fixture,
+			template: '{{#if show}}<div id="r2"></div>{{/if}}{{>>foo}}',
+			data: {
+				show: true
+			}
+		});
+
+		r2.attachChild( r1 );
+
+		t.ok( r2.find( 'div' ).id === 'r2' );
+		r2.set( 'show', false );
+		t.ok( r2.find( 'div' ) === undefined );
+	});
 
 	// TODO add tests (and add the functionality)...
 	// * cancelling a live query (also, followed by teardown)

--- a/test/browser-tests/methods/findAll.js
+++ b/test/browser-tests/methods/findAll.js
@@ -43,6 +43,31 @@ export default function() {
 		t.equal( lis.length, 4 );
 	});
 
+	test( `cancelling a query is only advisory if there are multiple references`, t => {
+		const r = new Ractive({
+			el: fixture,
+			template: '{{#each items}}<div />{{/each}}',
+			data: { items: [] }
+		});
+
+		const all = r.findAll( 'div', { live: true } );
+		// these simulate other refs
+		r.findAll( 'div', { live: true } );
+		r.findAll( 'div', { live: true } );
+
+		all.cancel();
+		r.push( 'items', 0 );
+		t.equal( all.length, 1 );
+
+		all.cancel();
+		r.push( 'items', 0 );
+		t.equal( all.length, 2 );
+
+		all.cancel();
+		r.push( 'items', 0 );
+		t.equal( all.length, 2 );
+	});
+
 	test( 'Nodes belonging to components are removed from live queries when those components are torn down', t => {
 		const Widget = Ractive.extend({
 			template: '<div>this should be removed</div>'
@@ -73,7 +98,7 @@ export default function() {
 		}, /Cannot call ractive\.findAll\('p', \.\.\.\) unless instance is rendered to the DOM/ );
 	});
 
-	test( 'findAll searches non-targeted attached children last', t => {
+	test( 'findAll skips non-target instances by default', t => {
 		fixture.innerHTML = '<div></div><div></div>';
 		const r1 = new Ractive({
 			el: fixture.children[0],
@@ -87,6 +112,25 @@ export default function() {
 		r1.attachChild( r2 );
 
 		const all = r1.findAll( 'div' );
+
+		t.equal( all.length, 1 );
+		t.strictEqual( all[0], r1.find( '#r1' ) );
+	});
+
+	test( 'findAll searches non-targeted attached children, when asked, last', t => {
+		fixture.innerHTML = '<div></div><div></div>';
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: '<div id="r1" />'
+		});
+		const r2 = new Ractive({
+			el: fixture.children[1],
+			template: '<div id="r2" />'
+		});
+
+		r1.attachChild( r2 );
+
+		const all = r1.findAll( 'div', { remote: true } );
 
 		t.equal( all.length, 2 );
 		t.strictEqual( all[0], r1.find( '#r1' ) );
@@ -130,6 +174,45 @@ export default function() {
 
 		const all = r1.findAll( 'div', { live: true } );
 
+		t.equal( all.length, 2 );
+		t.strictEqual( all[1], r1.find( '#r1' ) );
+		t.strictEqual( all[0], r2.find( '#r2' ) );
+
+		r1.detachChild( r3 );
+		t.equal( all.length, 2 );
+
+		r1.detachChild( r2 );
+		t.equal( all.length, 1 );
+		t.strictEqual( all[0], r1.find( '#r1' ) );
+
+		r1.attachChild( r3 );
+		t.equal( all.length, 1 );
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		t.equal( all.length, 2 );
+		t.strictEqual( all[1], r1.find( '#r1' ) );
+		t.strictEqual( all[0], r2.find( '#r2' ) );
+	});
+
+	test( 'live findAll searches with attached children and remotes stay up to date', t => {
+		fixture.innerHTML = '<div></div><div></div>';
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: '{{>>anchor}}<div id="r1" />'
+		});
+		const r2 = new Ractive({
+			template: '<div id="r2" />'
+		});
+		const r3 = new Ractive({
+			el: fixture.children[1],
+			template: '<div id="r3" />'
+		});
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		r1.attachChild( r3 );
+
+		const all = r1.findAll( 'div', { live: true, remote: true } );
+
 		t.equal( all.length, 3 );
 		t.strictEqual( all[1], r1.find( '#r1' ) );
 		t.strictEqual( all[0], r2.find( '#r2' ) );
@@ -154,5 +237,46 @@ export default function() {
 		t.strictEqual( all[1], r1.find( '#r1' ) );
 		t.strictEqual( all[0], r2.find( '#r2' ) );
 		t.strictEqual( all[2], r3.find( '#r3' ) );
+	});
+
+	test( 'live queries update with deeply nested elements correctly', t => {
+		fixture.innerHTML = '<div></div><div></div>';
+		const cmp = Ractive.extend({
+			template: '<div class="cmp" />'
+		});
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: '{{>>anchor}}<div id="r1" />'
+		});
+		const r2 = new Ractive({
+			template: '<div id="r2" /><cmp />',
+			components: { cmp }
+		});
+		const r3 = new Ractive({
+			el: fixture.children[1],
+			template: '<div id="r3" /><cmp />',
+			components: { cmp }
+		});
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		r1.attachChild( r3 );
+
+		let q1 = r1.findAll( 'div', { live: true } );
+		let q2 = r1.findAll( 'div', { live: true, remote: true } );
+
+		t.equal( q1.length, 3 );
+		t.equal( q2.length, 5 );
+
+		r1.detachChild( r2 );
+		r1.detachChild( r3 );
+
+		t.equal( q1.length, 1 );
+		t.equal( q2.length, 1 );
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		r1.attachChild( r3 );
+
+		t.equal( q1.length, 3 );
+		t.equal( q2.length, 5 );
 	});
 }

--- a/test/browser-tests/methods/findAll.js
+++ b/test/browser-tests/methods/findAll.js
@@ -72,4 +72,6 @@ export default function() {
 			ractive.findAll( 'p' );
 		}, /Cannot call ractive\.findAll\('p', \.\.\.\) unless instance is rendered to the DOM/ );
 	});
+
+	// TODO: tests for attached children
 }

--- a/test/browser-tests/methods/findAllComponents.js
+++ b/test/browser-tests/methods/findAllComponents.js
@@ -97,5 +97,82 @@ export default function() {
 		t.equal( widgets.length, 0 );
 	});
 
-	// TODO: tests for attached children
+	test( 'findAllComponents searches non-targeted attached children last', t => {
+		fixture.innerHTML = '<div></div><div></div>';
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: '<cmp />',
+			components: {
+				cmp: Ractive.extend({})
+			}
+		});
+		const r2 = new Ractive({
+			el: fixture.children[1]
+		});
+
+		r1.attachChild( r2 );
+
+		const all = r1.findAllComponents();
+
+		t.equal( all.length, 2 );
+		t.ok( all[1] === r2 );
+	});
+
+	test( 'findAllComponents searches targeted attached children in order', t => {
+		const r1 = new Ractive({
+			el: fixture,
+			template: '{{>>anchor}}<cmp/>',
+			components: {
+				cmp: Ractive.extend({})
+			}
+		});
+		const r2 = new Ractive({});
+
+		r1.attachChild( r2, { target: 'anchor' } );
+
+		const all = r1.findAllComponents();
+
+		t.equal( all.length, 2 );
+		t.ok( all[0] === r2 );
+	});
+
+	test( 'live findAllComponents searches with attached children stay up to date', t => {
+		fixture.innerHTML = '<div></div><div></div>';
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: '{{>>anchor}}<cmp/>',
+			components: {
+				cmp: Ractive.extend({})
+			}
+		});
+		const r2 = new Ractive({});
+		const r3 = new Ractive({
+			el: fixture.children[1],
+		});
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		r1.attachChild( r3 );
+
+		const all = r1.findAllComponents( { live: true } );
+
+		t.equal( all.length, 3 );
+		t.ok( all[0] === r2 );
+		t.ok( all[2] === r3 );
+
+		r1.detachChild( r3 );
+		t.equal( all.length, 2 );
+		t.ok( all[0] === r2 );
+
+		r1.detachChild( r2 );
+		t.equal( all.length, 1 );
+
+		r1.attachChild( r3 );
+		t.equal( all.length, 2 );
+		t.ok( all[1] === r3 );
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		t.equal( all.length, 3 );
+		t.ok( all[0] === r2 );
+		t.ok( all[2] === r3 );
+	});
 }

--- a/test/browser-tests/methods/findAllComponents.js
+++ b/test/browser-tests/methods/findAllComponents.js
@@ -96,4 +96,6 @@ export default function() {
 		ractive.set( 'shown', false );
 		t.equal( widgets.length, 0 );
 	});
+
+	// TODO: tests for attached children
 }

--- a/test/browser-tests/methods/findAllComponents.js
+++ b/test/browser-tests/methods/findAllComponents.js
@@ -97,7 +97,7 @@ export default function() {
 		t.equal( widgets.length, 0 );
 	});
 
-	test( 'findAllComponents searches non-targeted attached children last', t => {
+	test( 'findAllComponents searches non-targeted attached children, when asked, last', t => {
 		fixture.innerHTML = '<div></div><div></div>';
 		const r1 = new Ractive({
 			el: fixture.children[0],
@@ -112,7 +112,7 @@ export default function() {
 
 		r1.attachChild( r2 );
 
-		const all = r1.findAllComponents();
+		const all = r1.findAllComponents( { remote: true } );
 
 		t.equal( all.length, 2 );
 		t.ok( all[1] === r2 );
@@ -155,6 +155,43 @@ export default function() {
 
 		const all = r1.findAllComponents( { live: true } );
 
+		t.equal( all.length, 2 );
+		t.ok( all[0] === r2 );
+
+		r1.detachChild( r3 );
+		t.equal( all.length, 2 );
+		t.ok( all[0] === r2 );
+
+		r1.detachChild( r2 );
+		t.equal( all.length, 1 );
+
+		r1.attachChild( r3 );
+		t.equal( all.length, 1 );
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		t.equal( all.length, 2 );
+		t.ok( all[0] === r2 );
+	});
+
+	test( 'live findAllComponents searches with attached children and remotes stay up to date', t => {
+		fixture.innerHTML = '<div></div><div></div>';
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: '{{>>anchor}}<cmp/>',
+			components: {
+				cmp: Ractive.extend({})
+			}
+		});
+		const r2 = new Ractive({});
+		const r3 = new Ractive({
+			el: fixture.children[1],
+		});
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		r1.attachChild( r3 );
+
+		const all = r1.findAllComponents( { live: true, remote: true } );
+
 		t.equal( all.length, 3 );
 		t.ok( all[0] === r2 );
 		t.ok( all[2] === r3 );
@@ -174,5 +211,46 @@ export default function() {
 		t.equal( all.length, 3 );
 		t.ok( all[0] === r2 );
 		t.ok( all[2] === r3 );
+	});
+
+	test( 'live queries update with deeply nested attached components correctly', t => {
+		fixture.innerHTML = '<div></div><div></div>';
+		const cmp = Ractive.extend({
+			template: '<div class="cmp" />'
+		});
+		const r1 = new Ractive({
+			el: fixture.children[0],
+			template: '{{>>anchor}}<div id="r1" />'
+		});
+		const r2 = new Ractive({
+			template: '<div id="r2" /><cmp />',
+			components: { cmp }
+		});
+		const r3 = new Ractive({
+			el: fixture.children[1],
+			template: '<div id="r3" /><cmp />',
+			components: { cmp }
+		});
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		r1.attachChild( r3 );
+
+		let q1 = r1.findAllComponents( { live: true } );
+		let q2 = r1.findAllComponents( { live: true, remote: true } );
+
+		t.equal( q1.length, 2 );
+		t.equal( q2.length, 4 );
+
+		r1.detachChild( r2 );
+		r1.detachChild( r3 );
+
+		t.equal( q1.length, 0 );
+		t.equal( q2.length, 0 );
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		r1.attachChild( r3 );
+
+		t.equal( q1.length, 2 );
+		t.equal( q2.length, 4 );
 	});
 }

--- a/test/browser-tests/methods/findComponent.js
+++ b/test/browser-tests/methods/findComponent.js
@@ -58,7 +58,7 @@ export default function() {
 		t.equal( findAll.length, 1);
 	});
 
-	test( 'findComponent finds non-targeted attached children last', t => {
+	test( 'findComponent finds non-targeted attached children last when asked', t => {
 		const cmp = Ractive.extend({});
 		const r = new Ractive({
 			el: fixture,
@@ -70,17 +70,17 @@ export default function() {
 		const r2 = new cmp();
 		r.attachChild( r2, { name: 'cmp' } );
 
-		let res = r.findComponent();
+		let res = r.findComponent( { remote: true } );
 		t.ok( res && res !== r2 );
 
-		res = r.findComponent( 'cmp' );
+		res = r.findComponent( 'cmp', { remote: true } );
 		t.ok( res && res !== r2 );
 
 		r.set( 'show', false );
-		res = r.findComponent();
+		res = r.findComponent( { remote: true } );
 		t.ok( res && res === r2 );
 
-		res = r.findComponent( 'cmp' );
+		res = r.findComponent( 'cmp', { remote: true } );
 		t.ok( res && res === r2 );
 	});
 

--- a/test/browser-tests/methods/findComponent.js
+++ b/test/browser-tests/methods/findComponent.js
@@ -57,4 +57,50 @@ export default function() {
 		t.ok( find, 'component not found' );
 		t.equal( findAll.length, 1);
 	});
+
+	test( 'findComponent finds non-targeted attached children last', t => {
+		const cmp = Ractive.extend({});
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#if show}}<cmp />{{/if}}`,
+			data: { show: true },
+			components: { cmp }
+		});
+
+		const r2 = new cmp();
+		r.attachChild( r2, { name: 'cmp' } );
+
+		let res = r.findComponent();
+		t.ok( res && res !== r2 );
+
+		res = r.findComponent( 'cmp' );
+		t.ok( res && res !== r2 );
+
+		r.set( 'show', false );
+		res = r.findComponent();
+		t.ok( res && res === r2 );
+
+		res = r.findComponent( 'cmp' );
+		t.ok( res && res === r2 );
+	});
+
+	test( 'findComponent finds targeted attached children in template order', t => {
+		const cmp = Ractive.extend({});
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#if show}}{{>>foo}}{{/if}}<cmp />`,
+			data: { show: false },
+			components: { cmp }
+		});
+
+		const r2 = new cmp();
+		r.attachChild( r2, { target: 'foo', name: 'cmp' } );
+
+		let res = r.findComponent( 'cmp' );
+		t.ok( res && res !== r2 );
+
+		r.set( 'show', true );
+		res = r.findComponent( 'cmp' );
+		t.ok( res && res === r2 );
+	});
 }

--- a/test/browser-tests/methods/removeMapping.js
+++ b/test/browser-tests/methods/removeMapping.js
@@ -1,0 +1,43 @@
+import { test } from 'qunit';
+import { initModule } from '../test-config';
+
+export default function() {
+	initModule( 'methods/removeMapping.js' );
+
+	test( 'removeMapping removes a mapping and rebinds', t => {
+		const cmp = Ractive.extend({
+			template: '{{foo}}'
+		});
+		const r = new Ractive({
+			el: fixture,
+			template: '<cmp />',
+			data: { bar: 'foo' },
+			components: { cmp }
+		});
+
+		t.equal( fixture.innerHTML, '' );
+		r.findComponent().addMapping( 'foo', 'bar' );
+		t.equal( fixture.innerHTML, 'foo' );
+		r.findComponent().removeMapping( 'foo' );
+		t.equal( fixture.innerHTML, '' );
+	});
+
+	test( 'removeMapping allows implicit mappings to resume', t => {
+		const cmp = Ractive.extend({
+			template: '{{bar}}'
+		});
+		const r = new Ractive({
+			el: fixture,
+			template: '<cmp />',
+			data: { bar: 'foo', baz: { bat: 'yep' } },
+			components: { cmp }
+		});
+
+		t.equal( fixture.innerHTML, 'foo' );
+		r.findComponent().addMapping( 'bar', 'baz.bat' );
+		t.equal( fixture.innerHTML, 'yep' );
+		r.findComponent().removeMapping( 'bar' );
+		t.equal( fixture.innerHTML, 'foo' );
+	});
+}
+

--- a/test/browser-tests/shuffling.js
+++ b/test/browser-tests/shuffling.js
@@ -395,6 +395,36 @@ export default function() {
 	removedElementsTest( 'splice', ractive => ractive.splice( 'options', 1, 1 ) );
 	removedElementsTest( 'merge', ractive => ractive.merge( 'options', [ 'a', 'c' ] ) );
 
-	// TODO: add tests for shuffling added mappings
-	// TODO: add tests for shuffling attached children
+	test( 'manual mappings update correctly during shuffle', t => {
+		const r1 = new Ractive({
+			el: fixture,
+			template: '{{>>anchor}}',
+			data: { list: [ 0, 1 ] }
+		});
+		const r2 = new Ractive({
+			template: '{{item}}'
+		});
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		r2.addMapping( 'item', 'list.1' );
+		t.htmlEqual( fixture.innerHTML, '1' );
+		r1.unshift( 'list', 2 );
+		t.htmlEqual( fixture.innerHTML, '0' );
+	});
+
+	test( 'targeted attached children shuffle correctly', t => {
+		const r1 = new Ractive({
+			el: fixture,
+			template: '{{#each list as item}}{{#if @index === 1}}{{>>anchor}}{{/if}}{{/each}}',
+			data: { list: [ 0, 1, 2 ] }
+		});
+		const r2 = new Ractive({
+			template: '{{item}}'
+		});
+
+		r1.attachChild( r2, { target: 'anchor' } );
+		t.htmlEqual( fixture.innerHTML, '1' );
+		r1.unshift( 'list', 3 );
+		t.htmlEqual( fixture.innerHTML, '0' );
+	});
 }

--- a/test/browser-tests/shuffling.js
+++ b/test/browser-tests/shuffling.js
@@ -394,4 +394,7 @@ export default function() {
 
 	removedElementsTest( 'splice', ractive => ractive.splice( 'options', 1, 1 ) );
 	removedElementsTest( 'merge', ractive => ractive.merge( 'options', [ 'a', 'c' ] ) );
+
+	// TODO: add tests for shuffling added mappings
+	// TODO: add tests for shuffling attached children
 }


### PR DESCRIPTION
**Description of the pull request:**
This is my attempt to solve one of the last big issues I have with components: there's not a good API for dealing with them outside of the template. My primary irritation being that there's a bit more friction making larger apps with lots of views than I'd like. There are three concerns I've tried to address here:

1. There's no (good/safe) way to share data between to instances without having one be a component child of the other, and even then it can be a bit touchy.
2. There's not an obvious way to dynamically render an externally controlled (Ractive) component into a Ractive-controlled piece of DOM without getting hacky.
3. There is some layout support, but it's not really conducive to dealing with complex component structures as-is.

Some of those are partially addressed by conditional directives and event expressions, but in a very small way.

Here's what this does, or will do when it's finished, to address those:

* Add a ~~`mapPath`/`unmapPath`~~ `addMapping`/`removeMapping` API to allow programmatic control over what mappings a component gets. Mapping directive attributes are great, but sometimes you need more control or dynamism than can be achieved with those.

* Add `attachChild` and `detachChild` API to allow programmatic insertion and removal of external instances/components in a vdom-aware manner. There are actually two sides to this, one of which addresses points 2 and 3 above.

  * Starting with the simpler one, you can attach a child instance, and it will take on a new parent instance, meaning that events will bubble and, assuming no isolation, you get implicit mappings to the root of the parent when the child attaches and rebinds.

* For the more complex side, there is a new vdom item that is somewhat like the existing Component called an Anchor. An anchor has a name and may house one or more components depending on how it is specified. Since it's similar to a partial, the preliminary syntax is `{{>>name [multi]}}`, where `multi` is optional and specifies that the anchor should be multi-tenant. `attachChild` accepts an options object that may specify a target name, and if it does, the instance is re-rendered into the matching anchor. If no anchor is found, the instance is unrendered and will render if/when a matching anchor appears. If an anchor is unrendered, then its content instances are also unrendered.
A single tenant anchor will render the last instance in, so if you attach a new child and specify an anchor that is occupied, the current tenant will be unrendered and the new tenant rendered. When the new tenant is removed, the the previous tenant will be re-rendered.
A multi-tenant anchor will simply append any instances that target it. The instance also render and unrender with the anchor, as you'd expect, so they work nicely in sections.
I've considered a few more advanced behaviors for anchors, like multiple anchors with the same name allowing children to fill them in order, but I wanted to get some feedback before I get too far off the rails. As a for instance, specifying queue ordering (fifo/filo) for handling single tenant anchors.

I think the layout/anchor portion would be a huge win for more complex apps and navigation, though I've been wrong before :smile:. I also think the mapping API would be tremendously useful for larger apps with many components/views. I think simply having non-anchored/external instances would be a pretty decent help for arranging components so that you could at least share base state easily without having to shove all of your dom into one overarching Ractive template.

To expand a bit on multi-tenant anchors, I see those as useful for components that are static or absolutely positioned. There's probably more that needs to be done there to make that fully useful, like let the instance know that it is number x of y tenants.

**Status**

* [x] Basic attach/detach support
* [x] find working
* [x] findAll working - including live queries
* [x] findComponent working
* [x] findAllComponents working, including live queries
* [x] mapPath
* [x] unmapPath
* [x] Basic anchor support
* [x] multi-tenant anchor support
* [x] safe transitions
* [ ] API fully fleshed and discussed
* [ ] Functionality feedback
* [x] Tests!
* [x] More tests!

**Is breaking:**
I don't think so, but it's based on the try-rebind branch that can handle rebinding when mappings appear and disappear a bit more gracefully than edge.

**Reviewers:**
Yes, please! Any feedback is welcome, including hacking. I've seen a number of requests that match some portion of what I'm trying to address here.