### PR TITLE
Fun component, binding, and dynamic literal partial bug - #2641

### DIFF
--- a/src/view/items/Partial.js
+++ b/src/view/items/Partial.js
@@ -24,7 +24,10 @@ export default class Partial extends Mustache {
 			super.bind();
 			if ( this.model && ( templateObj = this.model.get() ) && typeof templateObj === 'object' && ( typeof templateObj.template === 'string' || isArray( templateObj.t ) ) ) {
 				if ( templateObj.template ) {
+					this.source = templateObj.template;
 					templateObj = parsePartial( this.template.r, templateObj.template, this.ractive );
+				} else {
+					this.source = templateObj.t;
 				}
 				this.setTemplate( this.template.r, templateObj.t );
 			} else if ( ( !this.model || typeof this.model.get() !== 'string' ) && this.refName ) {
@@ -145,11 +148,16 @@ export default class Partial extends Mustache {
 					this.setTemplate( template );
 					this.fragment.resetTemplate( this.partialTemplate );
 				} else if ( template && typeof template === 'object' && ( typeof template.template === 'string' || isArray( template.t ) ) ) {
-					if ( template.template ) {
-						template = parsePartial( this.name, template.template, this.ractive );
+					if ( template.t !== this.source && template.template !== this.source ) {
+						if ( template.template ) {
+							this.source = template.template;
+							template = parsePartial( this.name, template.template, this.ractive );
+						} else {
+							this.source = template.t;
+						}
+						this.setTemplate( this.name, template.t );
+						this.fragment.resetTemplate( this.partialTemplate );
 					}
-					this.setTemplate( this.name, template.t );
-					this.fragment.resetTemplate( this.partialTemplate );
 				}
 			}
 


### PR DESCRIPTION
**Description of the pull request:**
This records the source of a dynamic literal partial that is used to compare to the new literal partial during update so that the template is not reset unnecessarily. This avoids an error on init when a binding in a child component triggers said partial to update even though there's nothing to update. Note that pre-parsing a template on-the-fly from the computation will cause this check to fail and thus throw the error, but if you're not pre-parsing before the call, I'd say just pass the string and let Ractive handle it.

@JonDum finds interesting bugs :smile:

**Fixes the following issues:**
#2641

**Is breaking:**
No