### PR TITLE
Check observer value before firing in case a computed is invloved - #2629

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -136,7 +136,10 @@ class Observer {
 
 	handleChange () {
 		if ( !this.dirty ) {
-			this.newValue = this.model.get();
+			const newValue = this.model.get();
+			if ( isEqual( newValue, this.oldValue ) ) return;
+
+			this.newValue = newValue;
 
 			if ( this.strict && this.newValue === this.oldValue ) return;
 

--- a/src/view/items/element/binding/Binding.js
+++ b/src/view/items/element/binding/Binding.js
@@ -72,10 +72,12 @@ export default class Binding {
 
 	handleChange () {
 		const value = this.getValue();
+		if ( this.lastValue === value ) return;
 
 		runloop.start( this.root );
 		this.attribute.locked = true;
 		this.model.set( value );
+		this.lastValue = value;
 
 		// if the value changes before observers fire, unlock to be updatable cause something weird and potentially freezy is up
 		if ( this.model.get() !== value ) this.attribute.locked = false;

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -1170,4 +1170,29 @@ export default function() {
 
 		t.equal( count, 1 );
 	});
+
+	test( `observers only fire for a computation when it actually changes (#2629)`, t => {
+		const r = new Ractive({
+			computed: {
+				int () {
+					return Math.round( this.get( 'number' ) );
+				}
+			},
+			data: {
+				number: 1,
+				observerCalledTimes: 0
+			}
+		});
+
+		r.observe( 'int', function () {
+			this.add( 'observerCalledTimes', 1 );
+		});
+
+		r.set( 'number', 1.1 );
+		r.set( 'number', 1.2 );
+		r.set( 'number', 1.3 );
+		r.set( 'number', 1.4 );
+
+		t.equal( r.get( 'observerCalledTimes' ), 1 );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This adds an `isEqual` check on observers so that observers on computations don't fire multiple times for an unchanged value just because the computation was invalidated.

That by itself is not compatible with two-way bindings and mutating observers, so this also adds a check in the `handleChange` of `Binding` that compares the last value it notified for with the one that it would notify for now. If they are the same, it just skips the notification. That avoids firing the same value multiple times and confusing the observer based on the state of the model/observer and the binding/attribute being in different states while the user still has input control i.e. the control is locked as far as Ractive is concerned so that it doesn't cause the cursor to jump home on every keystroke.

I _think_ that has the issue covered. It's kinda hard to say with some of the nuance involved in these scenarios, but all of the tests turn green. I still say that mutating observers on bindings are a whole heap of trouble :laughing: 

**Fixes the following issues:**
#2629 

**Is breaking:**
Don't think so.
