### PR TITLE
Make sure nested components don't interfere with the transition manager completion

### DIFF
--- a/src/global/TransitionManager.js
+++ b/src/global/TransitionManager.js
@@ -79,13 +79,13 @@ function check ( tm ) {
 	// we notify the parent if there is one, otherwise
 	// start detaching nodes
 	if ( !tm.outrosComplete ) {
+		tm.outrosComplete = true;
+
 		if ( tm.parent && !tm.parent.outrosComplete ) {
 			tm.parent.decrementOutros( tm );
 		} else {
 			tm.detachNodes();
 		}
-
-		tm.outrosComplete = true;
 	}
 
 	// Once everything is done, we can notify parent transition
@@ -95,7 +95,8 @@ function check ( tm ) {
 			tm.callback();
 		}
 
-		if ( tm.parent ) {
+		if ( tm.parent && !tm.notifiedTotal ) {
+			tm.notifiedTotal = true;
 			tm.parent.decrementTotal();
 		}
 	}

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -1052,4 +1052,42 @@ export default function() {
 
 		t.htmlEqual( fixture.innerHTML, 'root.next.next.next.next true' );
 	});
+
+	test( 'nested components play nice with the transition manager - #2578', t => {
+		const done = t.async();
+		let count = 0, count1 = 0, count2 = 0;
+
+		const cmp2 = Ractive.extend({
+			template: 'yep',
+			oncomplete () {
+				count2++;
+			}
+		});
+		const cmp1 = Ractive.extend({
+			template: '<cmp2 />',
+			components: { cmp2 },
+			oncomplete () {
+				count1++;
+			}
+		});
+
+		new Ractive({
+			el: fixture,
+			template: '{{#each items}}<cmp1 />{{/each}}',
+			data: {
+				items: [ 0, 0, 0 ]
+			},
+			components: { cmp1 },
+			oncomplete () {
+				count++;
+			}
+		});
+
+		setTimeout( () => {
+			t.equal( count, 1 );
+			t.equal( count1, 3 );
+			t.equal( count2, 3 );
+			done();
+		}, 200 );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This adds guards to nested transaction managers to make sure they don't adjust their parent totals more than once during checks. This bug was introduced when checks started being run multiple times in order to avoid non-transitioning elements getting stuck in the DOM whilst waiting on other unrelated elements to transition out.

See #2578