### PR TITLE
Invalidate resolvers when shuffling an expression - #2602

### DIFF
--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -65,7 +65,6 @@ export default class Computation extends Model {
 
 		this.deps = [];
 
-		this.boundsSensitive = true;
 		this.dirty = true;
 
 		// TODO: is there a less hackish way to do this?
@@ -169,5 +168,11 @@ export default class Computation extends Model {
 		}
 		if ( this.root.computations[this.key] === this ) delete this.root.computations[this.key];
 		super.teardown();
+	}
+
+	unregister ( dependent ) {
+		super.unregister( dependent );
+		// tear down expressions with no deps, because they will be replaced when needed
+		if ( this.isExpression && this.deps.length === 0 ) this.teardown();
 	}
 }

--- a/test/browser-tests/shuffling.js
+++ b/test/browser-tests/shuffling.js
@@ -394,4 +394,23 @@ export default function() {
 
 	removedElementsTest( 'splice', ractive => ractive.splice( 'options', 1, 1 ) );
 	removedElementsTest( 'merge', ractive => ractive.merge( 'options', [ 'a', 'c' ] ) );
+
+	test( `mapped unresolved computations should shuffle correctly (#2602)`, t => {
+		const cmp = Ractive.extend({
+			template: '{{foo.baz || 1}}-{{foo.bar}}|'
+		});
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each list}}<cmp foo="{{.}}" />{{/each}}`,
+			data: {
+				list: [ { bar: 1 }, { bar: 2 }, { bar: 3 } ]
+			},
+			components: { cmp }
+		});
+
+		t.htmlEqual( fixture.innerHTML, '1-1|1-2|1-3|' );
+		r.splice( 'list', 0, 0, r.splice( 'list', 2, 1 ).result[0] );
+		r.findAllComponents()[1].set( 'foo.baz', 10 );
+		t.htmlEqual( fixture.innerHTML, '1-3|10-1|1-2|' );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
When shuffling an expression proxy that has unresolved references, the resolvers should be recreated in the new context.

**Fixes the following issues:**
#2602

**Is breaking:**
Nerp.