### PR TITLE
BREAKING: default modifyArrays to false - RFC

### DIFF
--- a/src/Ractive/config/defaults.js
+++ b/src/Ractive/config/defaults.js
@@ -21,7 +21,7 @@ export default {
 	data:                   {},
 	computed:               {},
 	magic:                  false,
-	modifyArrays:           true,
+	modifyArrays:           false,
 	adapt:                  [],
 	isolated:               false,
 	twoway:                 true,

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -671,7 +671,7 @@ export default function() {
 
 		let list = [];
 
-		new Ractive({
+		const r = new Ractive({
 			el: fixture,
 			template: `
 				{{#each list}}
@@ -692,7 +692,7 @@ export default function() {
 		];
 
 		for ( let i = 0; i < list2.length; i++ ) {
-			list.push( list2[i] );
+			r.push( 'list', list2[i] );
 		}
 
 		t.htmlEqual( fixture.innerHTML, '11233' );

--- a/test/browser-tests/methods/findAll.js
+++ b/test/browser-tests/methods/findAll.js
@@ -39,7 +39,7 @@ export default function() {
 		const lis = ractive.findAll( 'li', { live: true });
 		t.equal( lis.length, 3 );
 
-		ractive.get( 'items' ).push( 'd' );
+		ractive.push( 'items', 'd' );
 		t.equal( lis.length, 4 );
 	});
 

--- a/test/browser-tests/methods/findAllComponents.js
+++ b/test/browser-tests/methods/findAllComponents.js
@@ -57,7 +57,7 @@ export default function() {
 		t.equal( widgets[1].get( 'content' ), 'b' );
 		t.equal( widgets[2].get( 'content' ), 'c' );
 
-		ractive.get( 'widgets' ).push( 'd' );
+		ractive.push( 'widgets', 'd' );
 		t.equal( widgets.length, 4 );
 		t.ok( widgets[3] instanceof Widget );
 		t.equal( widgets[3].get( 'content' ), 'd' );

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -548,14 +548,14 @@ export default function() {
 				{ name: 'three' }
 			];
 
-			new Ractive({
+			const r = new Ractive({
 				el: fixture,
 				template: '{{#items}}{{name}}{{/items}}',
 				magic: true,
 				data: { items }
 			});
 
-			items.push({ name: 'four' });
+			r.push( 'items', { name: 'four' } );
 			t.htmlEqual( fixture.innerHTML, 'onetwothreefour' );
 		});
 
@@ -1773,10 +1773,10 @@ export default function() {
 
 			t.equal( fixture.innerHTML, '123' );
 
-			array.push({ foo: 6 });
+			ractive.push( 'array', { foo: 6 } );
 			t.equal( fixture.innerHTML, '123' );
 
-			array.unshift({ foo: 0 });
+			ractive.unshift( 'array', { foo: 0 } );
 			t.equal( fixture.innerHTML, '012' );
 
 			ractive.set( 'array', [] );
@@ -1784,7 +1784,6 @@ export default function() {
 			t.equal( fixture.innerHTML, '' );
 
 			ractive.set( 'array', array );
-			t.ok( array._ractive );
 			t.equal( fixture.innerHTML, '012' );
 		});
 
@@ -1810,15 +1809,15 @@ export default function() {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '{{#array}}<p>{{#( foo.slice( 0, 3 ) )}}{{.}}{{/()}}</p>{{/array}}',
-				data: { array: array }
+				data: { array }
 			});
 
 			t.htmlEqual( fixture.innerHTML, '<p>123</p><p>234</p><p>345</p><p>456</p><p>567</p>' );
 
-			array.push({ foo: [ 6, 7, 8, 9, 10 ] });
+			ractive.push( 'array', { foo: [ 6, 7, 8, 9, 10 ] } );
 			t.htmlEqual( fixture.innerHTML, '<p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
 
-			array.unshift({ foo: [ 0, 1, 2, 3, 4 ] });
+			ractive.unshift( 'array', { foo: [ 0, 1, 2, 3, 4 ] } );
 			t.htmlEqual( fixture.innerHTML, '<p>012</p><p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
 
 			ractive.set( 'array', [] );
@@ -1826,7 +1825,6 @@ export default function() {
 			t.htmlEqual( fixture.innerHTML, '' );
 
 			ractive.set( 'array', array );
-			t.ok( array._ractive );
 			t.htmlEqual( fixture.innerHTML, '<p>012</p><p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
 		});
 	}

--- a/test/browser-tests/plugins/adaptors/arrays.js
+++ b/test/browser-tests/plugins/adaptors/arrays.js
@@ -5,7 +5,8 @@ export default function() {
 	initModule( 'plugins/adaptors/arrays.js' );
 
 	const List = Ractive.extend({
-		template: '<ul>{{#items}}<li>{{.}}</li>{{/items}}</ul>'
+		template: '<ul>{{#items}}<li>{{.}}</li>{{/items}}</ul>',
+		modifyArrays: true
 	});
 
 	test( 'array.push()', t => {
@@ -77,7 +78,8 @@ export default function() {
 			data: {
 				items,
 				limit: 3
-			}
+			},
+			modifyArrays: true
 		});
 
 		t.htmlEqual( fixture.innerHTML, '<p>0 / 3</p>' );
@@ -104,7 +106,8 @@ export default function() {
 			el: fixture,
 			template: '{{#people}}<Widget person="{{this}}"/>{{/people}}',
 			data: { people },
-			components: { Widget }
+			components: { Widget },
+			modifyArrays: true
 		});
 
 		t.htmlEqual( fixture.innerHTML, '<p>alice</p><p>bob</p><p>charles</p>');
@@ -131,7 +134,8 @@ export default function() {
 			el: fixture,
 			template: '{{#people}}<Widget person="{{this}}"/>{{/people}}{{#people}}<Widget person="{{this}}"/>{{/people}}',
 			data: { people },
-			components: { Widget }
+			components: { Widget },
+			modifyArrays: true
 		});
 
 		t.htmlEqual( fixture.innerHTML, '<p>alice</p><p>bob</p><p>charles</p><p>alice</p><p>bob</p><p>charles</p>');
@@ -161,7 +165,8 @@ export default function() {
 				],
 				columns: [ 'foo', 'bar', 'baz' ],
 				selectedColumn: 'foo'
-			}
+			},
+			modifyArrays: true
 		});
 
 		t.htmlEqual( fixture.innerHTML, '<p>foo0a</p><p>bar0b</p><p>baz0c</p><strong>a</strong><p>foo1d</p><p>bar1e</p><p>baz1f</p><strong>d</strong><p>foo2g</p><p>bar2h</p><p>baz2i</p><strong>g</strong>' );
@@ -183,7 +188,8 @@ export default function() {
 			template: '<select>{{#options}}<option>{{this}}</option>{{/options}}</select>',
 			data: {
 				options: [ 'a', 'b', 'c' ]
-			}
+			},
+			modifyArrays: true
 		});
 
 		ractive.get( 'options' ).push( 'd' );

--- a/test/browser-tests/plugins/adaptors/magic.js
+++ b/test/browser-tests/plugins/adaptors/magic.js
@@ -231,7 +231,7 @@ export default function() {
 
 		test( "Magic adapters shouldn't tear themselves down while resetting (#1342)", t => {
 			let list = 'abcde'.split('');
-			new MagicRactive({
+			const r = new MagicRactive({
 				el: fixture,
 				template: '{{#list}}{{.}}{{/}}',
 				data: { list: list },
@@ -241,10 +241,10 @@ export default function() {
 			t.htmlEqual( fixture.innerHTML, 'abcde' );
 			// if the wrapper causes itself to be recreated, this is where it happens
 			// during reset
-			list.pop();
+			r.pop( 'list' );
 			t.htmlEqual( fixture.innerHTML, 'abcd' );
 			// since the wrapper now has two magic adapters, two fragments get popped
-			list.pop();
+			r.pop( 'list' );
 			t.htmlEqual( fixture.innerHTML, 'abc' );
 		});
 
@@ -281,7 +281,8 @@ export default function() {
 				el: fixture,
 				template: `{{#items}}{{.num}}{{#.items}}-{{.num}}{{/}}{{/}}`,
 				data: { items },
-				magic: true
+				magic: true,
+				modifyArrays: true
 			});
 
 			t.htmlEqual( fixture.innerHTML, '1234' );

--- a/test/browser-tests/shuffling.js
+++ b/test/browser-tests/shuffling.js
@@ -458,7 +458,7 @@ export default function() {
 		});
 
 		t.equal( r.findAll( 'div' ).length, 3 );
-		const i = r.get( 'list' ).pop();
+		const i = r.pop( 'list' ).result;
 		r.unshift( 'list', i );
 		t.equal( r.findAll( 'div' ).length, 3 );
 	});
@@ -483,7 +483,7 @@ export default function() {
 		});
 
 		t.equal( count, 3 );
-		const i = r.get( 'list' ).pop();
+		const i = r.pop( 'list' ).result;
 		t.equal( count, 3 );
 		r.unshift( 'list', i );
 		t.equal( count, 6 );


### PR DESCRIPTION
**Description of the pull request:**
This defaults modifyArrays to false. The goal is to eventually split magic and array adaptors into plugins, and this is one of the first steps to do so - that has the extra bonus of boosting performance.

The longshot is that if you want to use the non-Ractive flavors of array methods, you would now have to opt in. I believe the Ractive versions have been pushed as the preferred way to handle arrays for a while. What does everyone think? Change it, or leave it as it is for now?

**Is breaking:**
Yes