### PR TITLE
Store last value on group for radio name bindings so they don't get stuck - #2638

### DIFF
--- a/src/view/items/element/binding/Binding.js
+++ b/src/view/items/element/binding/Binding.js
@@ -72,18 +72,23 @@ export default class Binding {
 
 	handleChange () {
 		const value = this.getValue();
-		if ( this.lastValue === value ) return;
+		if ( this.lastVal() === value ) return;
 
 		runloop.start( this.root );
 		this.attribute.locked = true;
 		this.model.set( value );
-		this.lastValue = value;
+		this.lastVal( true, value );
 
 		// if the value changes before observers fire, unlock to be updatable cause something weird and potentially freezy is up
 		if ( this.model.get() !== value ) this.attribute.locked = false;
 		else runloop.scheduleTask( () => this.attribute.locked = false );
 
 		runloop.end();
+	}
+
+	lastVal ( setting, value ) {
+		if ( setting ) this.lastValue = value;
+		else return this.lastValue;
 	}
 
 	rebind () {

--- a/src/view/items/element/binding/RadioNameBinding.js
+++ b/src/view/items/element/binding/RadioNameBinding.js
@@ -53,6 +53,11 @@ export default class RadioNameBinding extends Binding {
 		}
 	}
 
+	lastVal ( setting, value ) {
+		if ( setting ) this.group.lastValue = value;
+		else return this.group.lastValue;
+	}
+
 	render () {
 		super.render();
 

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -399,6 +399,36 @@ export default function() {
 		t.equal( ractive.get( 'items[1].checked' ), true );
 	});
 
+	test( "Radio name inputs don't get stuck after one pass on each value (#2638)", t => {
+		const r = new Ractive({
+			el: fixture,
+			template: '{{#items}}<input type="radio" name="{{~/color}}" value="{{.}}" />{{/items}}',
+			data: {
+				items: [
+					"red", "blue"
+				],
+				color: "red"
+			}
+		});
+
+		const inputs = r.findAll( 'input' );
+		t.equal( inputs[0].checked, true );
+		t.equal( r.get( 'color' ), 'red' );
+
+		inputs[1].checked = true;
+		fire( inputs[1], 'change' );
+		t.equal( r.get( 'color' ), 'blue' );
+		inputs[0].checked = true;
+		fire( inputs[0], 'change' );
+		t.equal( r.get( 'color' ), 'red' );
+		inputs[1].checked = true;
+		fire( inputs[1], 'change' );
+		t.equal( r.get( 'color' ), 'blue' );
+		inputs[0].checked = true;
+		fire( inputs[0], 'change' );
+		t.equal( r.get( 'color' ), 'red' );
+	});
+
 	test( 'Radio name inputs respond to model changes (regression, see #783)', t => {
 		const ractive = new Ractive({
 			el: fixture,


### PR DESCRIPTION
**Description of the pull request:**
Bindings use this.lastValue to track whether or not they change, but grouped bindings with a single value don't really work with that because the group manages the value. This adds a `lastVal` function to bindings that lets the individual implementation decide how to get and set last values.

Question: would it be better to just check for `this.group` and if it's there use it instead of `this.lastValue`? I went the overridden method route because it seems more clear to me what should be happening.

**Fixes the following issues:**
#2638

**Is breaking:**
No
