### PR TITLE
make sure observers that init lock during the init - fixes #2594

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -104,6 +104,7 @@ class Observer {
 		}
 
 		if ( options.init !== false ) {
+			this.dirty = true;
 			this.dispatch();
 		} else {
 			this.oldValue = this.newValue;

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -1138,4 +1138,36 @@ export default function() {
 
 		r.add( 'foo.bar' );
 	});
+
+	test( 'observers should not be re-entrant when they init (#2594)', t => {
+		let count = 0;
+		new Ractive({
+			el: fixture,
+			data: { list: [ 0, 0 ] },
+			oninit () {
+				this.observe( 'list', () => {
+					count++;
+					this.set( 'list', [] );
+				});
+			}
+		});
+
+		t.equal( count, 1 );
+	});
+
+	test( 'pattern observers should not be re-entrant when they init', t => {
+		let count = 0;
+		new Ractive({
+			el: fixture,
+			data: { obj: { list: [ 0, 0 ] } },
+			oninit () {
+				this.observe( 'obj.*', ( n, o, k ) => {
+					count++;
+					this.set( k, [] );
+				});
+			}
+		});
+
+		t.equal( count, 1 );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This set the dirty flag on observers that fire on init so that if they happen to cause their keypath to update, the observer won't fire again. This is a regression from 0.7.3 caused by some shuffling of observer code and a hole in the test suite.

**Fixes the following issues:**
#2594

**Is breaking:**
Quite the opposite.
