### PR TITLE
allow pattern observers to get notified multiple times per runloop - #2631

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -256,8 +256,8 @@ class PatternObserver {
 	}
 
 	handleChange () {
-		if ( !this.dirty ) {
-			this.newValues = {};
+		if ( !this.dirty || this.changed.length ) {
+			if ( !this.dirty ) this.newValues = {};
 
 			// handle case where previously extant keypath no longer exists -
 			// observer should still fire, with undefined as new value

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -1170,4 +1170,26 @@ export default function() {
 
 		t.equal( count, 1 );
 	});
+
+	test( 'pattern observers handle multi-key set correctly (#2631)', t => {
+		const list = [];
+		const r = new Ractive({
+			data: {
+				list: [ { a: 1 }, { a: 2 }, { a: 3 } ]
+			},
+			onconfig () {
+				this.observe( 'list.*.a', (n, o, k, i) => {
+					list[i] = n;
+				});
+			}
+		});
+
+		t.deepEqual( list, [ 1, 2, 3 ] );
+		r.set({
+			'list.0.a': 3,
+			'list.1.a': 4,
+			'list.2.a': 5
+		});
+		t.deepEqual( list, [ 3, 4, 5 ] );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This adds a check in the dirty handling of pattern observers that allows the change to be processed if there are pending keys registered as changed. What's happening now is multiple `set`s via map only fire the first key changed for the pattern observer because the rest of them are ignored while the observer is dirty.

Would it be better to keep a list of keys seen for this cycle and only allow unseen changes through to avoid issues with two-way binding mutation and pattern observers or pattern observers that mutate their observed value in general? Or is that far enough in left field to safely ignore?

**Fixes the following issues:**
#2631

**Is breaking:**
Don't think so