### PR TITLE
Avoid unnecessary rebind and optimize splices shufffling - #2599

### DIFF
--- a/src/shared/getNewIndices.js
+++ b/src/shared/getNewIndices.js
@@ -36,6 +36,7 @@ export default function getNewIndices ( length, methodName, args ) {
 
 	removeStart = Math.min( length, spliceArguments[0] );
 	removeEnd = removeStart + spliceArguments[1];
+	newIndices.startIndex = removeStart;
 
 	for ( i = 0; i < removeStart; i += 1 ) {
 		newIndices.push( i );


### PR DESCRIPTION
**Description of the pull request:**
This adds a check to avoid an unnecessary rebind on fragments that keep their same index when shuffling.

It also adds handling for splices, as opposed to merges, when shuffling where only one block of fragments will be added and/or removed. This avoids moving DOM that doesn't really need to be moved.

Here are the relevant numbers in jsweb perf on my slowish linux box (number in ms):

|test|edge|pr|
|---|---:|---:|
|1. create 1000|750.6|761.6|
|2. swap in 1000 more|36.5|39.0|
|3. append 100|112.7|46.7|
|4. remove first|76.6|71.6|
|5. remove last|36.7|7.4|

The numbers that move a bunch of DOM vary up to 150% depending on the browser's mood when you run the test, but the splice numbers in 3, 4, and 5 are fairly consistently distanced. For instance, the best run on number 1 for any build was 453.8 and the worst was 1133.3.

Removal of the last row now consistently beats 0.7.3, which comes in at around 13.6.

**Fixes the following issues:**
#2599 and more of #2366

**Is breaking:**
Shouldn't be.

**Reviewers:**
@martypdx @michaljerabek