### PR TITLE
Make sure cancelled observers don't fire - #2604

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -118,6 +118,7 @@ class Observer {
 	}
 
 	cancel () {
+		this.cancelled = true;
 		if ( this.model ) {
 			this.model.unregister( this );
 		} else {
@@ -126,9 +127,11 @@ class Observer {
 	}
 
 	dispatch () {
-		this.callback.call( this.context, this.newValue, this.oldValue, this.keypath );
-		this.oldValue = this.newValue;
-		this.dirty = false;
+		if ( !this.cancelled ) {
+			this.callback.call( this.context, this.newValue, this.oldValue, this.keypath );
+			this.oldValue = this.newValue;
+			this.dirty = false;
+		}
 	}
 
 	handleChange () {
@@ -140,7 +143,7 @@ class Observer {
 			runloop.addObserver( this, this.defer );
 			this.dirty = true;
 
-			if ( this.once ) this.cancel();
+			if ( this.once ) runloop.scheduleTask( () => this.cancel() );
 		}
 	}
 


### PR DESCRIPTION
**Description of the pull request:**
This adds a check in observers that stops them from firing after `cancel` has been called even if they were already scheduled to run in the current loop. This means that a deferred observer will no longer fire in components that have been removed from the view. So observers that set data on an array that is their context and/or mapping don't create extra array elements as they are spliced out.

**Fixes the following issues:**
#2604

**Is breaking:**
Maybe? I'm not really sure what the prescribed behavior is in this case.

**Reviewers:**
@martypdx @Rich-Harris @MartinKolarik @fskreuz - again, need feedback on whether this is the right way to handle this or if the check should be handled by the dev.