### PR TITLE
Add a destroyed step to the view for safe hierarchical teardown - #2608

### DIFF
--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -73,6 +73,10 @@ export default class Fragment {
 		});
 	}
 
+	destroyed () {
+		this.items.forEach( i => i.destroyed() );
+	}
+
 	detach () {
 		const docFrag = createDocumentFragment();
 		this.items.forEach( item => docFrag.appendChild( item.detach() ) );

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -90,6 +90,10 @@ export default class RepeatedFragment {
 		return fragment.bind( model );
 	}
 
+	destroyed () {
+		this.iterations.forEach( i => i.destroyed() );
+	}
+
 	detach () {
 		const docFrag = createDocumentFragment();
 		this.iterations.forEach( fragment => docFrag.appendChild( fragment.detach() ) );

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -6,7 +6,7 @@ import ConditionalAttribute from './element/ConditionalAttribute';
 import updateLiveQueries from './element/updateLiveQueries';
 import { toArray } from '../../utils/array';
 import { escapeHtml, voidElementNames } from '../../utils/html';
-import { bind, rebind, render, unbind, unrender, update } from '../../shared/methodCallers';
+import { bind, rebind, render, unbind, update } from '../../shared/methodCallers';
 import { createElement, detachNode, matches, safeAttributeString, decamelize } from '../../utils/dom';
 import createItem from './createItem';
 import { html, svg } from '../../config/namespaces';
@@ -123,9 +123,14 @@ export default class Element extends Item {
 			null;
 	}
 
+	destroyed () {
+		this.attributes.forEach( a => a.destroyed() );
+		if ( this.fragment ) this.fragment.destroyed();
+	}
+
 	detach () {
-		// if this element is no longer rendered, the transitinos are complete and the attributes can be torn down
-		if ( !this.rendered ) this.attributes.forEach( unrender );
+		// if this element is no longer rendered, the transitions are complete and the attributes can be torn down
+		if ( !this.rendered ) this.destroyed();
 
 		return detachNode( this.node );
 	}

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -71,6 +71,10 @@ export default class Attribute extends Item {
 		}
 	}
 
+	destroyed () {
+		this.updateDelegate( true );
+	}
+
 	getString () {
 		return this.fragment ?
 			this.fragment.toString() :

--- a/src/view/items/element/Decorator.js
+++ b/src/view/items/element/Decorator.js
@@ -91,6 +91,10 @@ export default class Decorator {
 		}
 	}
 
+	destroyed () {
+		if ( this.intermediary ) this.intermediary.teardown();
+	}
+
 	handleChange () { this.bubble(); }
 
 	rebind () {

--- a/src/view/items/element/Transition.js
+++ b/src/view/items/element/Transition.js
@@ -200,6 +200,8 @@ export default class Transition {
 		}
 	}
 
+	destroyed () {}
+
 	getStyle ( props ) {
 		const computedStyle = getComputedStyle( this.owner.node );
 

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -125,6 +125,10 @@ export default class EventDirective {
 		}
 	}
 
+	destroyed () {
+		this.events.forEach( e => e.unlisten() );
+	}
+
 	fire ( event, passedArgs = [] ) {
 
 		// augment event object

--- a/src/view/items/shared/Item.js
+++ b/src/view/items/shared/Item.js
@@ -17,6 +17,8 @@ export default class Item {
 		}
 	}
 
+	destroyed () {}
+
 	find () {
 		return null;
 	}

--- a/test/browser-tests/events/misc.js
+++ b/test/browser-tests/events/misc.js
@@ -267,4 +267,33 @@ export default function() {
 	} catch ( err ) {
 		// do nothing
 	}
+
+	test( 'events in nested elements are torn down properly (#2608)', t => {
+		let count = 0;
+		const r = new Ractive({
+			el: fixture,
+			template: '{{#if foo}}<div><div on-foo="bar" /></div>{{/if}}',
+			data: { foo: true },
+			events: {
+				foo () {
+					count++;
+
+					return {
+						teardown () {
+							count--;
+						}
+					};
+				}
+			}
+		});
+
+		t.equal( count, 1 );
+		r.toggle( 'foo' );
+		t.equal( count, 0 );
+		r.toggle( 'foo' );
+		t.equal( count, 1 );
+		r.toggle( 'foo' );
+		t.equal( count, 0 );
+		r.toggle( 'foo' );
+	});
 }

--- a/test/browser-tests/plugins/decorators.js
+++ b/test/browser-tests/plugins/decorators.js
@@ -511,4 +511,31 @@ export default function() {
 		r.set( 'bar', 'baz' );
 		t.htmlEqual( fixture.innerHTML, '<div>baz</div>' );
 	});
+
+	test( 'decorators in nested elements are torn down (#2608)', t => {
+		let count = 0;
+		const r = new Ractive({
+			el: fixture,
+			template: '{{#if foo}}<div><div as-foo /></div>{{/if}}',
+			decorators: {
+				foo () {
+					count++;
+					return {
+						teardown () {
+							count--;
+						}
+					};
+				}
+			},
+			data: { foo: true }
+		});
+
+		t.equal( count, 1 );
+		r.toggle( 'foo' );
+		t.equal( count, 0 );
+		r.toggle( 'foo' );
+		t.equal( count, 1 );
+		r.toggle( 'foo' );
+		t.equal( count, 0 );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This adds another view lifecycle step `destroyed` that is triggered after an element is detached during an unrender. Things like decorators and attributes can't be unrendered immediately when their parent element gets the signal to unrender, as that would potentially change the DOM before transitions complete. This was handled for the top-level element, but nested children were not getting notified properly that their decorators, events, and attributes could be torn down safely. With this, the element detach checks to see if it is unrendered, and if it is, it starts the destroyed cycle for its attributes and everything in its fragment.

**Fixes the following issues:**
#2608

**Is breaking:**
No