### PR TITLE
Attempt to address remaining blockers for 0.8 - RFC/Review

### DIFF
--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -142,9 +142,6 @@ function initialiseProperties ( ractive ) {
 	// observers
 	ractive._observers = [];
 
-	// links
-	ractive._links = {};
-
 	if(!ractive.component){
 		ractive.root = ractive;
 		ractive.parent = ractive.container = null; // TODO container still applicable?

--- a/src/Ractive/prototype/get.js
+++ b/src/Ractive/prototype/get.js
@@ -1,8 +1,8 @@
 import { splitKeypath } from '../../shared/keypaths';
 import resolveReference from '../../view/resolvers/resolveReference';
 
-export default function Ractive$get ( keypath ) {
-	if ( !keypath ) return this.viewmodel.get( true );
+export default function Ractive$get ( keypath, opts ) {
+	if ( typeof keypath !== 'string' ) return this.viewmodel.get( true, keypath );
 
 	const keys = splitKeypath( keypath );
 	const key = keys[0];
@@ -22,5 +22,5 @@ export default function Ractive$get ( keypath ) {
 	}
 
 	model = this.viewmodel.joinAll( keys );
-	return model.get( true );
+	return model.get( true, opts );
 }

--- a/src/Ractive/prototype/link.js
+++ b/src/Ractive/prototype/link.js
@@ -17,7 +17,7 @@ export default function link( there, here ) {
 		model = model.joinAll( sourcePath.slice( 1 ) );
 	}
 
-	this.viewmodel.joinAll( splitKeypath( here ) ).link( model || this.viewmodel.joinAll( sourcePath ) );
+	this.viewmodel.joinAll( splitKeypath( here ) ).link( model || this.viewmodel.joinAll( sourcePath ), there );
 
 	runloop.end();
 

--- a/src/Ractive/prototype/link.js
+++ b/src/Ractive/prototype/link.js
@@ -8,77 +8,18 @@ export default function link( there, here ) {
 	}
 
 	const promise = runloop.start();
-
 	let model;
-	let ln = this._links[ here ];
-
-	if ( ln ) {
-		if ( ln.source.model.str !== there || ln.dest.model.str !== here ) {
-			ln.unlink();
-			delete this._links[ here ];
-			this.viewmodel.joinAll( splitKeypath( here ) ).set( ln.initialValue );
-		} else { // already linked, so nothing to do
-			runloop.end();
-			return promise;
-		}
-	}
 
 	// may need to allow a mapping to resolve implicitly
 	const sourcePath = splitKeypath( there );
 	if ( !this.viewmodel.has( sourcePath[0] ) && this.component ) {
 		model = resolveReference( this.component.parentFragment, sourcePath[0] );
-
-		if ( model ) {
-			this.viewmodel.map( sourcePath[0], model );
-		}
+		model = model.joinAll( sourcePath.slice( 1 ) );
 	}
 
-	ln = new Link( this.viewmodel.joinAll( sourcePath ), this.viewmodel.joinAll( splitKeypath( here ) ), this );
-	this._links[ here ] = ln;
-	ln.source.handleChange();
+	this.viewmodel.joinAll( splitKeypath( here ) ).link( model || this.viewmodel.joinAll( sourcePath ) );
 
 	runloop.end();
 
 	return promise;
-}
-
-class Link {
-	constructor ( source, dest, ractive ) {
-		this.source = new LinkSide( source, this );
-		this.dest = new LinkSide( dest, this );
-		this.ractive = ractive;
-		this.locked = false;
-		this.initialValue = dest.get();
-	}
-
-	sync ( side ) {
-		if ( !this.locked ) {
-			this.locked = true;
-
-			if ( side === this.dest ) {
-				this.source.model.set( this.dest.model.get() );
-			} else {
-				this.dest.model.set( this.source.model.get() );
-			}
-
-			this.locked = false;
-		}
-	}
-
-	unlink () {
-		this.source.model.unregister( this.source );
-		this.dest.model.unregister( this.dest );
-	}
-}
-
-class LinkSide {
-	constructor ( model, owner ) {
-		this.model = model;
-		this.owner = owner;
-		model.register( this );
-	}
-
-	handleChange () {
-		this.owner.sync( this );
-	}
 }

--- a/src/Ractive/prototype/merge.js
+++ b/src/Ractive/prototype/merge.js
@@ -16,9 +16,8 @@ function getComparator ( option ) {
 	throw new Error( 'If supplied, options.compare must be a string, function, or `true`' ); // TODO link to docs
 }
 
-export default function Ractive$merge ( keypath, array, options ) {
-	const model = this.viewmodel.joinAll( splitKeypath( keypath ) );
-	const promise = runloop.start( this, true );
+export function merge ( ractive, model, array, options ) {
+	const promise = runloop.start( ractive, true );
 	const value = model.get();
 
 	if ( array === value ) {
@@ -32,4 +31,8 @@ export default function Ractive$merge ( keypath, array, options ) {
 
 	runloop.end();
 	return promise;
+}
+
+export default function thisRactive$merge ( keypath, array, options ) {
+	return merge( this, this.viewmodel.joinAll( splitKeypath( keypath ) ), array, options );
 }

--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -3,7 +3,7 @@ import { isArray, isEqual, isObject } from '../../utils/is';
 import { splitKeypath, escapeKey } from '../../shared/keypaths';
 import { removeFromArray } from '../../utils/array';
 import resolveReference from '../../view/resolvers/resolveReference';
-import { modelMatches } from '../../view/resolvers/resolve';
+import { rebindMatch } from '../../shared/rebind';
 import ReferenceResolver from '../../view/resolvers/ReferenceResolver';
 
 export default function observe ( keypath, callback, options ) {
@@ -145,10 +145,10 @@ class Observer {
 		}
 	}
 
-	rebinding ( next ) {
-		debugger
+	rebinding ( next, previous ) {
+		next = rebindMatch( this.keypath, next, previous );
 		// TODO: set up a resolver if next is undefined?
-		if ( next && !modelMatches( next, this.keypath ) ) return false;
+		if ( next === this.model ) return false;
 
 		if ( this.model ) this.model.unregister( this );
 		if ( next ) runloop.scheduleTask( () => this.resolved( next ) );

--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -251,7 +251,7 @@ class PatternObserver {
 	}
 
 	rebinding ( next, prev ) {
-		debugger
+		// TODO: move basemodel if it matches
 	}
 
 	shuffle ( newIndices ) {

--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -157,7 +157,7 @@ class Observer {
 		if ( next === this.model ) return false;
 
 		if ( this.model ) this.model.unregister( this );
-		if ( next ) runloop.scheduleTask( () => this.resolved( next ) );
+		if ( next ) next.addShuffleTask( () => this.resolved( next ) );
 	}
 
 	resolved ( model ) {

--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -250,10 +250,6 @@ class PatternObserver {
 		this.changed.push( key );
 	}
 
-	rebinding ( next, prev ) {
-		// TODO: move basemodel if it matches
-	}
-
 	shuffle ( newIndices ) {
 		if ( !isArray( this.baseModel.value ) ) return;
 

--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -3,6 +3,7 @@ import { isArray, isEqual, isObject } from '../../utils/is';
 import { splitKeypath, escapeKey } from '../../shared/keypaths';
 import { removeFromArray } from '../../utils/array';
 import resolveReference from '../../view/resolvers/resolveReference';
+import { modelMatches } from '../../view/resolvers/resolve';
 import ReferenceResolver from '../../view/resolvers/ReferenceResolver';
 
 export default function observe ( keypath, callback, options ) {
@@ -144,6 +145,15 @@ class Observer {
 		}
 	}
 
+	rebinding ( next ) {
+		debugger
+		// TODO: set up a resolver if next is undefined?
+		if ( next && !modelMatches( next, this.keypath ) ) return false;
+
+		if ( this.model ) this.model.unregister( this );
+		if ( next ) runloop.scheduleTask( () => this.resolved( next ) );
+	}
+
 	resolved ( model ) {
 		this.model = model;
 		this.keypath = model.getKeypath( this.ractive );
@@ -232,6 +242,10 @@ class PatternObserver {
 
 	notify ( key ) {
 		this.changed.push( key );
+	}
+
+	rebinding ( next, prev ) {
+		debugger
 	}
 
 	shuffle ( newIndices ) {

--- a/src/Ractive/prototype/pop.js
+++ b/src/Ractive/prototype/pop.js
@@ -1,2 +1,2 @@
 import makeArrayMethod from './shared/makeArrayMethod';
-export default makeArrayMethod( 'pop' );
+export default makeArrayMethod( 'pop' ).path;

--- a/src/Ractive/prototype/push.js
+++ b/src/Ractive/prototype/push.js
@@ -1,2 +1,2 @@
 import makeArrayMethod from './shared/makeArrayMethod';
-export default makeArrayMethod( 'push' );
+export default makeArrayMethod( 'push' ).path;

--- a/src/Ractive/prototype/reverse.js
+++ b/src/Ractive/prototype/reverse.js
@@ -1,2 +1,2 @@
 import makeArrayMethod from './shared/makeArrayMethod';
-export default makeArrayMethod( 'reverse' );
+export default makeArrayMethod( 'reverse' ).path;

--- a/src/Ractive/prototype/set.js
+++ b/src/Ractive/prototype/set.js
@@ -1,41 +1,8 @@
-import { isObject } from '../../utils/is';
-import bind from '../../utils/bind';
-import { splitKeypath } from '../../shared/keypaths';
-import runloop from '../../global/runloop';
+import { build, set } from '../../shared/set';
 
 export default function Ractive$set ( keypath, value ) {
-	const promise = runloop.start( this, true );
+	const ractive = this;
 
-	// Set multiple keypaths in one go
-	if ( isObject( keypath ) ) {
-		const map = keypath;
-
-		for ( const k in map ) {
-			if ( map.hasOwnProperty( k) ) {
-				set( this, k, map[k] );
-			}
-		}
-	}
-	// Set a single keypath
-	else {
-		set( this, keypath, value );
-	}
-
-	runloop.end();
-
-	return promise;
+	return set( ractive, build( ractive, keypath, value ) );
 }
 
-
-function set ( ractive, keypath, value ) {
-	if ( typeof value === 'function' ) value = bind( value, ractive );
-
-	if ( /\*/.test( keypath ) ) {
-		ractive.viewmodel.findMatches( splitKeypath( keypath ) ).forEach( model => {
-			model.set( value );
-		});
-	} else {
-		const model = ractive.viewmodel.joinAll( splitKeypath( keypath ) );
-		model.set( value );
-	}
-}

--- a/src/Ractive/prototype/shared/add.js
+++ b/src/Ractive/prototype/shared/add.js
@@ -1,5 +1,5 @@
 import { isNumeric } from '../../../utils/is';
-import { splitKeypath } from '../../../shared/keypaths';
+import { build, set } from '../../../shared/set';
 
 const errorMessage = 'Cannot add to a non-numeric value';
 
@@ -8,27 +8,11 @@ export default function add ( ractive, keypath, d ) {
 		throw new Error( 'Bad arguments' );
 	}
 
-	let changes;
+	const sets = build( ractive, keypath, d );
 
-	if ( /\*/.test( keypath ) ) {
-		changes = {};
-
-		ractive.viewmodel.findMatches( splitKeypath( keypath ) ).forEach( model => {
-			const value = model.get();
-
-			if ( !isNumeric( value ) ) throw new Error( errorMessage );
-
-			changes[ model.getKeypath() ] = value + d;
-		});
-
-		return ractive.set( changes );
-	}
-
-	const value = ractive.get( keypath );
-
-	if ( !isNumeric( value ) ) {
-		throw new Error( errorMessage );
-	}
-
-	return ractive.set( keypath, +value + d );
+	return set( ractive, sets.map( pair => {
+		const [ model, add ] = pair, value = model.get();
+		if ( !isNumeric( add ) || !isNumeric( value ) ) throw new Error( errorMessage );
+		return [ model, value + add ];
+	}));
 }

--- a/src/Ractive/prototype/shift.js
+++ b/src/Ractive/prototype/shift.js
@@ -1,2 +1,2 @@
 import makeArrayMethod from './shared/makeArrayMethod';
-export default makeArrayMethod( 'shift' );
+export default makeArrayMethod( 'shift' ).path;

--- a/src/Ractive/prototype/sort.js
+++ b/src/Ractive/prototype/sort.js
@@ -1,2 +1,2 @@
 import makeArrayMethod from './shared/makeArrayMethod';
-export default makeArrayMethod( 'sort' );
+export default makeArrayMethod( 'sort' ).path;

--- a/src/Ractive/prototype/splice.js
+++ b/src/Ractive/prototype/splice.js
@@ -1,2 +1,2 @@
 import makeArrayMethod from './shared/makeArrayMethod';
-export default makeArrayMethod( 'splice' );
+export default makeArrayMethod( 'splice' ).path;

--- a/src/Ractive/prototype/teardown.js
+++ b/src/Ractive/prototype/teardown.js
@@ -28,8 +28,6 @@ export default function Ractive$teardown () {
 	this.shouldDestroy = true;
 	const promise = ( this.fragment.rendered ? this.unrender() : Promise.resolve() );
 
-	Object.keys( this._links ).forEach( k => this._links[k].unlink() );
-
 	teardownHook.fire( this );
 
 	return promise;

--- a/src/Ractive/prototype/toggle.js
+++ b/src/Ractive/prototype/toggle.js
@@ -1,22 +1,10 @@
 import { badArguments } from '../../config/errors';
-import { splitKeypath } from '../../shared/keypaths';
+import { gather, set } from '../../shared/set';
 
 export default function Ractive$toggle ( keypath ) {
 	if ( typeof keypath !== 'string' ) {
 		throw new TypeError( badArguments );
 	}
 
-	let changes;
-
-	if ( /\*/.test( keypath ) ) {
-		changes = {};
-
-		this.viewmodel.findMatches( splitKeypath( keypath ) ).forEach( model => {
-			changes[ model.getKeypath() ] = !model.get();
-		});
-
-		return this.set( changes );
-	}
-
-	return this.set( keypath, !this.get( keypath ) );
+	return set( this, gather( this, keypath ).map( m => [ m, !m.get() ] ) );
 }

--- a/src/Ractive/prototype/unlink.js
+++ b/src/Ractive/prototype/unlink.js
@@ -1,13 +1,9 @@
-import Promise from '../../utils/Promise';
+import { splitKeypath } from '../../shared/keypaths';
+import runloop from '../../global/runloop';
 
 export default function unlink( here ) {
-	let ln = this._links[ here ];
-
-	if ( ln ) {
-		ln.unlink();
-		delete this._links[ here ];
-		return this.set( here, ln.intialValue );
-	} else {
-		return Promise.resolve( true );
-	}
+	const promise = runloop.start();
+	this.viewmodel.joinAll( splitKeypath( here ), { lastLink: false } ).unlink();
+	runloop.end();
+	return promise;
 }

--- a/src/Ractive/prototype/unshift.js
+++ b/src/Ractive/prototype/unshift.js
@@ -1,2 +1,2 @@
 import makeArrayMethod from './shared/makeArrayMethod';
-export default makeArrayMethod( 'unshift' );
+export default makeArrayMethod( 'unshift' ).path;

--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -4,25 +4,20 @@ import { splitKeypath } from '../../shared/keypaths';
 
 const updateHook = new Hook( 'update' );
 
-export default function Ractive$update ( keypath ) {
-	if ( keypath ) keypath = splitKeypath( keypath );
+export function update ( ractive, model ) {
+	if ( model.parent && model.parent.wrapper ) return update( ractive, model.parent );
 
-	const model = keypath ?
-		this.viewmodel.joinAll( keypath ) :
-		this.viewmodel;
-
-	if ( model.parent && model.parent.wrapper ) return this.update( model.parent.getKeypath( this ) );
-
-	const promise = runloop.start( this, true );
+	const promise = runloop.start( ractive, true );
 
 	model.mark();
 	model.registerChange( model.getKeypath(), model.get() );
 
-	if ( keypath ) {
+	if ( !model.isRoot ) {
 		// there may be unresolved refs that are now resolvable up the context tree
-		let parent = model.parent;
-		while ( keypath.length && parent ) {
-			if ( parent.clearUnresolveds ) parent.clearUnresolveds( keypath.pop() );
+		let parent = model.parent, key = model.key;
+		while ( parent && !parent.isRoot ) {
+			if ( parent.clearUnresolveds ) parent.clearUnresolveds( key );
+			key = parent.key;
 			parent = parent.parent;
 		}
 	}
@@ -32,7 +27,13 @@ export default function Ractive$update ( keypath ) {
 
 	runloop.end();
 
-	updateHook.fire( this, model );
+	updateHook.fire( ractive, model );
 
 	return promise;
+}
+
+export default function Ractive$update ( keypath ) {
+	if ( keypath ) keypath = splitKeypath( keypath );
+
+	return update( this, keypath ? this.viewmodel.joinAll( keypath ) : this.viewmodel );
 }

--- a/src/Ractive/static/adaptors/array/patch.js
+++ b/src/Ractive/static/adaptors/array/patch.js
@@ -10,6 +10,9 @@ mutatorMethods.forEach( methodName => {
 	const method = function ( ...args ) {
 		const newIndices = getNewIndices( this.length, methodName, args );
 
+		// lock any magic array wrappers, so that things don't get fudged
+		this._ractive.wrappers.forEach( r => { if ( r.magic ) r.magic.locked = true; } );
+
 		// apply the underlying method
 		const result = Array.prototype[ methodName ].apply( this, arguments );
 
@@ -25,6 +28,10 @@ mutatorMethods.forEach( methodName => {
 		runloop.end();
 
 		this._ractive.setting = false;
+
+		// unlock the magic arrays... magic... bah
+		this._ractive.wrappers.forEach( r => { if ( r.magic ) r.magic.locked = false; } );
+
 		return result;
 	};
 

--- a/src/Ractive/static/adaptors/magic.js
+++ b/src/Ractive/static/adaptors/magic.js
@@ -19,7 +19,7 @@ try {
 
 export default magicAdaptor;
 
-function createOrWrapDescriptor ( originalDescriptor, ractive, keypath ) {
+function createOrWrapDescriptor ( originalDescriptor, ractive, keypath, wrapper ) {
 	if ( originalDescriptor.set && originalDescriptor.set.__magic ) {
 		originalDescriptor.set.__magic.dependants.push({ ractive, keypath });
 		return originalDescriptor;
@@ -42,6 +42,7 @@ function createOrWrapDescriptor ( originalDescriptor, ractive, keypath ) {
 				originalDescriptor.set.call( this, value );
 			}
 
+			if ( wrapper.locked ) return;
 			setting = true;
 			dependants.forEach( ({ ractive, keypath }) => {
 				ractive.set( keypath, value );
@@ -85,7 +86,7 @@ class MagicWrapper {
 
 			const childKeypath = keypath ? `${keypath}.${escapeKey( key )}` : escapeKey( key );
 
-			const descriptor = createOrWrapDescriptor( originalDescriptor, ractive, childKeypath );
+			const descriptor = createOrWrapDescriptor( originalDescriptor, ractive, childKeypath, this );
 
 
 

--- a/src/Ractive/static/adaptors/magicArray.js
+++ b/src/Ractive/static/adaptors/magicArray.js
@@ -9,6 +9,7 @@ class MagicArrayWrapper {
 
 		this.magicWrapper = magicAdaptor.wrap( ractive, array, keypath );
 		this.arrayWrapper = arrayAdaptor.wrap( ractive, array, keypath );
+		this.arrayWrapper.magic = this.magicWrapper;
 
 		// ugh, this really is a terrible hack
 		Object.defineProperty( this, '__model', {

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -4,7 +4,7 @@ import { capture, startCapturing, stopCapturing } from '../global/capture';
 import { warnIfDebug } from '../utils/log';
 import Model from './Model';
 import ComputationChild from './ComputationChild';
-import { handleChange } from '../shared/methodCallers';
+import { handleChange, marked } from '../shared/methodCallers';
 import { hasConsole } from '../config/environment';
 
 // TODO this is probably a bit anal, maybe we should leave it out
@@ -114,6 +114,7 @@ export default class Computation extends Model {
 	handleChange () {
 		this.dirty = true;
 
+		this.links.forEach( marked );
 		this.deps.forEach( handleChange );
 		this.children.forEach( handleChange );
 		this.clearUnresolveds(); // TODO same question as on Model - necessary for primitives?
@@ -133,6 +134,10 @@ export default class Computation extends Model {
 
 	mark () {
 		this.handleChange();
+	}
+
+	rebinding ( next, previous ) {
+		// TODO: model swap
 	}
 
 	set ( value ) {

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -137,7 +137,8 @@ export default class Computation extends Model {
 	}
 
 	rebinding ( next, previous ) {
-		// TODO: model swap
+		// computations will grab all of their deps again automagically
+		if ( next !== previous ) this.handleChange();
 	}
 
 	set ( value ) {

--- a/src/model/LinkModel.js
+++ b/src/model/LinkModel.js
@@ -11,7 +11,7 @@ export default class LinkModel extends ModelBase {
 		this.owner = owner;
 		this.target = target;
 		this.key = key === undefined ? owner.key : key;
-		if ( owner.isLink ) this.keypath = `${owner.keypath}.${this.key}`;
+		if ( owner.isLink ) this.sourcePath = `${owner.sourcePath}.${this.key}`;
 
 		target.registerLink( this );
 
@@ -77,7 +77,7 @@ export default class LinkModel extends ModelBase {
 	}
 
 	relinking ( target, root = true ) {
-		if ( root && this.keypath ) target = rebindMatch( this.keypath, target, this.target );
+		if ( root && this.sourcePath ) target = rebindMatch( this.sourcePath, target, this.target );
 		if ( !target || this.target === target ) return;
 
 		this.target.unregisterLink( this );
@@ -155,7 +155,7 @@ export default class LinkModel extends ModelBase {
 
 ModelBase.prototype.link = function link ( model, keypath ) {
 	const lnk = this._link || new LinkModel( this.parent, this, model, this.key );
-	lnk.keypath = keypath;
+	lnk.sourcePath = keypath;
 	if ( this._link ) this._link.relinking( model );
 	this.rebinding( lnk, this );
 	fireShuffleTasks();

--- a/src/model/LinkModel.js
+++ b/src/model/LinkModel.js
@@ -1,0 +1,169 @@
+import ModelBase from './ModelBase';
+import KeypathModel from './specials/KeypathModel';
+import { capture } from '../global/capture';
+import { handleChange, mark, marked, teardown } from '../shared/methodCallers';
+import runloop from '../global/runloop';
+
+export default class LinkModel extends ModelBase {
+	constructor ( parent, owner, target, key ) {
+		super( parent );
+
+		this.owner = owner;
+		this.target = target;
+		this.key = key === undefined ? owner.key : key;
+
+		target.registerLink( this );
+
+		this.isReadonly = parent.isReadonly;
+
+		this.isLink = true;
+	}
+
+	animate ( from, to, options, interpolator ) {
+		this.target.animate( from, to, options, interpolator );
+	}
+
+	get ( shouldCapture ) {
+		if ( shouldCapture ) capture( this );
+		return this.target.get( false );
+	}
+
+	getKeypath ( ractive ) {
+		if ( ractive && ractive !== this.root.ractive ) return this.target.getKeypath( ractive );
+
+		return super.getKeypath( ractive );
+	}
+
+	getKeypathModel ( ractive ) {
+		if ( !this.keypathModel ) this.keypathModel = new KeypathModel( this );
+		if ( ractive && ractive !== this.root.ractive ) return this.keypathModel.getChild( ractive );
+		return this.keypathModel;
+	}
+
+	handleChange () {
+		this.deps.forEach( handleChange );
+		this.links.forEach( handleChange );
+		this.notifyUpstream();
+	}
+
+	joinKey ( key ) {
+		// TODO: handle nested links
+		if ( key === undefined || key === '' ) return this;
+
+		if ( !this.childByKey.hasOwnProperty( key ) ) {
+			const child = new LinkModel( this, this, this.target.joinKey( key ), key );
+			this.children.push( child );
+			this.childByKey[ key ] = child;
+		}
+
+		return this.childByKey[ key ];
+	}
+
+	mark () {
+		this.target.mark();
+	}
+
+	marked () {
+		this.links.forEach( marked );
+		this.children.forEach( mark );
+
+		this.deps.forEach( handleChange );
+		this.clearUnresolveds();
+	}
+
+	relinked () {
+		this.target.registerLink( this );
+		this.handleChange();
+		this.children.forEach( c => c.relinked() );
+	}
+
+	relinking ( target, root = true ) {
+		if ( !target || this.target === target ) return;
+
+		this.target.unregisterLink( this );
+		if ( this.keypathModel ) this.keypathModel.rebindChildren( target );
+
+		this.target = target;
+		this.children.forEach( c => {
+			c.relinking( target.joinKey( c.key ), false );
+		});
+
+		if ( root ) runloop.scheduleTask( () => this.relinked() );
+	}
+
+	set ( value ) {
+		this.target.set( value );
+	}
+
+	shuffle ( newIndices ) {
+		if ( this.shuffling ) return;
+		this.shuffling = true;
+		if ( !this.target.shuffling ) this.target.shuffle( newIndices );
+
+		let i = newIndices.length;
+		while ( i-- ) {
+			const idx = newIndices[ i ];
+			// nothing is actually changing, so move in the index and roll on
+			if ( i === idx ) {
+				continue;
+			}
+
+			// rebind the children on i to idx
+			if ( i in this.childByKey ) this.childByKey[ i ].rebinding( !~idx ? undefined : this.joinKey( idx ), this.childByKey[ i ] );
+
+			if ( !~idx && this.keyModels[ i ] ) {
+				this.keyModels[i].rebinding( undefined, this.keyModels[i]);
+			} else if ( ~idx && this.keyModels[ i ] ) {
+				if ( !this.keyModels[ idx ] ) this.childByKey[ idx ].getKeyModel( idx );
+				this.keyModels[i].rebinding( this.keyModels[ idx ], this.keyModels[i] );
+			}
+		}
+
+		const upstream = this.source().length !== this.source().value.length;
+
+		this.links.forEach( l => l.shuffle( newIndices ) );
+
+		i = this.deps.length;
+		while ( i-- ) {
+			if ( this.deps[i].shuffle ) this.deps[i].shuffle( newIndices );
+		}
+
+		this.marked();
+
+		i = this.deps.length;
+		while ( i-- ) {
+			if ( !this.deps[i].shuffle ) this.deps[i].handleChange();
+		}
+
+		if ( upstream ) this.notifyUpstream();
+
+		this.shuffling = false;
+	}
+
+	source () {
+		if ( this.target.source ) return this.target.source();
+		else return this.target;
+	}
+
+	teardown () {
+		this.children.forEach( teardown );
+	}
+}
+
+ModelBase.prototype.link = function link ( model ) {
+	const lnk = this._link || new LinkModel( this.parent, this, model, this.key );
+	if ( this._link ) this._link.relinking( model );
+	this.rebinding( lnk, this );
+	if ( !this._link ) this.parent.clearUnresolveds();
+	this._link = lnk;
+	return lnk;
+};
+
+ModelBase.prototype.unlink = function unlink () {
+	if ( this._link ) {
+		const ln = this._link;
+		this._link = undefined;
+		ln.rebinding( this, this._link );
+		ln.teardown();
+	}
+};

--- a/src/model/LinkModel.js
+++ b/src/model/LinkModel.js
@@ -3,6 +3,7 @@ import KeypathModel from './specials/KeypathModel';
 import { capture } from '../global/capture';
 import { handleChange, mark, marked, teardown } from '../shared/methodCallers';
 import runloop from '../global/runloop';
+import { rebindMatch } from '../shared/rebind';
 
 export default class LinkModel extends ModelBase {
 	constructor ( parent, owner, target, key ) {
@@ -11,6 +12,7 @@ export default class LinkModel extends ModelBase {
 		this.owner = owner;
 		this.target = target;
 		this.key = key === undefined ? owner.key : key;
+		if ( owner.isLink ) this.keypath = `${owner.keypath}.${this.key}`;
 
 		target.registerLink( this );
 
@@ -78,6 +80,7 @@ export default class LinkModel extends ModelBase {
 	}
 
 	relinking ( target, root = true ) {
+		if ( this.keypath ) target = rebindMatch( this.keypath, target, this.target );
 		if ( !target || this.target === target ) return;
 
 		this.target.unregisterLink( this );
@@ -150,8 +153,9 @@ export default class LinkModel extends ModelBase {
 	}
 }
 
-ModelBase.prototype.link = function link ( model ) {
+ModelBase.prototype.link = function link ( model, keypath ) {
 	const lnk = this._link || new LinkModel( this.parent, this, model, this.key );
+	lnk.keypath = keypath;
 	if ( this._link ) this._link.relinking( model );
 	this.rebinding( lnk, this );
 	if ( !this._link ) this.parent.clearUnresolveds();

--- a/src/model/LinkModel.js
+++ b/src/model/LinkModel.js
@@ -24,9 +24,9 @@ export default class LinkModel extends ModelBase {
 		this.target.animate( from, to, options, interpolator );
 	}
 
-	get ( shouldCapture ) {
+	get ( shouldCapture, opts ) {
 		if ( shouldCapture ) capture( this );
-		return this.target.get( false );
+		return this.target.get( false, opts );
 	}
 
 	getKeypath ( ractive ) {
@@ -159,8 +159,10 @@ ModelBase.prototype.link = function link ( model, keypath ) {
 	if ( this._link ) this._link.relinking( model );
 	this.rebinding( lnk, this );
 	fireShuffleTasks();
-	if ( !this._link ) this.parent.clearUnresolveds();
+
+	const unresolved = !this._link;
 	this._link = lnk;
+	if ( unresolved ) this.parent.clearUnresolveds();
 	lnk.marked();
 	return lnk;
 };

--- a/src/model/LinkModel.js
+++ b/src/model/LinkModel.js
@@ -1,4 +1,4 @@
-import ModelBase from './ModelBase';
+import ModelBase, { fireShuffleTasks } from './ModelBase';
 import KeypathModel from './specials/KeypathModel';
 import { capture } from '../global/capture';
 import { handleChange, marked, teardown } from '../shared/methodCallers';
@@ -158,8 +158,10 @@ ModelBase.prototype.link = function link ( model, keypath ) {
 	lnk.keypath = keypath;
 	if ( this._link ) this._link.relinking( model );
 	this.rebinding( lnk, this );
+	fireShuffleTasks();
 	if ( !this._link ) this.parent.clearUnresolveds();
 	this._link = lnk;
+	lnk.marked();
 	return lnk;
 };
 

--- a/src/model/LinkModel.js
+++ b/src/model/LinkModel.js
@@ -115,7 +115,7 @@ export default class LinkModel extends ModelBase {
 			if ( i in this.childByKey ) this.childByKey[ i ].rebinding( !~idx ? undefined : this.joinKey( idx ), this.childByKey[ i ] );
 
 			if ( !~idx && this.keyModels[ i ] ) {
-				this.keyModels[i].rebinding( undefined, this.keyModels[i]);
+				this.keyModels[i].rebinding( undefined, this.keyModels[i] );
 			} else if ( ~idx && this.keyModels[ i ] ) {
 				if ( !this.keyModels[ idx ] ) this.childByKey[ idx ].getKeyModel( idx );
 				this.keyModels[i].rebinding( this.keyModels[ idx ], this.keyModels[i] );
@@ -149,6 +149,7 @@ export default class LinkModel extends ModelBase {
 	}
 
 	teardown () {
+		if ( this._link ) this._link.teardown();
 		this.children.forEach( teardown );
 	}
 }

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -203,8 +203,8 @@ export default class Model extends ModelBase {
 			// keep track of array lengths
 			if ( isArray( value ) ) this.length = value.length;
 
-			this.links.forEach( marked );
 			this.children.forEach( mark );
+			this.links.forEach( marked );
 
 			this.deps.forEach( handleChange );
 			this.clearUnresolveds();
@@ -279,11 +279,10 @@ export default class Model extends ModelBase {
 			}
 		}
 
-		fireShuffleTasks();
-
 		const upstream = this.length !== this.value.length;
 
 		this.links.forEach( l => l.shuffle( newIndices ) );
+		fireShuffleTasks();
 
 		i = this.deps.length;
 		while ( i-- ) {

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -1,50 +1,25 @@
+import ModelBase from './ModelBase';
+import LinkModel from './LinkModel';
+import KeypathModel from './specials/KeypathModel';
 import { capture } from '../global/capture';
 import Promise from '../utils/Promise';
-import { isEqual, isNumeric } from '../utils/is';
-import { removeFromArray } from '../utils/array';
-import { handleChange, mark, teardown } from '../shared/methodCallers';
+import { isArray, isEqual, isNumeric } from '../utils/is';
+import { handleChange, mark, marked, teardown } from '../shared/methodCallers';
 import Ticker from '../shared/Ticker';
 import getPrefixer from './helpers/getPrefixer';
-import { isArray, isObject } from '../utils/is';
-import KeyModel from './specials/KeyModel';
-import KeypathModel from './specials/KeypathModel';
-import { escapeKey, unescapeKey } from '../shared/keypaths';
-import runloop from '../global/runloop';
-
-const hasProp = Object.prototype.hasOwnProperty;
-
-function updateFromBindings ( model ) {
-	model.updateFromBindings( true );
-}
-
-function updateKeypathDependants ( model ) {
-	model.updateKeypathDependants();
-}
+import { unescapeKey } from '../shared/keypaths';
 
 let originatingModel = null;
 
-export default class Model {
+export default class Model extends ModelBase {
 	constructor ( parent, key ) {
-		this.deps = [];
-
-		this.children = [];
-		this.childByKey = {};
-
-		this.indexModels = [];
-
-		this.unresolved = [];
-		this.unresolvedByKey = {};
-
-		this.bindings = [];
-		this.patternObservers = [];
+		super( parent );
 
 		this.value = undefined;
 
 		this.ticker = null;
 
 		if ( parent ) {
-			this.parent = parent;
-			this.root = parent.root;
 			this.key = unescapeKey( key );
 			this.isReadonly = parent.isReadonly;
 
@@ -105,15 +80,6 @@ export default class Model {
 		}
 	}
 
-	addUnresolved ( key, resolver ) {
-		if ( !this.unresolvedByKey[ key ] ) {
-			this.unresolved.push( key );
-			this.unresolvedByKey[ key ] = [];
-		}
-
-		this.unresolvedByKey[ key ].push( resolver );
-	}
-
 	animate ( from, to, options, interpolator ) {
 		if ( this.ticker ) this.ticker.stop();
 
@@ -171,6 +137,7 @@ export default class Model {
 		const previousOriginatingModel = originatingModel; // for the array.length special case
 		originatingModel = this;
 
+		this.links.forEach( handleChange );
 		this.children.forEach( mark );
 		this.deps.forEach( handleChange );
 
@@ -180,30 +147,7 @@ export default class Model {
 
 		// keep track of array length
 		if ( isArray( value ) ) this.length = value.length;
-	}
-
-	clearUnresolveds ( specificKey ) {
-		let i = this.unresolved.length;
-
-		while ( i-- ) {
-			const key = this.unresolved[i];
-
-			if ( specificKey && key !== specificKey ) continue;
-
-			const resolvers = this.unresolvedByKey[ key ];
-			const hasKey = this.has( key );
-
-			let j = resolvers.length;
-			while ( j-- ) {
-				if ( hasKey ) resolvers[j].attemptResolution();
-				if ( resolvers[j].resolved ) resolvers.splice( j, 1 );
-			}
-
-			if ( !resolvers.length ) {
-				this.unresolved.splice( i, 1 );
-				this.unresolvedByKey[ key ] = null;
-			}
-		}
+		else if ( this.key === 'length' && isArray( this.parent.value ) ) this.parent.length = this.parent.value.length;
 	}
 
 	createBranch ( key ) {
@@ -213,134 +157,26 @@ export default class Model {
 		return branch;
 	}
 
-	findMatches ( keys ) {
-		const len = keys.length;
-
-		let existingMatches = [ this ];
-		let matches;
-		let i;
-
-		for ( i = 0; i < len; i += 1 ) {
-			const key = keys[i];
-
-			if ( key === '*' ) {
-				matches = [];
-				existingMatches.forEach( model => {
-					matches.push.apply( matches, model.getValueChildren( model.get() ) );
-				});
-			} else {
-				matches = existingMatches.map( model => model.joinKey( key ) );
-			}
-
-			existingMatches = matches;
-		}
-
-		return matches;
-	}
-
 	get ( shouldCapture ) {
+		if ( this._link ) return this._link.get( shouldCapture );
 		if ( shouldCapture ) capture( this );
 		// if capturing, this value needs to be unwrapped because it's for external use
 		return shouldCapture && this.wrapper ? this.wrapper.value : this.value;
 	}
 
-	getIndexModel ( fragmentIndex ) {
-		const indexModels = this.parent.indexModels;
-
-		// non-numeric keys are a special of a numeric index in a object iteration
-		if ( typeof this.key === 'string' && fragmentIndex !== undefined ) {
-			return new KeyModel( fragmentIndex, this );
-		} else if ( !indexModels[ this.key ] ) {
-			indexModels[ this.key ] = new KeyModel( this.key, this );
-		}
-
-		return indexModels[ this.key ];
-	}
-
-	getKeyModel () {
-		// TODO... different to IndexModel because key can never change
-		return new KeyModel( escapeKey( this.key ), this );
-	}
-
 	getKeypathModel ( ractive ) {
-		let keypath = this.getKeypath(), model = this.keypathModel || ( this.keypathModel = new KeypathModel( this ) );
-
-		if ( ractive && ractive.component ) {
-			let mapped = this.getKeypath( ractive );
-			if ( mapped !== keypath ) {
-				let map = ractive.viewmodel.keypathModels || ( ractive.viewmodel.keypathModels = {} );
-				let child = map[ keypath ] || ( map[ keypath ] = new KeypathModel( this, ractive ) );
-				model.addChild( child );
-				return child;
-			}
-		}
-
-		return model;
+		if ( !this.keypathModel ) this.keypathModel = new KeypathModel( this );
+		return this.keypathModel;
 	}
 
-	getKeypath ( ractive ) {
-		if ( ! this.keypath ) this.keypath = this.parent.isRoot ? escapeKey( this.key ) : this.parent.getKeypath() + '.' + escapeKey( this.key );
-
-		let root = this.keypath;
-
-		if ( ractive && ractive.component ) {
-			let map = ractive.viewmodel.mappings;
-			for ( let k in map ) {
-				if ( root.indexOf( map[ k ].getKeypath() ) >= 0 ) {
-					root = root.replace( map[ k ].getKeypath(), k );
-					break;
-				}
-			}
+	joinKey ( key, opts ) {
+		if ( this._link ) {
+			if ( opts && !opts.lastLink === false && ( key === undefined || key === '' ) ) return this;
+			return this._link.joinKey( key );
 		}
 
-		return root;
-	}
-
-	getValueChildren ( value ) {
-		let children;
-		if ( isArray( value ) ) {
-			children = [];
-			// special case - array.length. This is a horrible kludge, but
-			// it'll do for now. Alternatives welcome
-			if ( originatingModel && originatingModel.parent === this && originatingModel.key === 'length' ) {
-				children.push( originatingModel );
-			}
-			value.forEach( ( m, i ) => {
-				children.push( this.joinKey( i ) );
-			});
-
-		}
-
-		else if ( isObject( value ) || typeof value === 'function' ) {
-			children = Object.keys( value ).map( key => this.joinKey( key ) );
-		}
-
-		else if ( value != null ) {
-			return [];
-		}
-
-		return children;
-	}
-
-	has ( key ) {
-		const value = this.get();
-		if ( !value ) return false;
-
-		key = unescapeKey( key );
-		if ( hasProp.call( value, key ) ) return true;
-
-		// We climb up the constructor chain to find if one of them contains the key
-		let constructor = value.constructor;
-		while ( constructor !== Function && constructor !== Array && constructor !== Object ) {
-			if ( hasProp.call( constructor.prototype, key ) ) return true;
-			constructor = constructor.constructor;
-		}
-
-		return false;
-	}
-
-	joinKey ( key ) {
 		if ( key === undefined || key === '' ) return this;
+
 
 		if ( !this.childByKey.hasOwnProperty( key ) ) {
 			const child = new Model( this, key );
@@ -348,19 +184,13 @@ export default class Model {
 			this.childByKey[ key ] = child;
 		}
 
+		if ( this.childByKey[ key ]._link ) return this.childByKey[ key ]._link;
 		return this.childByKey[ key ];
 	}
 
-	joinAll ( keys ) {
-		let model = this;
-		for ( let i = 0; i < keys.length; i += 1 ) {
-			model = model.joinKey( keys[i] );
-		}
-
-		return model;
-	}
-
 	mark () {
+		if ( this._link ) return this._link.mark();
+
 		const value = this.retrieve();
 
 		if ( !isEqual( value, this.value ) ) {
@@ -373,6 +203,7 @@ export default class Model {
 			// keep track of array lengths
 			if ( isArray( value ) ) this.length = value.length;
 
+			this.links.forEach( marked );
 			this.children.forEach( mark );
 
 			this.deps.forEach( handleChange );
@@ -418,46 +249,6 @@ export default class Model {
 		this.shuffle( newIndices );
 	}
 
-	notifyUpstream () {
-		let parent = this.parent, prev = this;
-		while ( parent ) {
-			if ( parent.patternObservers.length ) parent.patternObservers.forEach( o => o.notify( prev.key ) );
-			parent.deps.forEach( handleChange );
-			prev = parent;
-			parent = parent.parent;
-		}
-	}
-
-	register ( dep ) {
-		this.deps.push( dep );
-	}
-
-	registerChange ( key, value ) {
-		if ( !this.isRoot ) {
-			this.root.registerChange( key, value );
-		} else {
-			this.changes[ key ] = value;
-			runloop.addInstance( this.root.ractive );
-		}
-	}
-
-	registerPatternObserver ( observer ) {
-		this.patternObservers.push( observer );
-		this.register( observer );
-	}
-
-	registerTwowayBinding ( binding ) {
-		this.bindings.push( binding );
-	}
-
-	removeUnresolved ( key, resolver ) {
-		const resolvers = this.unresolvedByKey[ key ];
-
-		if ( resolvers ) {
-			removeFromArray( resolvers, resolver );
-		}
-	}
-
 	retrieve () {
 		return this.parent.value ? this.parent.value[ this.key ] : undefined;
 	}
@@ -468,116 +259,50 @@ export default class Model {
 	}
 
 	shuffle ( newIndices ) {
-		const indexModels = [];
-
-		newIndices.forEach( ( newIndex, oldIndex ) => {
-			if ( newIndex !== oldIndex && this.childByKey[oldIndex] ) this.childByKey[oldIndex].shuffled();
-
-			if ( !~newIndex ) return;
-
-			const model = this.indexModels[ oldIndex ];
-
-			if ( !model ) return;
-
-			indexModels[ newIndex ] = model;
-
-			if ( newIndex !== oldIndex ) {
-				model.rebind( newIndex );
+		this.shuffling = true;
+		let i = newIndices.length;
+		while ( i-- ) {
+			const idx = newIndices[ i ];
+			// nothing is actually changing, so move in the index and roll on
+			if ( i === idx ) {
+				continue;
 			}
-		});
 
-		this.indexModels = indexModels;
+			// rebind the children on i to idx
+			if ( i in this.childByKey ) this.childByKey[ i ].rebinding( !~idx ? undefined : this.joinKey( idx ), this.childByKey[ i ] );
 
-		// shuffles need to happen before marks...
-		this.deps.forEach( dep => {
-			if ( dep.shuffle ) dep.shuffle( newIndices );
-		});
+			if ( !~idx && this.keyModels[ i ] ) {
+				this.keyModels[i].rebinding( undefined, this.keyModels[i]);
+			} else if ( ~idx && this.keyModels[ i ] ) {
+				if ( !this.keyModels[ idx ] ) this.childByKey[ idx ].getKeyModel( idx );
+				this.keyModels[i].rebinding( this.keyModels[ idx ], this.keyModels[i] );
+			}
+		}
 
 		const upstream = this.length !== this.value.length;
-		this.updateKeypathDependants();
+
+		this.links.forEach( l => l.shuffle( newIndices ) );
+
+		i = this.deps.length;
+		while ( i-- ) {
+			if ( this.deps[i].shuffle ) this.deps[i].shuffle( newIndices );
+		}
+
 		this.mark();
 
-		// ...but handleChange must happen after (TODO document why)
-		this.deps.forEach( dep => {
-			if ( !dep.shuffle ) dep.handleChange();
-		});
-
-		// if the length has changed, notify upstream
-		if ( upstream ) {
-			this.notifyUpstream();
-		}
-	}
-
-	shuffled () {
-		let i = this.children.length;
+		i = this.deps.length;
 		while ( i-- ) {
-			this.children[i].shuffled();
+			if ( !this.deps[i].shuffle ) this.deps[i].handleChange();
 		}
-		if ( this.wrapper ) {
-			this.wrapper.teardown();
-			this.wrapper = null;
-			this.rewrap = true;
-		}
+
+		if ( upstream ) this.notifyUpstream();
+		this.shuffling = false;
 	}
 
 	teardown () {
+		if ( this._link ) this._link.teardown();
 		this.children.forEach( teardown );
 		if ( this.wrapper ) this.wrapper.teardown();
-		if ( this.keypathModels ) {
-			for ( let k in this.keypathModels ) {
-				this.keypathModels[ k ].teardown();
-			}
-		}
-	}
-
-	unregister ( dependant ) {
-		removeFromArray( this.deps, dependant );
-	}
-
-	unregisterPatternObserver ( observer ) {
-		removeFromArray( this.patternObservers, observer );
-		this.unregister( observer );
-	}
-
-	unregisterTwowayBinding ( binding ) {
-		removeFromArray( this.bindings, binding );
-	}
-
-	updateFromBindings ( cascade ) {
-		let i = this.bindings.length;
-		while ( i-- ) {
-			const value = this.bindings[i].getValue();
-			if ( value !== this.value ) this.set( value );
-		}
-
-		// check for one-way bindings if there are no two-ways
-		if ( !this.bindings.length ) {
-			const oneway = findBoundValue( this.deps );
-			if ( oneway && oneway.value !== this.value ) this.set( oneway.value );
-		}
-
-		if ( cascade ) {
-			this.children.forEach( updateFromBindings );
-		}
-	}
-
-	updateKeypathDependants () {
-		this.children.forEach( updateKeypathDependants );
-		if ( this.keypathModel ) this.keypathModel.handleChange();
-	}
-}
-
-export function findBoundValue( list ) {
-	let i = list.length;
-	while ( i-- ) {
-		if ( list[i].bound ) {
-			const owner = list[i].owner;
-			if ( owner ) {
-				const value = owner.name === 'checked' ?
-					owner.node.checked :
-					owner.node.value;
-				return { value };
-			}
-		}
+		if ( this.keypathModel ) this.keypathModel.teardown();
 	}
 }

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -270,20 +270,20 @@ export default class Model extends ModelBase {
 			}
 
 			// rebind the children on i to idx
-			if ( i in this.childByKey ) this.childByKey[ i ].rebinding( !~idx ? undefined : this.joinKey( idx ), this.childByKey[ i ] );
+			if ( i in this.childByKey ) this.childByKey[ i ].rebinding( !~idx ? undefined : this.joinKey( idx ), this.childByKey[ i ], true );
 
 			if ( !~idx && this.keyModels[ i ] ) {
-				this.keyModels[i].rebinding( undefined, this.keyModels[i] );
+				this.keyModels[i].rebinding( undefined, this.keyModels[i], false );
 			} else if ( ~idx && this.keyModels[ i ] ) {
 				if ( !this.keyModels[ idx ] ) this.childByKey[ idx ].getKeyModel( idx );
-				this.keyModels[i].rebinding( this.keyModels[ idx ], this.keyModels[i] );
+				this.keyModels[i].rebinding( this.keyModels[ idx ], this.keyModels[i], false );
 			}
 		}
 
 		const upstream = this.length !== this.value.length;
 
 		this.links.forEach( l => l.shuffle( newIndices ) );
-		fireShuffleTasks();
+		fireShuffleTasks( 'early' );
 
 		i = this.deps.length;
 		while ( i-- ) {
@@ -291,11 +291,7 @@ export default class Model extends ModelBase {
 		}
 
 		this.mark();
-
-		i = this.deps.length;
-		while ( i-- ) {
-			if ( !this.deps[i].shuffle ) this.deps[i].handleChange();
-		}
+		fireShuffleTasks( 'mark' );
 
 		if ( upstream ) this.notifyUpstream();
 		this.shuffling = false;

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -1,4 +1,4 @@
-import ModelBase from './ModelBase';
+import ModelBase, { fireShuffleTasks } from './ModelBase';
 import LinkModel from './LinkModel';
 import KeypathModel from './specials/KeypathModel';
 import { capture } from '../global/capture';
@@ -278,6 +278,8 @@ export default class Model extends ModelBase {
 				this.keyModels[i].rebinding( this.keyModels[ idx ], this.keyModels[i] );
 			}
 		}
+
+		fireShuffleTasks();
 
 		const upstream = this.length !== this.value.length;
 

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -157,10 +157,11 @@ export default class Model extends ModelBase {
 		return branch;
 	}
 
-	get ( shouldCapture ) {
-		if ( this._link ) return this._link.get( shouldCapture );
+	get ( shouldCapture, opts ) {
+		if ( this._link ) return this._link.get( shouldCapture, opts );
 		if ( shouldCapture ) capture( this );
 		// if capturing, this value needs to be unwrapped because it's for external use
+		if ( opts && opts.virtual ) return this.getVirtual( false );
 		return shouldCapture && this.wrapper ? this.wrapper.value : this.value;
 	}
 

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -273,7 +273,7 @@ export default class Model extends ModelBase {
 			if ( i in this.childByKey ) this.childByKey[ i ].rebinding( !~idx ? undefined : this.joinKey( idx ), this.childByKey[ i ] );
 
 			if ( !~idx && this.keyModels[ i ] ) {
-				this.keyModels[i].rebinding( undefined, this.keyModels[i]);
+				this.keyModels[i].rebinding( undefined, this.keyModels[i] );
 			} else if ( ~idx && this.keyModels[ i ] ) {
 				if ( !this.keyModels[ idx ] ) this.childByKey[ idx ].getKeyModel( idx );
 				this.keyModels[i].rebinding( this.keyModels[ idx ], this.keyModels[i] );

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -205,7 +205,7 @@ export default class ModelBase {
 		while ( i-- ) {
 			const link = this.links[i];
 			// only relink the root of the link tree
-			if ( link.owner._link ) link.relinking( next, previous );
+			if ( link.owner._link ) link.relinking( next );
 		}
 
 		i = this.children.length;

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -1,4 +1,5 @@
 import KeyModel from './specials/KeyModel';
+import KeypathModel from './specials/KeypathModel';
 import { escapeKey, unescapeKey } from '../shared/keypaths';
 import { handleChange } from '../shared/methodCallers';
 import { addToArray, removeFromArray } from '../utils/array';
@@ -6,6 +7,8 @@ import { isArray, isObject } from '../utils/is';
 import runloop from '../global/runloop';
 
 const hasProp = Object.prototype.hasOwnProperty;
+
+let shuffleTasks = [];
 
 export default class ModelBase {
 	constructor ( parent ) {
@@ -37,6 +40,8 @@ export default class ModelBase {
 
 		this.unresolvedByKey[ key ].push( resolver );
 	}
+
+	addShuffleTask ( task ) { shuffleTasks.push( task ); }
 
 	clearUnresolveds ( specificKey ) {
 		let i = this.unresolved.length;
@@ -199,9 +204,8 @@ export default class ModelBase {
 		i = this.links.length;
 		while ( i-- ) {
 			const link = this.links[i];
-			//if ( link.parent.isLink ) link.rebinding( next ? link.parent.joinKey( next.key ) : undefined, link, false );
-			//else link.relinking( next );
-			if ( next && link.owner._link ) link.relinking( next );
+			// only relink the root of the link tree
+			if ( link.owner._link ) link.relinking( next, previous );
 		}
 
 		i = this.children.length;
@@ -329,3 +333,13 @@ export function findBoundValue( list ) {
 		}
 	}
 }
+
+export function fireShuffleTasks () {
+	const tasks = shuffleTasks;
+	shuffleTasks = [];
+	let i = tasks.length;
+	while ( i-- ) tasks[i]();
+}
+
+KeyModel.prototype.addShuffleTask = ModelBase.prototype.addShuffleTask;
+KeypathModel.prototype.addShuffleTask = ModelBase.prototype.addShuffleTask;

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -103,7 +103,11 @@ export default class ModelBase {
 	getKeypath ( ractive ) {
 		if ( ractive !== this.ractive && this._link ) return this._link.target.getKeypath( ractive );
 
-		return this.parent.isRoot ? this.key : `${this.parent.getKeypath( ractive )}.${escapeKey( this.key )}`;
+		if ( !this.keypath ) {
+			this.keypath = this.parent.isRoot ? this.key : `${this.parent.getKeypath( ractive )}.${escapeKey( this.key )}`;
+		}
+
+		return this.keypath;
 	}
 
 	getValueChildren ( value ) {

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -1,0 +1,331 @@
+import KeyModel from './specials/KeyModel';
+import { escapeKey, unescapeKey } from '../shared/keypaths';
+import { handleChange } from '../shared/methodCallers';
+import { addToArray, removeFromArray } from '../utils/array';
+import { isArray, isObject } from '../utils/is';
+import runloop from '../global/runloop';
+
+const hasProp = Object.prototype.hasOwnProperty;
+
+export default class ModelBase {
+	constructor ( parent ) {
+		this.deps = [];
+
+		this.children = [];
+		this.childByKey = {};
+		this.links = [];
+
+		this.keyModels = {};
+
+		this.unresolved = [];
+		this.unresolvedByKey = {};
+
+		this.bindings = [];
+		this.patternObservers = [];
+
+		if ( parent ) {
+			this.parent = parent;
+			this.root = parent.root;
+		}
+	}
+
+	addUnresolved ( key, resolver ) {
+		if ( !this.unresolvedByKey[ key ] ) {
+			this.unresolved.push( key );
+			this.unresolvedByKey[ key ] = [];
+		}
+
+		this.unresolvedByKey[ key ].push( resolver );
+	}
+
+	clearUnresolveds ( specificKey ) {
+		let i = this.unresolved.length;
+
+		while ( i-- ) {
+			const key = this.unresolved[i];
+
+			if ( specificKey && key !== specificKey ) continue;
+
+			const resolvers = this.unresolvedByKey[ key ];
+			const hasKey = this.has( key );
+
+			let j = resolvers.length;
+			while ( j-- ) {
+				if ( hasKey ) resolvers[j].attemptResolution();
+				if ( resolvers[j].resolved ) resolvers.splice( j, 1 );
+			}
+
+			if ( !resolvers.length ) {
+				this.unresolved.splice( i, 1 );
+				this.unresolvedByKey[ key ] = null;
+			}
+		}
+	}
+
+	findMatches ( keys ) {
+		const len = keys.length;
+
+		let existingMatches = [ this ];
+		let matches;
+		let i;
+
+		for ( i = 0; i < len; i += 1 ) {
+			const key = keys[i];
+
+			if ( key === '*' ) {
+				matches = [];
+				existingMatches.forEach( model => {
+					matches.push.apply( matches, model.getValueChildren( model.get() ) );
+				});
+			} else {
+				matches = existingMatches.map( model => model.joinKey( key ) );
+			}
+
+			existingMatches = matches;
+		}
+
+		return matches;
+	}
+
+	getKeyModel ( key, skip ) {
+		if ( key !== undefined && !skip ) return this.parent.getKeyModel( key, true );
+
+		if ( !( key in this.keyModels ) ) this.keyModels[ key ] = new KeyModel( escapeKey( key ), this );
+
+		return this.keyModels[ key ];
+	}
+
+	getKeypath ( ractive ) {
+		if ( ractive !== this.ractive && this._link ) return this._link.target.getKeypath( ractive );
+
+		return this.parent.isRoot ? this.key : `${this.parent.getKeypath( ractive )}.${escapeKey( this.key )}`;
+	}
+
+	getValueChildren ( value ) {
+		let children;
+		if ( isArray( value ) ) {
+			children = [];
+			if ( 'length' in this && this.length !== value.length ) {
+				children.push( this.joinKey( 'length' ) );
+			}
+			value.forEach( ( m, i ) => {
+				children.push( this.joinKey( i ) );
+			});
+		}
+
+		else if ( isObject( value ) || typeof value === 'function' ) {
+			children = Object.keys( value ).map( key => this.joinKey( key ) );
+		}
+
+		else if ( value != null ) {
+			return [];
+		}
+
+		return children;
+	}
+
+	getVirtual ( shouldCapture ) {
+		const value = this.get( shouldCapture, { virtual: false } );
+		if ( isObject( value ) ) {
+			const result = isArray( value ) ? [] : {};
+
+			const keys = Object.keys( value );
+			let i = keys.length;
+			while ( i-- ) {
+				const child = this.childByKey[ keys[i] ];
+				if ( !child ) result[ keys[i] ] = value[ keys[i] ];
+				else if ( child._link ) result[ keys[i] ] = child._link.getVirtual();
+				else result[ keys[i] ] = child.getVirtual();
+			}
+
+			i = this.children.length;
+			while ( i-- ) {
+				const child = this.children[i];
+				if ( !( child.key in result ) && child._link ) {
+					result[ child.key ] = child._link.getVirtual();
+				}
+			}
+
+			return result;
+		} else return value;
+	}
+
+	has ( key ) {
+		if ( this._link ) return this._link.has( key );
+
+		const value = this.get();
+		if ( !value ) return false;
+
+		key = unescapeKey( key );
+		if ( hasProp.call( value, key ) ) return true;
+
+		// We climb up the constructor chain to find if one of them contains the key
+		let constructor = value.constructor;
+		while ( constructor !== Function && constructor !== Array && constructor !== Object ) {
+			if ( hasProp.call( constructor.prototype, key ) ) return true;
+			constructor = constructor.constructor;
+		}
+
+		return false;
+	}
+
+	joinAll ( keys, opts ) {
+		let model = this;
+		for ( let i = 0; i < keys.length; i += 1 ) {
+			if ( opts && opts.lastLink === false && i + 1 === keys.length && model.childByKey[keys[i]] && model.childByKey[keys[i]]._link ) return model.childByKey[keys[i]];
+			model = model.joinKey( keys[i], opts );
+		}
+
+		return model;
+	}
+
+	notifyUpstream () {
+		let parent = this.parent, prev = this;
+		while ( parent ) {
+			if ( parent.patternObservers.length ) parent.patternObservers.forEach( o => o.notify( prev.key ) );
+			parent.deps.forEach( handleChange );
+			prev = parent;
+			parent = parent.parent;
+		}
+	}
+
+	rebinding ( next, previous ) {
+		// tell the deps to move to the new target
+		let i = this.deps.length;
+		while ( i-- ) {
+			if ( this.deps[i].rebinding ) this.deps[i].rebinding( next, previous );
+		}
+
+		i = this.links.length;
+		while ( i-- ) {
+			const link = this.links[i];
+			//if ( link.parent.isLink ) link.rebinding( next ? link.parent.joinKey( next.key ) : undefined, link, false );
+			//else link.relinking( next );
+			if ( next && link.owner._link ) link.relinking( next );
+		}
+
+		i = this.children.length;
+		while ( i-- ) {
+			const child = this.children[i];
+			child.rebinding( next ? next.joinKey( child.key ) : undefined, child );
+		}
+
+		i = this.unresolved.length;
+		while ( i-- ) {
+			const unresolved = this.unresolvedByKey[ this.unresolved[i] ];
+			let c = unresolved.length;
+			while ( c-- ) {
+				unresolved[c].rebinding( next, previous );
+			}
+		}
+
+		if ( this.keypathModel ) this.keypathModel.rebinding( next, previous );
+
+		i = this.bindings.length;
+		while ( i-- ) {
+			this.bindings[i].rebinding( next, previous );
+		}
+	}
+
+	register ( dep ) {
+		this.deps.push( dep );
+	}
+
+	registerChange ( key, value ) {
+		if ( !this.isRoot ) {
+			this.root.registerChange( key, value );
+		} else {
+			this.changes[ key ] = value;
+			runloop.addInstance( this.root.ractive );
+		}
+	}
+
+	registerLink ( link ) {
+		addToArray( this.links, link );
+	}
+
+	registerPatternObserver ( observer ) {
+		this.patternObservers.push( observer );
+		this.register( observer );
+	}
+
+	registerTwowayBinding ( binding ) {
+		this.bindings.push( binding );
+	}
+
+	removeUnresolved ( key, resolver ) {
+		const resolvers = this.unresolvedByKey[ key ];
+
+		if ( resolvers ) {
+			removeFromArray( resolvers, resolver );
+		}
+	}
+
+	shuffled () {
+		let i = this.children.length;
+		while ( i-- ) {
+			this.children[i].shuffled();
+		}
+		if ( this.wrapper ) {
+			this.wrapper.teardown();
+			this.wrapper = null;
+			this.rewrap = true;
+		}
+	}
+
+	unregister ( dependant ) {
+		removeFromArray( this.deps, dependant );
+	}
+
+	unregisterLink ( link ) {
+		removeFromArray( this.links, link );
+	}
+
+	unregisterPatternObserver ( observer ) {
+		removeFromArray( this.patternObservers, observer );
+		this.unregister( observer );
+	}
+
+	unregisterTwowayBinding ( binding ) {
+		removeFromArray( this.bindings, binding );
+	}
+
+	updateFromBindings ( cascade ) {
+		let i = this.bindings.length;
+		while ( i-- ) {
+			const value = this.bindings[i].getValue();
+			if ( value !== this.value ) this.set( value );
+		}
+
+		// check for one-way bindings if there are no two-ways
+		if ( !this.bindings.length ) {
+			const oneway = findBoundValue( this.deps );
+			if ( oneway && oneway.value !== this.value ) this.set( oneway.value );
+		}
+
+		if ( cascade ) {
+			this.children.forEach( updateFromBindings );
+			this.links.forEach( updateFromBindings );
+			if ( this._link ) this._link.updateFromBindings( cascade );
+		}
+	}
+}
+
+function updateFromBindings ( model ) {
+	model.updateFromBindings( true );
+}
+
+export function findBoundValue( list ) {
+	let i = list.length;
+	while ( i-- ) {
+		if ( list[i].bound ) {
+			const owner = list[i].owner;
+			if ( owner ) {
+				const value = owner.name === 'checked' ?
+					owner.node.checked :
+					owner.node.value;
+				return { value };
+			}
+		}
+	}
+}

--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -41,7 +41,7 @@ export default class RootModel extends Model {
 		return computation;
 	}
 
-	createLink ( keypath, target ) {
+	createLink ( keypath, target, targetPath ) {
 		const keys = splitKeypath( keypath );
 
 		let model = this;
@@ -50,7 +50,7 @@ export default class RootModel extends Model {
 			model = this.childByKey[ key ] || this.joinKey( key );
 		}
 
-		return model.link( target );
+		return model.link( target, targetPath );
 	}
 
 	get ( shouldCapture, options ) {

--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -105,13 +105,13 @@ export default class RootModel extends Model {
 	}
 
 	has ( key ) {
-		// TODO: this childbykey thing should not be necessary
-		if ( key in this.computations || key in this.childByKey ) return true;
-
 		let value = this.value;
 
 		key = unescapeKey( key );
 		if ( hasProp.call( value, key ) ) return true;
+
+		// mappings/links
+		if ( key in this.computations || this.childByKey[key] && this.childByKey[key]._link ) return true;
 
 		// We climb up the constructor chain to find if one of them contains the key
 		let constructor = value.constructor;

--- a/src/model/specials/KeyModel.js
+++ b/src/model/specials/KeyModel.js
@@ -22,10 +22,10 @@ export default class KeyModel {
 
 	rebinding ( next, previous ) {
 		let i = this.deps.length;
-		while ( i-- ) this.deps[i].rebinding( next, previous );
+		while ( i-- ) this.deps[i].rebinding( next, previous, false );
 
 		i = this.links.length;
-		while ( i-- ) this.links[i].rebinding( next, previous );
+		while ( i-- ) this.links[i].rebinding( next, previous, false );
 	}
 
 	register ( dependant ) {

--- a/src/model/specials/KeypathModel.js
+++ b/src/model/specials/KeypathModel.js
@@ -56,12 +56,12 @@ export default class KeypathModel {
 		const keys = Object.keys( this.children );
 		let i = keys.length;
 		while ( i-- ) {
-			this.children[ keys[i] ].rebinding( next, previous );
+			this.children[ keys[i] ].rebinding( next, previous, false );
 		}
 
 		i = this.deps.length;
 		while ( i-- ) {
-			this.deps[i].rebinding( model, this );
+			this.deps[i].rebinding( model, this, false );
 		}
 	}
 

--- a/src/model/specials/KeypathModel.js
+++ b/src/model/specials/KeypathModel.js
@@ -1,22 +1,29 @@
 import { removeFromArray } from '../../utils/array';
-import { handleChange, teardown } from '../../shared/methodCallers';
+import { handleChange } from '../../shared/methodCallers';
+import { capture } from '../../global/capture';
 
 export default class KeypathModel {
 	constructor ( parent, ractive ) {
 		this.parent = parent;
 		this.ractive = ractive;
 		this.value = ractive ? parent.getKeypath( ractive ) : parent.getKeypath();
-		this.dependants = [];
-		this.children = [];
+		this.deps = [];
+		this.children = {};
+		this.isReadonly = this.isKeypath = true;
 	}
 
-	addChild( model ) {
-		this.children.push( model );
-		model.owner = this;
-	}
-
-	get () {
+	get ( shouldCapture ) {
+		if ( shouldCapture ) capture( this );
 		return this.value;
+	}
+
+	getChild ( ractive ) {
+		if ( !( ractive._guid in this.children ) ) {
+			const model = new KeypathModel( this.parent, ractive );
+			this.children[ ractive._guid ] = model;
+			model.owner = this;
+		}
+		return this.children[ ractive._guid ];
 	}
 
 	getKeypath () {
@@ -24,28 +31,60 @@ export default class KeypathModel {
 	}
 
 	handleChange () {
-		this.value = this.ractive ? this.parent.getKeypath( this.ractive ) : this.parent.getKeypath();
-		if ( this.ractive && this.owner ) {
-			this.ractive.viewmodel.keypathModels[ this.owner.value ] = this;
+		const keys = Object.keys( this.children );
+		let i = keys.length;
+		while ( i-- ) {
+			this.children[ keys[i] ].handleChange();
 		}
-		this.children.forEach( handleChange );
-		this.dependants.forEach( handleChange );
+
+		this.deps.forEach( handleChange );
 	}
 
-	register ( dependant ) {
-		this.dependants.push( dependant );
+	rebindChildren ( next ) {
+		const keys = Object.keys( this.children );
+		let i = keys.length;
+		while ( i-- ) {
+			const child = this.children[keys[i]];
+			child.value = next.getKeypath( child.ractive );
+			child.handleChange();
+		}
+	}
+
+	rebinding ( next, previous ) {
+		const model = next ? next.getKeypathModel( this.ractive ) : undefined;
+
+		const keys = Object.keys( this.children );
+		let i = keys.length;
+		while ( i-- ) {
+			this.children[ keys[i] ].rebinding( next, previous );
+		}
+
+		i = this.deps.length;
+		while ( i-- ) {
+			this.deps[i].rebinding( model, this );
+		}
+	}
+
+	register ( dep ) {
+		this.deps.push( dep );
 	}
 
 	removeChild( model ) {
-		removeFromArray( this.children, model );
+		if ( model.ractive ) delete this.children[ model.ractive._guid ];
 	}
 
 	teardown () {
 		if ( this.owner ) this.owner.removeChild( this );
-		this.children.forEach( teardown );
+
+		const keys = Object.keys( this.children );
+		let i = keys.length;
+		while ( i-- ) {
+			this.children[ keys[i] ].teardown();
+		}
 	}
 
-	unregister ( dependant ) {
-		removeFromArray( this.dependants, dependant );
+	unregister ( dep ) {
+		removeFromArray( this.deps, dep );
+		if ( !this.deps.length ) this.teardown();
 	}
 }

--- a/src/parse/converters/mustache/readSection.js
+++ b/src/parse/converters/mustache/readSection.js
@@ -103,17 +103,15 @@ export default function readSection ( parser, tag ) {
 			}
 
 			if ( !unlessBlock ) {
-				unlessBlock = createUnlessBlock( expression );
+				unlessBlock = [];
 			}
 
-			unlessBlock.f.push({
+			unlessBlock.push({
 				t: SECTION,
 				n: SECTION_IF,
-				x: flattenExpression( combine( conditions.concat( child.x ) ) ),
+				x: flattenExpression( child.x ),
 				f: children = []
 			});
-
-			conditions.push( invert( child.x ) );
 		}
 
 		else if ( !aliasOnly && ( child = readElse( parser, tag ) ) ) {
@@ -129,16 +127,14 @@ export default function readSection ( parser, tag ) {
 
 			// use an unless block if there's no elseif
 			if ( !unlessBlock ) {
-				unlessBlock = createUnlessBlock( expression );
-				children = unlessBlock.f;
-			} else {
-				unlessBlock.f.push({
-					t: SECTION,
-					n: SECTION_IF,
-					x: flattenExpression( combine( conditions ) ),
-					f: children = []
-				});
+				unlessBlock = [];
 			}
+
+			unlessBlock.push({
+				t: SECTION,
+				n: SECTION_UNLESS,
+				f: children = []
+			});
 		}
 
 		else {
@@ -169,50 +165,4 @@ export default function readSection ( parser, tag ) {
 	}
 
 	return section;
-}
-
-function createUnlessBlock ( expression ) {
-	let unlessBlock = {
-		t: SECTION,
-		n: SECTION_UNLESS,
-		f: []
-	};
-
-	refineExpression( expression, unlessBlock );
-	return unlessBlock;
-}
-
-function invert ( expression ) {
-	if ( expression.t === PREFIX_OPERATOR && expression.s === '!' ) {
-		return expression.o;
-	}
-
-	return {
-		t: PREFIX_OPERATOR,
-		s: '!',
-		o: parensIfNecessary( expression )
-	};
-}
-
-function combine ( expressions ) {
-	if ( expressions.length === 1 ) {
-		return expressions[0];
-	}
-
-	return {
-		t: INFIX_OPERATOR,
-		s: '&&',
-		o: [
-			parensIfNecessary( expressions[0] ),
-			parensIfNecessary( combine( expressions.slice( 1 ) ) )
-		]
-	};
-}
-
-function parensIfNecessary ( expression ) {
-	// TODO only wrap if necessary
-	return {
-		t: BRACKETED,
-		x: expression
-	};
 }

--- a/src/parse/utils/cleanup.js
+++ b/src/parse/utils/cleanup.js
@@ -87,9 +87,11 @@ export default function cleanup ( items, stripComments, preserveWhitespace, remo
 
 		// Split if-else blocks into two (an if, and an unless)
 		if ( item.l ) {
-			cleanup( item.l.f, stripComments, preserveWhitespace, removeLeadingWhitespaceInsideFragment, removeTrailingWhitespaceInsideFragment );
+			cleanup( item.l, stripComments, preserveWhitespace, removeLeadingWhitespaceInsideFragment, removeTrailingWhitespaceInsideFragment );
 
-			items.splice( i + 1, 0, item.l );
+			item.l.forEach( s => s.l = 1 );
+			item.l.unshift( i + 1, 0 );
+			items.splice.apply( items, item.l );
 			delete item.l; // TODO would be nice if there was a way around this
 		}
 

--- a/src/shared/methodCallers.js
+++ b/src/shared/methodCallers.js
@@ -2,8 +2,8 @@ export function bind               ( x ) { x.bind(); }
 export function cancel             ( x ) { x.cancel(); }
 export function handleChange       ( x ) { x.handleChange(); }
 export function mark               ( x ) { x.mark(); }
+export function marked             ( x ) { x.marked(); }
 export function render             ( x ) { x.render(); }
-export function rebind             ( x ) { x.rebind(); }
 export function teardown           ( x ) { x.teardown(); }
 export function unbind             ( x ) { x.unbind(); }
 export function unrender           ( x ) { x.unrender(); }

--- a/src/shared/rebind.js
+++ b/src/shared/rebind.js
@@ -1,0 +1,36 @@
+import { splitKeypath } from './keypaths';
+
+// this is the dry method of checking to see if a rebind applies to
+// a particular keypath because in some cases, a dep may be bound
+// directly to a particular keypath e.g. foo.bars.0.baz and need
+// to avoid getting kicked to foo.bars.1.baz if foo.bars is unshifted
+export function rebindMatch ( template, next, previous ) {
+	const keypath = template.r || template;
+
+	// no valid keypath, go with next
+	if ( !keypath || typeof keypath !== 'string' ) return next;
+
+	// completely contextual ref, go with next
+	if ( keypath === '.' || keypath[0] === '@' || (next || previous).isKey || (next || previous).isKeypath ) return next;
+
+	const parts = keypath.split( '/' );
+	const keys = splitKeypath( parts[ parts.length - 1 ] );
+
+	// check the keypath against the model keypath to see if it matches
+	let model = next || previous;
+	let i = keys.length;
+	let match = true, shuffling = false;
+
+	while ( model && i-- ) {
+		if ( model.shuffling ) shuffling = true;
+		// non-strict comparison to account for indices in keypaths
+		if ( keys[i] != model.key ) match = false;
+		model = model.parent;
+	}
+
+	// next is undefined, but keypath is shuffling and previous matches
+	if ( !next && match && shuffling ) return previous;
+	// next is defined, but doesn't match the keypath
+	else if ( next && !match && shuffling ) return previous;
+	else return next;
+}

--- a/src/shared/set.js
+++ b/src/shared/set.js
@@ -1,0 +1,48 @@
+import runloop from '../global/runloop';
+import { splitKeypath } from './keypaths';
+import { isObject } from '../utils/is';
+import bind from '../utils/bind';
+
+export function set ( ractive, pairs ) {
+	const promise = runloop.start( ractive, true );
+
+	let i = pairs.length;
+	while ( i-- ) {
+		let [ model, value ] = pairs[i];
+		if ( typeof value === 'function' ) value = bind( value, ractive );
+		model.set( value );
+	}
+
+	runloop.end();
+
+	return promise;
+}
+
+const star = /\*/;
+export function gather ( ractive, keypath, base = ractive.viewmodel ) {
+	if ( star.test( keypath ) ) {
+		return base.findMatches( splitKeypath( keypath ) );
+	} else {
+		return [ base.joinAll( splitKeypath( keypath ) ) ];
+	}
+}
+
+export function build ( ractive, keypath, value ) {
+	const sets = [];
+
+	// set multiple keypaths in one go
+	if ( isObject( keypath ) ) {
+		for ( const k in keypath ) {
+			if ( keypath.hasOwnProperty( k ) ) {
+				sets.push.apply( sets, gather( ractive, k ).map( m => [ m, keypath[k] ] ) );
+			}
+		}
+
+	}
+	// set a single keypath
+	else {
+		sets.push.apply( sets, gather( ractive, keypath ).map( m => [ m, value ] ) );
+	}
+
+	return sets;
+}

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -2,7 +2,7 @@ import { ELEMENT, YIELDER } from '../config/types';
 import runloop from '../global/runloop';
 import createItem from './items/createItem';
 import ReferenceResolver from './resolvers/ReferenceResolver';
-import { bind, rebind, toEscapedString, toString, unbind, unrender, update } from '../shared/methodCallers';
+import { bind, toEscapedString, toString, unbind, unrender, update } from '../shared/methodCallers';
 import processItems from './helpers/processItems';
 import parseJSON from '../utils/parseJSON';
 import { createDocumentFragment } from '../utils/dom';
@@ -229,10 +229,8 @@ export default class Fragment {
 		return this.argsList;
 	}
 
-	rebind ( context ) {
-		this.context = context;
-
-		this.items.forEach( rebind );
+	rebinding ( next ) {
+		this.context = next;
 	}
 
 	render ( target, occupants ) {
@@ -283,6 +281,10 @@ export default class Fragment {
 		this.resolvers.push( resolver );
 
 		return resolver; // so we can e.g. force resolution
+	}
+
+	shuffled () {
+		this.items.forEach( i => i.shuffled() );
 	}
 
 	toHtml () {

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -68,9 +68,12 @@ export default class Fragment {
 	}
 
 	createItems () {
-		this.items = this.template.map( ( template, index ) => {
-			return createItem({ parentFragment: this, template, index });
-		});
+		// this is a hot code path
+		let max = this.template.length;
+		this.items = [];
+		for ( let i = 0; i < max; i++ ) {
+			this.items[i] = createItem({ parentFragment: this, template: this.template[i], index: i });
+		}
 	}
 
 	destroyed () {

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -149,16 +149,14 @@ export default class RepeatedFragment {
 		return this.iterations[0] ? this.iterations[0].firstNode( skipParent ) : null;
 	}
 
-	rebind ( context ) {
-		this.context = context;
-
-		this.iterations.forEach( ( fragment ) => {
-			const model = context.joinKey( fragment.key || fragment.index );
+	rebinding ( next ) {
+		this.context = next;
+		this.iterations.forEach( fragment => {
+			const model = next ? next.joinKey( fragment.key || fragment.index ) : undefined;
 			if ( this.owner.template.z ) {
 				fragment.aliases = {};
 				fragment.aliases[ this.owner.template.z[0].n ] = model;
 			}
-			fragment.rebind( model );
 		});
 	}
 
@@ -193,6 +191,10 @@ export default class RepeatedFragment {
 		this.iterations = iterations;
 
 		this.bubble();
+	}
+
+	shuffled () {
+		this.iterations.forEach( i => i.shuffled() );
 	}
 
 	toString ( escape ) {
@@ -354,13 +356,13 @@ export default class RepeatedFragment {
 			if ( newIndex === -1 ) {
 				removed[ oldIndex ] = fragment;
 			} else if ( fragment.index !== newIndex ) {
-				fragment.index = newIndex;
 				const model = this.context.joinKey( newIndex );
+				fragment.index = newIndex;
+				fragment.context = model;
 				if ( this.owner.template.z ) {
 					fragment.aliases = {};
 					fragment.aliases[ this.owner.template.z[0].n ] = model;
 				}
-				fragment.rebind( model );
 			}
 		});
 
@@ -412,5 +414,7 @@ export default class RepeatedFragment {
 		this.iterations.forEach( update );
 
 		this.pendingNewIndices = null;
+
+		this.shuffled();
 	}
 }

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -40,7 +40,8 @@ export default class RepeatedFragment {
 		if ( this.isArray = isArray( value ) ) {
 			// we can't use map, because of sparse arrays
 			this.iterations = [];
-			for ( let i = 0; i < value.length; i += 1 ) {
+			let max = value.length;
+			for ( let i = 0; i < max; i += 1 ) {
 				this.iterations[i] = this.createIteration( i, i );
 			}
 		}

--- a/src/view/helpers/processItems.js
+++ b/src/view/helpers/processItems.js
@@ -18,11 +18,12 @@ export default function processItems ( items, values, guid, counter = 0 ) {
 		}
 
 		const placeholderId = `${guid}-${counter++}`;
+		const model = item.model || item.newModel;
 
-		values[ placeholderId ] = item.model ?
-			item.model.wrapper ?
-				item.model.wrapper.value :
-				item.model.get() :
+		values[ placeholderId ] = model ?
+			model.wrapper ?
+				model.wrapper.value :
+				model.get() :
 			undefined;
 
 		return '${' + placeholderId + '}';

--- a/src/view/items/Alias.js
+++ b/src/view/items/Alias.js
@@ -2,6 +2,7 @@ import { createDocumentFragment } from '../../utils/dom';
 import Fragment from '../Fragment';
 import Item from './shared/Item';
 import resolve from '../resolvers/resolve';
+import runloop from '../../global/runloop';
 
 function resolveAliases( section ) {
 	if ( section.template.z ) {
@@ -62,9 +63,13 @@ export default class Alias extends Item {
 		return this.fragment && this.fragment.firstNode( skipParent );
 	}
 
-	rebind () {
-		resolveAliases( this );
-		if ( this.fragment ) this.fragment.rebind();
+	rebinding () {
+		if ( this.locked ) return;
+		this.locked = true;
+		runloop.scheduleTask( () => {
+			this.locked = false;
+			resolveAliases( this );
+		});
 	}
 
 	render ( target ) {

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -83,6 +83,7 @@ export default class Component extends Item {
 		this.attributeByName = {};
 
 		this.attributes = [];
+		const leftovers = [];
 		( this.template.m || [] ).forEach( template => {
 			switch ( template.t ) {
 				case ATTRIBUTE:
@@ -100,14 +101,16 @@ export default class Component extends Item {
 					break;
 
 				default:
-					this.attributes.push( new ConditionalAttribute({
-						owner: this,
-						parentFragment: this.parentFragment,
-						template
-					}) );
+					leftovers.push( template );
 					break;
 			}
 		});
+
+		this.attributes.push( new ConditionalAttribute({
+			owner: this,
+			parentFragment: this.parentFragment,
+			template: leftovers
+		}) );
 
 		this.eventHandlers = [];
 		if ( this.template.v ) this.setupEvents();

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -9,7 +9,7 @@ import render from '../../Ractive/render';
 import { create } from '../../utils/object';
 import createItem from './createItem';
 import { removeFromArray } from '../../utils/array';
-import { bind, cancel, rebind, render as callRender, unbind, unrender, update } from '../../shared/methodCallers';
+import { bind, cancel, render as callRender, unbind, unrender, update } from '../../shared/methodCallers';
 import Hook from '../../events/Hook';
 import EventDirective from './shared/EventDirective';
 import RactiveEvent from './component/RactiveEvent';
@@ -179,18 +179,6 @@ export default class Component extends Item {
 		return this.instance.fragment.firstNode( skipParent );
 	}
 
-	rebind () {
-		// implicit mappings can cause issues during shuffles, so remap everythiing as necessary
-		// TODO: it's probably better not to throw ALL of the mappings away on rebind
-		this.instance.viewmodel.resetMappings();
-
-		this.attributes.forEach( rebind );
-
-		this.liveQueries.forEach( makeDirty );
-
-		this.instance.fragment.rebind( this.instance.viewmodel );
-	}
-
 	render ( target, occupants ) {
 		render( this.instance, target, null, occupants );
 
@@ -216,6 +204,11 @@ export default class Component extends Item {
 		});
 	}
 
+	shuffled () {
+		this.liveQueries.forEach( makeDirty );
+		super.shuffled();
+	}
+
 	toString () {
 		return this.instance.toHTML();
 	}
@@ -235,8 +228,6 @@ export default class Component extends Item {
 		if ( instance.fragment.rendered && instance.el.__ractive_instances__ ) {
 			removeFromArray( instance.el.__ractive_instances__, instance );
 		}
-
-		Object.keys( instance._links ).forEach( k => instance._links[k].unlink() );
 
 		teardownHook.fire( instance );
 	}

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -6,7 +6,7 @@ import ConditionalAttribute from './element/ConditionalAttribute';
 import updateLiveQueries from './element/updateLiveQueries';
 import { toArray } from '../../utils/array';
 import { escapeHtml, voidElementNames } from '../../utils/html';
-import { bind, rebind, render, unbind, unrender, update } from '../../shared/methodCallers';
+import { bind, render, unbind, unrender, update } from '../../shared/methodCallers';
 import { createElement, detachNode, matches, safeAttributeString, decamelize } from '../../utils/dom';
 import createItem from './createItem';
 import { html, svg } from '../../config/namespaces';
@@ -176,15 +176,6 @@ export default class Element extends Item {
 		return attribute ? attribute.getValue() : undefined;
 	}
 
-	rebind () {
-		this.attributes.forEach( rebind );
-
-		if ( this.fragment ) this.fragment.rebind();
-		if ( this.binding ) this.binding.rebind();
-
-		this.liveQueries.forEach( makeDirty );
-	}
-
 	recreateTwowayBinding () {
 		if ( this.binding ) {
 			this.binding.unbind();
@@ -274,6 +265,11 @@ export default class Element extends Item {
 		}
 
 		this.rendered = true;
+	}
+
+	shuffled () {
+		this.liveQueries.forEach( makeDirty );
+		super.shuffled();
 	}
 
 	toString () {

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -42,6 +42,7 @@ export default class Element extends Item {
 		this.attributeByName = {};
 
 		this.attributes = [];
+		const leftovers = [];
 		( this.template.m || [] ).forEach( template => {
 			switch ( template.t ) {
 				case ATTRIBUTE:
@@ -57,14 +58,16 @@ export default class Element extends Item {
 					break;
 
 				default:
-					this.attributes.push( new ConditionalAttribute({
-						owner: this,
-						parentFragment: this.parentFragment,
-						template
-					}) );
+					leftovers.push( template );
 					break;
 			}
 		});
+
+		this.attributes.push( new ConditionalAttribute({
+			owner: this,
+			parentFragment: this.parentFragment,
+			template: leftovers
+		}) );
 
 		let i = this.attributes.length;
 		while ( i-- ) {

--- a/src/view/items/Interpolator.js
+++ b/src/view/items/Interpolator.js
@@ -6,6 +6,11 @@ import { detachNode } from '../../utils/dom';
 import { inAttributes } from './element/ConditionalAttribute';
 
 export default class Interpolator extends Mustache {
+	bubble () {
+		if ( this.owner ) this.owner.bubble();
+		super.bubble();
+	}
+
 	detach () {
 		return detachNode( this.node );
 	}

--- a/src/view/items/Interpolator.js
+++ b/src/view/items/Interpolator.js
@@ -59,6 +59,7 @@ export default class Interpolator extends Mustache {
 
 	update () {
 		if ( this.dirty ) {
+			super.update();
 			this.dirty = false;
 			if ( this.rendered ) {
 				this.node.data = this.getString();

--- a/src/view/items/Interpolator.js
+++ b/src/view/items/Interpolator.js
@@ -64,7 +64,6 @@ export default class Interpolator extends Mustache {
 
 	update () {
 		if ( this.dirty ) {
-			super.update();
 			this.dirty = false;
 			if ( this.rendered ) {
 				this.node.data = this.getString();

--- a/src/view/items/Partial.js
+++ b/src/view/items/Partial.js
@@ -91,12 +91,6 @@ export default class Partial extends Mustache {
 		this.bubble();
 	}
 
-	rebind () {
-		super.unbind();
-		super.bind();
-		this.fragment.rebind();
-	}
-
 	render ( target, occupants ) {
 		this.fragment.render( target, occupants );
 	}
@@ -131,6 +125,7 @@ export default class Partial extends Mustache {
 
 		if ( this.dirty ) {
 			this.dirty = false;
+			super.update();
 
 			if ( !this.named ) {
 				if ( this.model ) {

--- a/src/view/items/Partial.js
+++ b/src/view/items/Partial.js
@@ -129,7 +129,6 @@ export default class Partial extends Mustache {
 
 		if ( this.dirty ) {
 			this.dirty = false;
-			super.update();
 
 			if ( !this.named ) {
 				if ( this.model ) {

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -90,8 +90,8 @@ export default class Section extends Mustache {
 		return !!value && !isEmpty( value );
 	}
 
-	rebinding ( next, previous ) {
-		if ( super.rebinding( next, previous ) ) {
+	rebinding ( next, previous, safe ) {
+		if ( super.rebinding( next, previous, safe ) ) {
 			if ( this.fragment && this.sectionType !== SECTION_IF && this.sectionType !== SECTION_UNLESS ) {
 				this.fragment.rebinding( next, previous );
 			}
@@ -126,7 +126,6 @@ export default class Section extends Mustache {
 	update () {
 		if ( !this.dirty ) return;
 
-		super.update();
 		if ( this.fragment && this.sectionType !== SECTION_IF && this.sectionType !== SECTION_UNLESS ) {
 			this.fragment.context = this.model;
 		}

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -74,11 +74,11 @@ export default class Section extends Mustache {
 		return this.fragment && this.fragment.firstNode( skipParent );
 	}
 
-	rebind () {
-		super.rebind();
-
-		if ( this.fragment ) {
-			this.fragment.rebind( this.sectionType === SECTION_IF || this.sectionType === SECTION_UNLESS ? null : this.model );
+	rebinding ( next ) {
+		if ( super.rebinding( next ) ) {
+			if ( this.fragment && this.sectionType !== SECTION_IF && this.sectionType !== SECTION_UNLESS ) {
+				this.fragment.rebinding( next );
+			}
 		}
 	}
 
@@ -109,6 +109,12 @@ export default class Section extends Mustache {
 
 	update () {
 		if ( !this.dirty ) return;
+
+		super.update();
+		if ( this.fragment && this.sectionType !== SECTION_IF && this.sectionType !== SECTION_UNLESS ) {
+			this.fragment.context = this.model;
+		}
+
 		if ( !this.model && this.sectionType !== SECTION_UNLESS ) return;
 
 		this.dirty = false;

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -74,10 +74,10 @@ export default class Section extends Mustache {
 		return this.fragment && this.fragment.firstNode( skipParent );
 	}
 
-	rebinding ( next ) {
-		if ( super.rebinding( next ) ) {
+	rebinding ( next, previous ) {
+		if ( super.rebinding( next, previous ) ) {
 			if ( this.fragment && this.sectionType !== SECTION_IF && this.sectionType !== SECTION_UNLESS ) {
-				this.fragment.rebinding( next );
+				this.fragment.rebinding( next, previous );
 			}
 		}
 	}

--- a/src/view/items/Text.js
+++ b/src/view/items/Text.js
@@ -23,10 +23,6 @@ export default class Text extends Item {
 		return this.node;
 	}
 
-	rebind () {
-		// noop
-	}
-
 	render ( target, occupants ) {
 		if ( inAttributes() ) return;
 		this.rendered = true;

--- a/src/view/items/Triple.js
+++ b/src/view/items/Triple.js
@@ -82,6 +82,7 @@ export default class Triple extends Mustache {
 	update () {
 		if ( this.rendered && this.dirty ) {
 			this.dirty = false;
+			super.update();
 
 			this.unrender();
 			const docFrag = createDocumentFragment();

--- a/src/view/items/Triple.js
+++ b/src/view/items/Triple.js
@@ -82,7 +82,6 @@ export default class Triple extends Mustache {
 	update () {
 		if ( this.rendered && this.dirty ) {
 			this.dirty = false;
-			super.update();
 
 			this.unrender();
 			const docFrag = createDocumentFragment();

--- a/src/view/items/Yielder.js
+++ b/src/view/items/Yielder.js
@@ -77,10 +77,6 @@ export default class Yielder extends Item {
 		return this.fragment.firstNode( skipParent );
 	}
 
-	rebind () {
-		this.fragment.rebind();
-	}
-
 	render ( target, occupants ) {
 		return this.fragment.render( target, occupants );
 	}

--- a/src/view/items/component/Mapping.js
+++ b/src/view/items/component/Mapping.js
@@ -6,7 +6,7 @@ import findElement from '../shared/findElement';
 import parseJSON from '../../../utils/parseJSON';
 import resolve from '../../resolvers/resolve';
 import { isArray } from '../../../utils/is';
-import runloop from '../../../global/runloop';
+//import runloop from '../../../global/runloop';
 
 export default class Mapping extends Item {
 	constructor ( options ) {
@@ -49,17 +49,6 @@ export default class Mapping extends Item {
 		}
 	}
 
-	rebind () {
-		if ( this.fragment ) this.fragment.rebind();
-
-		if ( this.boundFragment ) this.boundFragment.unbind();
-
-		// handle remapping
-		if ( isArray( this.template.f ) ) {
-			createMapping( this );
-		}
-	}
-
 	render () {}
 
 	unbind () {
@@ -67,16 +56,7 @@ export default class Mapping extends Item {
 		if ( this.boundFragment ) this.boundFragment.unbind();
 
 		if ( this.element.bound ) {
-			const viewmodel = this.element.instance.viewmodel;
-			if ( viewmodel.unmap( this.name ) ) {
-				if ( !this.element.rebinding ) {
-					this.element.rebinding = true;
-					runloop.scheduleTask( () => {
-						this.element.rebind();
-						this.element.rebinding = false;
-					});
-				}
-			}
+			if ( this.link.target === this.model ) this.link.owner.unlink();
 		}
 	}
 
@@ -92,7 +72,7 @@ export default class Mapping extends Item {
 	}
 }
 
-function createMapping ( item, check ) {
+function createMapping ( item ) {
 	const template = item.template.f;
 	const viewmodel = item.element.instance.viewmodel;
 	const childData = viewmodel.value;
@@ -106,20 +86,7 @@ function createMapping ( item, check ) {
 			item.model = item.parentFragment.findContext().joinKey( item.name );
 		}
 
-
-		if ( check ) {
-			// map the model and check for remap
-			const remapped = viewmodel.map( item.name, item.model );
-			if ( remapped !== item.model && item.element.bound && !item.element.rebinding ) {
-				item.element.rebinding = true;
-				runloop.scheduleTask( () => {
-					item.element.rebind();
-					item.element.rebinding = false;
-				});
-			}
-		} else {
-			viewmodel.map( item.name, item.model );
-		}
+		item.link = viewmodel.createLink( item.name, item.model );
 
 		if ( item.model.get() === undefined && item.name in childData ) {
 			item.model.set( childData[ item.name ] );

--- a/src/view/items/component/Mapping.js
+++ b/src/view/items/component/Mapping.js
@@ -6,7 +6,6 @@ import findElement from '../shared/findElement';
 import parseJSON from '../../../utils/parseJSON';
 import resolve from '../../resolvers/resolve';
 import { isArray } from '../../../utils/is';
-//import runloop from '../../../global/runloop';
 
 export default class Mapping extends Item {
 	constructor ( options ) {

--- a/src/view/items/component/Mapping.js
+++ b/src/view/items/component/Mapping.js
@@ -86,7 +86,7 @@ function createMapping ( item ) {
 			item.model = item.parentFragment.findContext().joinKey( item.name );
 		}
 
-		item.link = viewmodel.createLink( item.name, item.model );
+		item.link = viewmodel.createLink( item.name, item.model, template[0].r );
 
 		if ( item.model.get() === undefined && item.name in childData ) {
 			item.model.set( childData[ item.name ] );

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -29,7 +29,7 @@ export default class Attribute extends Item {
 
 		this.owner = options.owner || options.parentFragment.owner || options.element || findElement( options.parentFragment );
 		this.element = options.element || (this.owner.attributeByName ? this.owner : findElement( options.parentFragment ) );
-		this.parentFragment = this.element.parentFragment; // shared
+		this.parentFragment = options.parentFragment; // shared
 		this.ractive = this.parentFragment.ractive;
 
 		this.rendered = false;
@@ -66,6 +66,7 @@ export default class Attribute extends Item {
 
 	bubble () {
 		if ( !this.dirty ) {
+			this.parentFragment.bubble();
 			this.element.bubble();
 			this.dirty = true;
 		}

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -83,10 +83,6 @@ export default class Attribute extends Item {
 		return this.fragment ? this.fragment.valueOf() : booleanAttributes.test( this.name ) ? true : this.value;
 	}
 
-	rebind () {
-		if ( this.fragment ) this.fragment.rebind();
-	}
-
 	render () {
 		const node = this.element.node;
 		this.node = node;

--- a/src/view/items/element/BindingFlag.js
+++ b/src/view/items/element/BindingFlag.js
@@ -46,11 +46,6 @@ export default class BindingFlag extends Item {
 		else return true;
 	}
 
-	rebind () {
-		this.unbind();
-		this.bind();
-	}
-
 	render () {
 		set( this, this.getValue(), true );
 	}

--- a/src/view/items/element/ConditionalAttribute.js
+++ b/src/view/items/element/ConditionalAttribute.js
@@ -4,6 +4,7 @@ import { createElement } from '../../../utils/dom';
 import { toArray } from '../../../utils/array';
 import Fragment from '../../Fragment';
 import Item from '../shared/Item';
+import noop from '../../../utils/noop';
 
 const div = doc ? createElement( 'div' ) : null;
 
@@ -26,8 +27,10 @@ export default class ConditionalAttribute extends Item {
 		this.fragment = new Fragment({
 			ractive: this.ractive,
 			owner: this,
-			template: [ this.template ]
+			template: this.template
 		});
+		// this fragment can't participate in node-y things
+		this.fragment.findNextNode = noop;
 
 		this.dirty = false;
 	}
@@ -50,7 +53,7 @@ export default class ConditionalAttribute extends Item {
 		}
 
 		attributes = true;
-		this.fragment.render();
+		if ( !this.rendered ) this.fragment.render();
 		attributes = false;
 
 		this.rendered = true;
@@ -68,6 +71,7 @@ export default class ConditionalAttribute extends Item {
 
 	unrender () {
 		this.rendered = false;
+		this.fragment.unrender();
 	}
 
 	update () {

--- a/src/view/items/element/ConditionalAttribute.js
+++ b/src/view/items/element/ConditionalAttribute.js
@@ -43,10 +43,6 @@ export default class ConditionalAttribute extends Item {
 		}
 	}
 
-	rebind () {
-		this.fragment.rebind();
-	}
-
 	render () {
 		this.node = this.owner.node;
 		if ( this.node ) {

--- a/src/view/items/element/Decorator.js
+++ b/src/view/items/element/Decorator.js
@@ -9,6 +9,7 @@ import runloop from '../../../global/runloop';
 import { removeFromArray } from '../../../utils/array';
 import getFunction from '../../../shared/getFunction';
 import resolveReference from '../../resolvers/resolveReference';
+import { rebindMatch } from '../../../shared/rebind';
 
 const missingDecorator = {
 	update: noop,
@@ -97,8 +98,18 @@ export default class Decorator {
 
 	handleChange () { this.bubble(); }
 
-	rebinding () {
-		// TODO
+	rebinding ( next, previous, safe ) {
+		const idx = this.models.indexOf( previous );
+		if ( !~idx ) return;
+
+		next = rebindMatch( this.template.f.a.r[ idx ], next, previous );
+		if ( next === previous ) return;
+
+		previous.unregister( this );
+		this.models.splice( idx, 1, next );
+		if ( next ) next.addShuffleRegister( this, 'mark' );
+
+		if ( !safe ) this.bubble();
 	}
 
 	render () {

--- a/src/view/items/element/Decorator.js
+++ b/src/view/items/element/Decorator.js
@@ -93,14 +93,8 @@ export default class Decorator {
 
 	handleChange () { this.bubble(); }
 
-	rebind () {
-		if ( this.dynamicName ) this.nameFragment.rebind();
-		if ( this.dynamicArgs ) this.argsFragment.rebind();
-		if ( this.argsFn ) {
-			this.unbind();
-			this.bind();
-			if ( this.rendered ) this.update();
-		}
+	rebinding () {
+		// TODO
 	}
 
 	render () {

--- a/src/view/items/element/Transition.js
+++ b/src/view/items/element/Transition.js
@@ -246,11 +246,6 @@ export default class Transition {
 		return extend( {}, defaults, params );
 	}
 
-	rebind () {
-		this.unbind();
-		this.bind();
-	}
-
 	registerCompleteHandler ( fn ) {
 		addToArray( this.onComplete, fn );
 	}

--- a/src/view/items/element/binding/Binding.js
+++ b/src/view/items/element/binding/Binding.js
@@ -84,12 +84,13 @@ export default class Binding {
 		runloop.end();
 	}
 
-	rebind () {
-		// TODO what does this work with CheckboxNameBinding et al?
-		this.unbind();
-		this.model = this.attribute.interpolator.model;
-		this.bind();
-	}
+	rebinding ( next, previous ) {
+		if ( this.model && this.model === previous ) previous.unregisterTwowayBinding( this );
+		if ( next ) {
+			this.model = next;
+			runloop.scheduleTask( () => next.registerTwowayBinding( this ) );
+		}
+   	}
 
 	render () {
 		this.node = this.element.node;

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -196,10 +196,10 @@ export default class EventDirective {
 		if ( !this.models ) return;
 		const idx = this.models.indexOf( previous );
 
-		if ( !~idx ) {
+		if ( ~idx ) {
 			this.models.splice( idx, 1, next );
 			previous.unregister( this );
-			if ( next ) next.register( this );
+			if ( next ) next.addShuffleTask( () => next.register( this ) );
 		}
 	}
 

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -84,10 +84,11 @@ export default class EventDirective {
 					resolver = this.parentFragment.resolve( ref, model => {
 						this.models[i] = model;
 						removeFromArray( this.resolvers, resolver );
+						model.register( this );
 					});
 
 					this.resolvers.push( resolver );
-				}
+				} else model.register( this );
 
 				return model;
 			});
@@ -189,9 +190,17 @@ export default class EventDirective {
 		}
 	}
 
-	rebind () {
-		this.unbind();
-		this.bind();
+	handleChange () {}
+
+	rebinding ( next, previous ) {
+		if ( !this.models ) return;
+		const idx = this.models.indexOf( previous );
+
+		if ( !~idx ) {
+			this.models.splice( idx, 1, next );
+			previous.unregister( this );
+			if ( next ) next.register( this );
+		}
 	}
 
 	render () {
@@ -208,6 +217,9 @@ export default class EventDirective {
 			if ( this.resolvers ) this.resolvers.forEach( unbind );
 			this.resolvers = [];
 
+			if ( this.models ) this.models.forEach( m => {
+				if ( m.unregister ) m.unregister( this );
+			});
 			this.models = null;
 		}
 

--- a/src/view/items/shared/Item.js
+++ b/src/view/items/shared/Item.js
@@ -37,6 +37,10 @@ export default class Item {
 		return this.parentFragment.findNextNode( this );
 	}
 
+	shuffled () {
+		if ( this.fragment ) this.fragment.shuffled();
+	}
+
 	valueOf () {
 		return this.toString();
 	}

--- a/src/view/items/shared/Mustache.js
+++ b/src/view/items/shared/Mustache.js
@@ -1,5 +1,6 @@
 import Item from './Item';
-import resolve, { modelMatches } from '../../resolvers/resolve';
+import resolve from '../../resolvers/resolve';
+import { rebindMatch } from '../../../shared/rebind';
 
 export default class Mustache extends Item {
 	constructor ( options ) {
@@ -44,10 +45,10 @@ export default class Mustache extends Item {
 		this.bubble();
 	}
 
-	rebinding ( next ) {
+	rebinding ( next, previous ) {
+		next = rebindMatch( this.template, next, previous );
 		if ( this.static ) return false;
 		if ( next === this.model ) return false;
-		if ( next && !modelMatches( next, this.template ) ) return false;
 
 		if ( this.model ) {
 			this.model.unregister( this );

--- a/src/view/items/shared/Mustache.js
+++ b/src/view/items/shared/Mustache.js
@@ -45,17 +45,17 @@ export default class Mustache extends Item {
 		this.bubble();
 	}
 
-	rebinding ( next, previous ) {
+	rebinding ( next, previous, safe ) {
 		next = rebindMatch( this.template, next, previous );
 		if ( this.static ) return false;
 		if ( next === this.model ) return false;
 
 		if ( this.model ) {
 			this.model.unregister( this );
-			this.model = null;
 		}
-		this.newModel = next;
-		this.handleChange();
+		if ( next ) next.addShuffleRegister( this, 'mark' );
+		this.model = next;
+		if ( !safe ) this.handleChange();
 		return true;
 	}
 
@@ -64,14 +64,6 @@ export default class Mustache extends Item {
 			this.model && this.model.unregister( this );
 			this.model = undefined;
 			this.resolver && this.resolver.unbind();
-		}
-	}
-
-	update () {
-		if ( this.newModel ) {
-			this.model = this.newModel;
-			this.model.register( this );
-			this.newModel = undefined;
 		}
 	}
 }

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -48,15 +48,9 @@ export default class ExpressionProxy extends Model {
 	}
 
 	bubble () {
-		// TODO the @ prevents computed props from shadowing keypaths, but the real
-		// question is why it's a computed prop in the first place... (hint, it's
-		// to do with {{else}} blocks)
-		this.keypath = '@' + this.template.s.replace( /_(\d+)/g, ( match, i ) => {
-			if ( i >= this.models.length ) return match;
-
-			const model = this.models[i];
-			return model ? model.getKeypath() : '@undefined';
-		});
+		// refresh the keypath
+		this.keypath = undefined;
+		this.getKeypath();
 
 		this.dirty = true;
 
@@ -76,7 +70,20 @@ export default class ExpressionProxy extends Model {
 	}
 
 	getKeypath () {
-		return this.computation ? this.computation.getKeypath() : '@undefined';
+		if ( !this.template ) return '@undefined';
+		if ( !this.keypath ) {
+			// TODO the @ prevents computed props from shadowing keypaths, but the real
+			// question is why it's a computed prop in the first place... (hint, it's
+			// to do with {{else}} blocks)
+			this.keypath = '@' + this.template.s.replace( /_(\d+)/g, ( match, i ) => {
+				if ( i >= this.models.length ) return match;
+
+				const model = this.models[i];
+				return model ? model.getKeypath() : '@undefined';
+			});
+		}
+
+		return this.keypath;
 	}
 
 	getValue () {

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -46,14 +46,15 @@ export default class ExpressionProxy extends Model {
 		this.bubble();
 	}
 
-	bubble () {
+	bubble ( actuallyChanged = true ) {
 		// refresh the keypath
 		if ( this.registered ) delete this.root.expressions[ this.keypath ];
 		this.keypath = undefined;
 
-		this.dirty = true;
-
-		this.handleChange();
+		if ( actuallyChanged ) {
+			this.dirty = true;
+			this.handleChange();
+		}
 	}
 
 	get ( shouldCapture ) {
@@ -130,7 +131,7 @@ export default class ExpressionProxy extends Model {
 		this.handleChange();
 	}
 
-	rebinding ( next, previous ) {
+	rebinding ( next, previous, safe ) {
 		const idx = this.models.indexOf( previous );
 
 		if ( ~idx ) {
@@ -139,10 +140,10 @@ export default class ExpressionProxy extends Model {
 				previous.unregister( this );
 				this.models.splice( idx, 1, next );
 				// TODO: set up a resolver if there is no next?
-				if ( next ) next.addShuffleTask( () => next.register( this ) );
+				if ( next ) next.addShuffleRegister( this, 'mark' );
 			}
 		}
-		this.bubble();
+		this.bubble( !safe );
 	}
 
 	retrieve () {

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -18,8 +18,6 @@ function createResolver ( proxy, ref, index ) {
 	proxy.resolvers.push( resolver );
 }
 
-// TODO: making this not a computation introduces a corner-case with if/else, but leaving it as a computation introduces other corner cases
-
 export default class ExpressionProxy extends Model {
 	constructor ( fragment, template ) {
 		super( fragment.ractive.viewmodel, null );
@@ -73,9 +71,6 @@ export default class ExpressionProxy extends Model {
 	getKeypath () {
 		if ( !this.template ) return '@undefined';
 		if ( !this.keypath ) {
-			// TODO the @ prevents computed props from shadowing keypaths, but the real
-			// question is why it's a computed prop in the first place... (hint, it's
-			// to do with {{else}} blocks)
 			this.keypath = '@' + this.template.s.replace( /_(\d+)/g, ( match, i ) => {
 				if ( i >= this.models.length ) return match;
 

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -48,8 +48,8 @@ export default class ExpressionProxy extends Model {
 
 	bubble () {
 		// refresh the keypath
+		if ( this.registered ) delete this.root.expressions[ this.keypath ];
 		this.keypath = undefined;
-		this.getKeypath();
 
 		this.dirty = true;
 
@@ -77,6 +77,9 @@ export default class ExpressionProxy extends Model {
 				const model = this.models[i];
 				return model ? model.getKeypath() : '@undefined';
 			});
+
+			this.root.expressions[ this.keypath ] = this;
+			this.registered = true;
 		}
 
 		return this.keypath;

--- a/src/view/resolvers/ReferenceExpressionProxy.js
+++ b/src/view/resolvers/ReferenceExpressionProxy.js
@@ -4,6 +4,7 @@ import { REFERENCE } from '../../config/types';
 import ExpressionProxy from './ExpressionProxy';
 import resolveReference from './resolveReference';
 import resolve from './resolve';
+import { rebindMatch } from '../../shared/rebind';
 import { handleChange, mark, marked, unbind } from '../../shared/methodCallers';
 import { removeFromArray } from '../../utils/array';
 import { isEqual } from '../../utils/is';
@@ -54,6 +55,7 @@ export default class ReferenceExpressionProxy extends Model {
 		super( null, null );
 		this.dirty = true;
 		this.root = fragment.ractive.viewmodel;
+		this.template = template;
 
 		this.resolvers = [];
 
@@ -75,16 +77,27 @@ export default class ReferenceExpressionProxy extends Model {
 			handleChange: () => this.handleChange(),
 			rebinding: ( next, previous ) => {
 				if ( previous === this.base ) {
-					this.base = next;
+					next = rebindMatch( template, next, previous );
+					if ( next !== this.base ) {
+						this.base.unregister( intermediary );
+						this.base = next;
+						// TODO: if there is no next, set up a resolver?
+					}
 				} else {
 					const idx = this.members.indexOf( previous );
 					if ( ~idx ) {
-						this.members.splice( idx, 1, next );
+						// only direct references will rebind... expressions handle themselves
+						next = rebindMatch( template.m[idx].n, next, previous );
+						if ( next !== this.members[idx] ) {
+							this.members.splice( idx, 1, next );
+							// TODO: if there is no next, set up a resolver?
+						}
 					}
 				}
 
-				if ( previous ) previous.unregister( this.intermediary );
-				// TODO: set up resolver for missing models
+				if ( next !== previous ) previous.unregister( intermediary );
+				if ( next ) next.addShuffleTask( () => next.register( intermediary ) );
+
 				this.bubble();
 			}
 		};
@@ -130,36 +143,6 @@ export default class ReferenceExpressionProxy extends Model {
 	bubble () {
 		if ( !this.base ) return;
 		if ( !this.dirty ) this.handleChange();
-
-		/*
-		// if some members are not resolved, abort
-		let i = this.members.length;
-		while ( i-- ) {
-			if ( !this.members[i] ) return;
-		}
-
-		this.isUnresolved = false;
-
-		const keys = this.members.map( model => escapeKey( String( model.get() ) ) );
-		const model = this.base.joinAll( keys );
-
-		if ( model === this.model ) return;
-
-		if ( this.model ) {
-			this.model.unregister( this );
-			this.model.unregisterTwowayBinding( this );
-		}
-
-		this.model = model;
-		this.parent = model.parent;
-
-		model.register( this );
-		model.registerTwowayBinding( this );
-
-		if ( this.keypathModel ) this.keypathModel.handleChange();
-
-		if ( !this.dirty ) this.handleChange();
-		*/
 	}
 
 	forceResolution () {
@@ -178,7 +161,6 @@ export default class ReferenceExpressionProxy extends Model {
 			}
 
 			if ( this.base && resolved ) {
-				this.members.forEach( m => m.register && m.register( this.intermediary ) );
 				const keys = this.members.map( m => escapeKey( String( m.get() ) ) );
 				const model = this.base.joinAll( keys );
 
@@ -189,6 +171,7 @@ export default class ReferenceExpressionProxy extends Model {
 					}
 
 					this.model = model;
+					this.parent = model.parent;
 					this.model.register( this );
 					this.model.registerTwowayBinding( this );
 
@@ -256,6 +239,8 @@ export default class ReferenceExpressionProxy extends Model {
 	retrieve () {
 		return this.value;
 	}
+
+	rebinding () { } // NOOP
 
 	set ( value ) {
 		if ( !this.model ) throw new Error( 'Unresolved reference expression. This should not happen!' );

--- a/src/view/resolvers/resolve.js
+++ b/src/view/resolvers/resolve.js
@@ -1,8 +1,6 @@
 import resolveReference from './resolveReference';
 import ExpressionProxy from './ExpressionProxy';
 import ReferenceExpressionProxy from './ReferenceExpressionProxy';
-import { splitKeypath } from '../../shared/keypaths';
-import { isNumeric } from '../../utils/is';
 
 export default function resolve ( fragment, template ) {
 	if ( template.r ) {
@@ -15,30 +13,5 @@ export default function resolve ( fragment, template ) {
 
 	else {
 		return new ReferenceExpressionProxy( fragment, template.rx );
-	}
-}
-
-export function modelMatches( model, template ) {
-	// these are always contextual, and thus always match
-	if ( model.isKey || model.isKeypath ) return true;
-
-	// check to see if the template matches the given model
-	if ( template.r ) {
-		const ref = template.r;
-
-		if ( ref === '.' ) return true;
-		if ( ref[0] === '@' ) return true;
-
-		const parts = ref.split( '/' );
-		const keys = splitKeypath( parts[ parts.length - 1 ] );
-
-		let i = keys.length;
-		while ( i-- ) {
-			if ( isNumeric( keys[i] ) && keys[i] !== model.key ) return false;
-			model = model.parent;
-		}
-		return true;
-	} else {
-		return true;
 	}
 }

--- a/src/view/resolvers/resolve.js
+++ b/src/view/resolvers/resolve.js
@@ -11,7 +11,7 @@ export default function resolve ( fragment, template ) {
 		return new ExpressionProxy( fragment, template.x );
 	}
 
-	else {
+	else if ( template.rx ) {
 		return new ReferenceExpressionProxy( fragment, template.rx );
 	}
 }

--- a/src/view/resolvers/resolve.js
+++ b/src/view/resolvers/resolve.js
@@ -1,6 +1,8 @@
 import resolveReference from './resolveReference';
 import ExpressionProxy from './ExpressionProxy';
 import ReferenceExpressionProxy from './ReferenceExpressionProxy';
+import { splitKeypath } from '../../shared/keypaths';
+import { isNumeric } from '../../utils/is';
 
 export default function resolve ( fragment, template ) {
 	if ( template.r ) {
@@ -13,5 +15,30 @@ export default function resolve ( fragment, template ) {
 
 	else {
 		return new ReferenceExpressionProxy( fragment, template.rx );
+	}
+}
+
+export function modelMatches( model, template ) {
+	// these are always contextual, and thus always match
+	if ( model.isKey || model.isKeypath ) return true;
+
+	// check to see if the template matches the given model
+	if ( template.r ) {
+		const ref = template.r;
+
+		if ( ref === '.' ) return true;
+		if ( ref[0] === '@' ) return true;
+
+		const parts = ref.split( '/' );
+		const keys = splitKeypath( parts[ parts.length - 1 ] );
+
+		let i = keys.length;
+		while ( i-- ) {
+			if ( isNumeric( keys[i] ) && keys[i] !== model.key ) return false;
+			model = model.parent;
+		}
+		return true;
+	} else {
+		return true;
 	}
 }

--- a/src/view/resolvers/resolveAmbiguousReference.js
+++ b/src/view/resolvers/resolveAmbiguousReference.js
@@ -43,7 +43,7 @@ export default function resolveAmbiguousReference ( fragment, ref ) {
 
 			if ( fragment.context.has( key ) ) {
 				if ( crossedComponentBoundary ) {
-					return localViewmodel.createLink( key, fragment.context.joinKey( keys.shift() ) ).joinAll( keys );
+					return localViewmodel.createLink( key, fragment.context.joinKey( keys.shift() ), key ).joinAll( keys );
 				}
 
 				return fragment.context.joinAll( keys );

--- a/src/view/resolvers/resolveAmbiguousReference.js
+++ b/src/view/resolvers/resolveAmbiguousReference.js
@@ -18,12 +18,12 @@ export default function resolveAmbiguousReference ( fragment, ref ) {
 		if ( fragment.isIteration ) {
 			if ( key === fragment.parent.keyRef ) {
 				if ( keys.length > 1 ) badReference( key );
-				return fragment.context.getKeyModel();
+				return fragment.context.getKeyModel( fragment.key );
 			}
 
 			if ( key === fragment.parent.indexRef ) {
 				if ( keys.length > 1 ) badReference( key );
-				return fragment.context.getIndexModel( fragment.index );
+				return fragment.context.getKeyModel( fragment.index );
 			}
 		}
 
@@ -43,7 +43,7 @@ export default function resolveAmbiguousReference ( fragment, ref ) {
 
 			if ( fragment.context.has( key ) ) {
 				if ( crossedComponentBoundary ) {
-					localViewmodel.map( key, fragment.context.joinKey( key ) );
+					return localViewmodel.createLink( key, fragment.context.joinKey( keys.shift() ) ).joinAll( keys );
 				}
 
 				return fragment.context.joinAll( keys );

--- a/src/view/resolvers/resolveReference.js
+++ b/src/view/resolvers/resolveReference.js
@@ -14,9 +14,9 @@ export default function resolveReference ( fragment, ref ) {
 		const match = keypathExpr.exec( ref );
 		if ( match && match[1] ) {
 			const model = resolveReference( fragment, match[1] );
-			if ( model ) return model.getKeypathModel( fragment.ractive );
+			if ( model ) return model.getKeypathModel();
 		}
-		return context.getKeypathModel( fragment.ractive );
+		return context.getKeypathModel();
 	}
 	if ( ref.indexOf( '@rootpath' ) === 0 ) {
 		// check to see if this is an empty component root
@@ -27,17 +27,16 @@ export default function resolveReference ( fragment, ref ) {
 		const match = keypathExpr.exec( ref );
 		if ( match && match[1] ) {
 			const model = resolveReference( fragment, match[1] );
-			if ( model ) return model.getKeypathModel();
+			if ( model ) return model.getKeypathModel( fragment.ractive.root );
 		}
-		return context.getKeypathModel();
+		return context.getKeypathModel( fragment.ractive.root );
 	}
-	if ( ref === '@index' ) {
+	if ( ref === '@index' || ref === '@key' ) {
 		const repeater = fragment.findRepeatingFragment();
 		// make sure the found fragment is actually an iteration
 		if ( !repeater.isIteration ) return;
-		return repeater.context.getIndexModel( repeater.index );
+		return repeater.context.getKeyModel( repeater[ ref[1] === 'i' ? 'index' : 'key' ] );
 	}
-	if ( ref === '@key' ) return fragment.findRepeatingFragment().context.getKeyModel();
 	if ( ref === '@this' ) {
 		return fragment.ractive.viewmodel.getRactiveModel();
 	}

--- a/test/__support/js/samples/parse.js
+++ b/test/__support/js/samples/parse.js
@@ -474,7 +474,7 @@ const parseTests = [
 	{
 		name: 'If else syntax',
 		template: `{{#if foo}}foo{{else}}not foo{{/if}}`,
-		parsed: {v:4,t:[{t:4,n:50,r:'foo',f:['foo']},{t:4,n:51,r:'foo',f:['not foo']}]}
+		parsed: {v:4,t:[{t:4,n:50,r:'foo',f:['foo']},{t:4,n:51,l:1,f:['not foo']}]}
 	},
 	{
 		name: 'Nested If else syntax',
@@ -489,12 +489,12 @@ const parseTests = [
 			'{{else}}' +
 			'	bar' +
 			'{{/if}}',
-		parsed: {v:4,t:[{t:4,n:50,r:'foo',f:['foo ',{t:4,n:50,r:'foo2',f:['foo2']},{t:4,n:51,r:'foo2',f:['not foo2']}]},{t:4,n:51,r:'foo',f:['bar']}]}
+		parsed: {v:4,t:[{t:4,n:50,r:'foo',f:['foo ',{t:4,n:50,r:'foo2',f:['foo2']},{t:4,n:51,l:1,f:['not foo2']}]},{t:4,n:51,l:1,f:['bar']}]}
 	},
 	{
 		name: 'Each else syntax',
 		template: `{{#each foo:i}}foo #{{i+1}}{{else}}no foos{{/each}}`,
-		parsed: {v:4,t:[{t:4,n:52,r:'foo',i:'i',f:['foo #',{ t:2,x:{r:['i'],s:'_0+1'}}]},{t:4,n:51,r:'foo',f:['no foos']}]}
+		parsed: {v:4,t:[{t:4,n:52,r:'foo',i:'i',f:['foo #',{ t:2,x:{r:['i'],s:'_0+1'}}]},{t:4,n:51,l:1,f:['no foos']}]}
 	},
 	{
 		name: 'Else not allowed in #unless',
@@ -719,7 +719,7 @@ const parseTests = [
 	{
 		name: '{{else}} block in attribute',
 		template: `<img src="{{#if mobile}}small{{else}}big{{/if}}.png">`,
-		parsed: {v:4,t:[{t:7,e:'img',m:[{n:'src',f:[{t:4,r:'mobile',n:50,f:['small']},{t:4,r:'mobile',n:51,f:['big']},'.png'],t:13}]}]}
+		parsed: {v:4,t:[{t:7,e:'img',m:[{n:'src',f:[{t:4,r:'mobile',n:50,f:['small']},{t:4,l:1,n:51,f:['big']},'.png'],t:13}]}]}
 	},
 	{
 		name: 'Attributes can contain HTML (#1322)',

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -120,7 +120,7 @@ export default function() {
 	test( 'Component removed from DOM on tear-down with teardown override that calls _super', t => {
 		const Widget = Ractive.extend({
 			template: 'foo',
-			teardown () {
+			onteardown () {
 				this._super();
 			}
 		});

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -885,4 +885,61 @@ export default function() {
 
 		t.equal( count, 1 );
 	});
+
+	test( 'expressions should shuffle correctly', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each list}}{{.foo + 1}}{{~/list.0.foo + 1}}{{/each}}`,
+			data: {
+				list: [ { foo: 1 }, { foo: 2 } ]
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, '2232' );
+		r.unshift( 'list', { foo: 3 } );
+		t.htmlEqual( fixture.innerHTML, '442434' );
+		r.splice( 'list', 1, 1 );
+		t.htmlEqual( fixture.innerHTML, '4434' );
+	});
+
+	test( 'expressions with mappings shuffle correctly', t => {
+		const cmp = Ractive.extend({
+			template: '{{foo.foo + 1}}{{bar.foo + 1}}'
+		});
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each list}}<cmp foo="{{.}}" bar="{{~/list.0}}" />{{/each}}`,
+			data: {
+				list: [ { foo: 1 }, { foo: 2 } ]
+			},
+			components: { cmp }
+		});
+
+		t.htmlEqual( fixture.innerHTML, '2232' );
+		r.unshift( 'list', { foo: 3 } );
+		t.htmlEqual( fixture.innerHTML, '442434' );
+		r.splice( 'list', 1, 1 );
+		t.htmlEqual( fixture.innerHTML, '4434' );
+	});
+
+	test( 'computations update correctly during a shuffle', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: '{{foo.foo}}{{foo.foo + 1}}',
+			computed: {
+				foo () {
+					return this.get( 'list.0' );
+				}
+			},
+			data: {
+				list: [ { foo: 1 }, { foo: 2 } ]
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, '12' );
+		r.unshift( 'list', { foo: 3 } );
+		t.htmlEqual( fixture.innerHTML, '34' );
+		r.shift( 'list' );
+		t.htmlEqual( fixture.innerHTML, '12' );
+	});
 }

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -869,4 +869,20 @@ export default function() {
 		ractive.set( 'foo', false );
 		t.equal( count, 2 );
 	});
+
+	test( 'expressions in conditional branches should not be re-evaluated', t => {
+		let count = 0;
+		new Ractive({
+			el: fixture,
+			template: '{{#if comp()}}foo{{else}}bar{{/if}}',
+			data: {
+				comp () {
+					count++;
+					return true;
+				}
+			}
+		});
+
+		t.equal( count, 1 );
+	});
 }

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -767,10 +767,10 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'nope yep' );
 		t.equal( count, 2 );
 		r.splice( 'foo', 0, 1 );
-		t.equal( count, 3 );
+		t.equal( count, 2 );
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 		r.set( 'foo', [] );
-		t.equal( count, 3 );
+		t.equal( count, 2 );
 	});
 
 	test( 'computations with a reference expression should update with the full reference too', t => {

--- a/test/browser-tests/events/expression.js
+++ b/test/browser-tests/events/expression.js
@@ -1,6 +1,6 @@
 import { test } from 'qunit';
 import { fire } from 'simulant';
-import { initModule } from '../test-config';
+import { initModule, onWarn } from '../test-config';
 
 export default function() {
 	initModule('event/expression.js');
@@ -110,5 +110,20 @@ export default function() {
 
 		t.equal( r.get( 'foo' ), 42 );
 		t.equal( r.get( 'bar' ), true );
+	});
+
+	test( 'accessing expression keypaths from a non-context method works and warns about deprecation', t => {
+		const bar = { notEmptyIPromise: true };
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#with foo()}}<button on-click="@this.set(@keypath + '.foo', 'yep')">click</button>{{/with}}`,
+			data: {
+				foo () { return bar; }
+			}
+		});
+
+		onWarn( msg => t.ok( /deprecated/.test( msg ) ) );
+		fire( r.find( 'button' ), 'click' );
+		t.equal( bar.foo, 'yep' );
 	});
 }

--- a/test/browser-tests/methods/get.js
+++ b/test/browser-tests/methods/get.js
@@ -58,7 +58,7 @@ export default function() {
 			}
 		});
 
-		const expected = { foo: 'mine', bar: 'foo', qux: 'qux' };
+		const expected = { foo: 'mine', qux: 'qux', bar: 'foo' };
 		t.deepEqual( ractive.findComponent( 'Widget' ).get(), expected );
 		t.deepEqual( fixture.innerHTML, JSON.stringify( expected ) );
 	});

--- a/test/browser-tests/methods/get.js
+++ b/test/browser-tests/methods/get.js
@@ -62,4 +62,44 @@ export default function() {
 		t.deepEqual( ractive.findComponent( 'Widget' ).get(), expected );
 		t.deepEqual( fixture.innerHTML, JSON.stringify( expected ) );
 	});
+
+	test( `get doesn't return children unless they are a value or virtual`, t => {
+		const r = new Ractive({
+			data: { base: { foo: 1, bar: 2, baz: { bat: 3 } } }
+		});
+
+		const base = r.get( 'base' );
+		delete base.foo;
+		t.ok( !( 'foo' in r.get( 'base' ) ) );
+
+		r.reset( base );
+		r.get( 'bar' );
+		delete base.bar;
+		t.ok( !( 'bar' in r.get() ) );
+
+		r.link( 'baz.bat', 'bar' );
+		t.ok( 'bar' in r.get() );
+		t.equal( r.get().bar, 3 );
+	});
+
+	test( `get doesn't return links in non-root models unless asked`, t => {
+		const r = new Ractive({
+			data: { base: { foo: { baz: 2 }, bar: 1 } }
+		});
+
+		r.link( 'base.bar', 'base.foo.bar' );
+		t.ok( !( 'bar' in r.get( 'base.foo' ) ) );
+		t.ok( 'bar' in r.get( 'base.foo', { virtual: true } ) );
+	});
+
+	test( `get returns links in root models unless asked not to`, t => {
+		const r = new Ractive({
+			data: { base: { foo: { baz: 2 }, bar: 1 } }
+		});
+
+		r.link( 'base.bar', 'bip' );
+		t.ok( !( 'bip' in r.get({ virtual: false }) ) );
+		t.ok( 'bip' in r.get({ virtual: true } ) );
+		t.ok( 'bip' in r.get() );
+	});
 }

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -1217,4 +1217,24 @@ export default function() {
 
 		t.equal( r.get( 'observerCalledTimes' ), 1 );
 	});
+
+	test( 'observers on conditional mappings fire correctly (#2636)', t => {
+		let val;
+
+		const cmp = Ractive.extend({
+			oninit () {
+				this.observe( 'bar', v => val = v );
+			}
+		});
+
+		const r = new Ractive({
+			el: fixture,
+			template: '<cmp {{#if baz}}bar="{{baz}}"{{/if}} />',
+			data: { baz: '' },
+			components: { cmp }
+		});
+
+		r.set( 'baz', 'hello' );
+		t.equal( val, 'hello' );
+	});
 }

--- a/test/browser-tests/node-info.js
+++ b/test/browser-tests/node-info.js
@@ -92,6 +92,20 @@ export default function() {
 		t.equal( r.get( 'items.0.foo' ), 'ha' );
 	});
 
+	test( 'node info relative set with map' , t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each items}}<span />{{/each}}`,
+			data: { items: [ { foo: 'yep', bar: 'nope' } ] }
+		});
+
+		const info = Ractive.getNodeInfo( r.find( 'span' ) );
+
+		info.set({ '.foo': 'ha', '.bar': 'yep' });
+		t.equal( r.get( 'items.0.foo' ), 'ha' );
+		t.equal( r.get( 'items.0.bar' ), 'yep' );
+	});
+
 	test( 'node info alias set' , t => {
 		const r = new Ractive({
 			el: fixture,
@@ -120,6 +134,20 @@ export default function() {
 		t.equal( r.get( 'foo.bat' ), 84 );
 	});
 
+	test( 'node info add with map', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#with foo}}{{#bar}}<span>hello</span>{{/}}{{/with}}`,
+			data: { foo: { bar: { baz: true }, bat: 41, bop: 1 } }
+		});
+
+		const info = Ractive.getNodeInfo( r.find( 'span' ) );
+
+		info.add({ '../bat': 1, '../bop': 1 });
+		t.equal( r.get( 'foo.bat' ), 42 );
+		t.equal( r.get( 'foo.bop' ), 2 );
+	});
+
 	test( 'node info subtract' , t => {
 		const r = new Ractive({
 			el: fixture,
@@ -133,6 +161,20 @@ export default function() {
 		t.equal( r.get( 'foo.bat' ), 40 );
 		info.subtract( '../bat', 42 );
 		t.equal( r.get( 'foo.bat' ), -2 );
+	});
+
+	test( 'node info subtract with map', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#with foo}}{{#bar}}<span>hello</span>{{/}}{{/with}}`,
+			data: { foo: { bar: { baz: true }, bat: 41, bop: 1 } }
+		});
+
+		const info = Ractive.getNodeInfo( r.find( 'span' ) );
+
+		info.subtract({ '../bat': 1, '../bop': 2 });
+		t.equal( r.get( 'foo.bat' ), 40 );
+		t.equal( r.get( 'foo.bop' ), -1 );
 	});
 
 	test( 'node info animate', t => {

--- a/test/browser-tests/node-info.js
+++ b/test/browser-tests/node-info.js
@@ -16,6 +16,21 @@ export default function() {
 		t.equal( info.get( '../bat' ), 'yep' );
 	});
 
+	test( 'node info relative data get with expression', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#with foo()}}{{#bar}}<span>hello</span>{{/}}{{/with}}`,
+			data: {
+				wat: { bar: { baz: true }, bat: 'yep' },
+				foo () { return this.get( 'wat' ); }
+			}
+		});
+
+		const info = Ractive.getNodeInfo( r.find( 'span' ) );
+
+		t.equal( info.get( '../bat' ), 'yep' );
+	});
+
 	test( 'node info alias data get' , t => {
 		const r = new Ractive({
 			el: fixture,
@@ -247,6 +262,34 @@ export default function() {
 		info.pop( '../' );
 
 		t.equal( r.findAll( 'span' ).length, 0 );
+	});
+
+	test( 'node info sort', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each items}}<span>{{.}}</span>{{/each}}`,
+			data: { items: [ 1, 0, 2 ] }
+		});
+
+		const info = Ractive.getNodeInfo( r.find( 'span' ) );
+
+		info.sort( '../' );
+
+		t.htmlEqual( fixture.innerHTML, '<span>0</span><span>1</span><span>2</span>' );
+	});
+
+	test( 'node info sreverse', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each items}}<span>{{.}}</span>{{/each}}`,
+			data: { items: [ 1, 0, 2 ] }
+		});
+
+		const info = Ractive.getNodeInfo( r.find( 'span' ) );
+
+		info.reverse( '../' );
+
+		t.htmlEqual( fixture.innerHTML, '<span>2</span><span>0</span><span>1</span>' );
 	});
 
 	test( 'node info shift', t => {

--- a/test/browser-tests/shuffling.js
+++ b/test/browser-tests/shuffling.js
@@ -419,7 +419,10 @@ export default function() {
 		const cmp = Ractive.extend({
 			template: '{{foo.bar}}',
 			onconfig () {
-				this.observe( 'foo.*', () => count++, { init: false } );
+				this.observe( 'foo.*', v => {
+					count++;
+					t.equal( v, 'd' );
+				}, { init: false } );
 			}
 		});
 		const r = new Ractive({
@@ -432,11 +435,16 @@ export default function() {
 		});
 
 		t.htmlEqual( fixture.innerHTML, 'abc' );
-		r.splice( 'list', 0, 0, r.splice( 'list', 2, 1 ).result[0] );
+		let item = r.splice( 'list', 2, 1 ).result[0];
+		r.splice( 'list', 0, 0, item );
 		t.htmlEqual( fixture.innerHTML, 'cab' );
-		r.splice( 'list', 0, 0, r.splice( 'list', 2, 1 ).result[0] );
+		item = r.splice( 'list', 2, 1 ).result[0];
+		r.splice( 'list', 0, 0, item );
 		t.htmlEqual( fixture.innerHTML, 'bca' );
-		t.equal( count, 6 );
+		t.equal( count, 0 );
+
+		r.set( 'list.0.bar', 'd' );
+		t.equal( count, 1 );
 	});
 
 	test( 'components that are spliced out should not fire observers - #2604', t => {
@@ -486,6 +494,6 @@ export default function() {
 		const i = r.get( 'list' ).pop();
 		t.equal( count, 3 );
 		r.unshift( 'list', i );
-		t.equal( count, 6 );
+		t.equal( count, 4 );
 	});
 }

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -1180,7 +1180,7 @@ export default function() {
 
 		const r = new Ractive({
 			el: fixture,
-			template: `{{#with { foo: 'bar' }}}<textarea>{{.foo}}</textarea><button on-click="set(@keypath + '.foo', 'baz')">click me</button>{{/with}}`
+			template: `{{#with { foo: 'bar' }}}<textarea>{{.foo}}</textarea><button on-click="event.set('.foo', 'baz')">click me</button>{{/with}}`
 		});
 
 		t.equal( r.find( 'textarea' ).value, 'bar' );


### PR DESCRIPTION
I want to apologize in advance for the big funky PR and the length of the description here. There are a number of chewy issues outstanding in edge that I consider to be blockers and this is my attempt to address them. There are a few somewhat overlapping things combined here:

## Rebinding
This moves from view-based rebinding to model-based rebinding, meaning that instead of the shuffle telling the view that everything in the view needs to rebind, the model that is shuffling tells all of its deps that its value is moving to a new model. It also supplies the target model so that the deps can make sure that it matches so that deps on the absolute path `list.0.bar` don't accidentally get shuffled to `list.1.bar` on an unshift. This is a good deal faster than having everything in the view re-resolve and has the added bonus of catching things that aren't view-related, like observers, mappings, and resolvers.

There are a handful of outstanding shuffle bugs, particularly on observers, that are resolved by this type of rebinding along with the next change...

## Mappings
This also takes the mapping and link constructs and merges them using a new type of model. The `LinkModel` is simply a model that points to another model, which may be a plain data model or another link itself. When a link model is mutated, it triggers the mutation on its source model and lets it filter back to the link, so there's still a single source of truth at the origin. That creates something like a parallel namespace for the link that manages its own deps, resolvers, etc. The separate namespace makes changing the root source of the link much simpler, since now it doesn't have to try to comb through combined deps and figure out which ones should be shuffled off to the new source and which ones should remain on the model.

**Side Note:** Since there was a ton of overlap between `Model` and `LinkModel`, I rebased them both on a new `ModelBase`. I'm not crazy about the name, but it DRYs up a good bit of code.

Any regular model may now be turned into a link by having a `LinkModel` installed on it at `_link`. The `ModelBase.link` method takes care of creating a link on a model, transferring (rebinding) the model's deps to the new link, and making sure everything updates. Linking on an already linked model simply updates the source of the link.

The issues with shuffling under a mapping e.g. `{{#each list}}<component foo="{{.}}" />{{/each}}` and observers are much easier to address, and I think they're all covered here. Conditional mappings also have their corner cases addressed when combined with the rebinding changes.

Since the method to generate aggregate root data on `instance.get()` changed to accommodate links, I also added an options object for `get` that allows you to control whether or not you want the aggregate or the source data directly. The root model defaults to providing the virtual data on get, and child models default to providing the source data so as not to be a breaking change. You can now call `instance.get({ virtual: false })` to get the actual root object and `instance.get('some.path', { virtual: true })` to get `some.path` including any children that may be links.

Since mappings and links are the same thing, this would open up the possibility to have nested mappings for components. It would also make cross instance links equivalent to mappings. I haven't addressed either of those here, but it looks like they'd be easy to achieve.

## Expressions
Expressions in edge are composed of a proper `Computation` and an `ExpressionProxy` that manages the computation. The problem with that is that the computation is registered with the root of the model based on its signature and signature can, and with expressions often do ,overlap. They also create a giant map to deal with in the root model if there happen to be a few expressions in a large iterative section. I was originally going to try to reuse the computations, but then I realized that expressions with object and array literals in them can't be safely reused.

This takes the `ExpressionProxy` and detaches it from a computation to let it stand as its own full model somewhat mirroring what `Computation` does. There is probably more that could be shared between them, but I'll address that later if this works out. Now realistically, there was no way to interact with an expression model outside of the template before, but there is definitely not a way to do so here where the expression is not registered anywhere in the model tree (other than as a dep). So to address that, I extended the context methods to resolve to actual models and perform their operations instead of resolving to keypaths and just calling the appropriate instance method. That adds a bit of code to the context methods, but it also opened up an opportunity to share more code as generalized helpers among the instance methods, notably handling `*` keypath resolution and maps of paths to values.

So, you can now cause an update in an expression as long as you have an anchoring event or node info object from an element where the expression is part of the context. To be clear, if you want to call any instance methods from an expression context, you will need to use the context method on the event object to do so, as the keypath can no longer be resolved e.g. `{{#foo()}}<a on-click="event.toggle('.bar')">click</a>{{/}}` as opposed to `{{#foo()}}<a on-click="@this.toggle(@keypath + '.bar')">click</a>{{/}}`. _I_ think that's an overall improvement anyways, and it has the added benefit of not updating the wrong section if the expression keypath happened to overlap somewhere else in the template. I also added `reverse` and `sort` to the context methods, as they were missed the first time around.

`if`/`elseif`/`else` in edge use a clever negation and stacking of their expressions to split each branch into its own section. The downside to that is that side-effecting or expensive computations with be run an additional time for each successive branch. This PR drops the expression duplication and adds a flag on elseif and else sections that marks them as subordinate. When a subordinate section binds, it looks up its nearest sibling and links it with itself. Then when any of the siblings updates, it notifies its subordinate siblings to update as well, and each of them checks to see that none of the prior siblings is truthy before checking their own condition. This effectively emulates the usual branching method of most languages. This is technically a breaking template change, but the new code can still manage an old template, so I don't think a template bump is necessary since there's already one in edge.

## Epilogue
If you have some time to look over the code, I'd really appreciate some review. If you have some more time to build it and try it out with a project, that would be great too! I'm thinking about publishing some scoped Ractive experiments on npm, and this would probably be a good place to start considering that if it passes review I'd still like to get some mileage on it before merging.

Thanks!

## TODOs
* [x] Implement and test rebinding for decorators
* [x] Implement and test rebinding for transitions