### PR TITLE
Keep twoway binding last val in sync with changes from the model - #2643

### DIFF
--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -170,6 +170,9 @@ export default class Attribute extends Item {
 			this.dirty = false;
 			if ( this.fragment ) this.fragment.update();
 			if ( this.rendered ) this.updateDelegate();
+			if ( this.isTwoway && !this.locked ) {
+				this.interpolator.twowayBinding.lastVal( true, this.interpolator.model.get() );
+			}
 		}
 	}
 }

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -1270,4 +1270,27 @@ export default function() {
 		t.equal( fixture.querySelectorAll( 'span' ).length, 1 );
 		t.equal( fixture.querySelectorAll( 'div' ).length, 3 );
 	});
+
+	test( 'bindings stay up to date when updated from the model (#2643)', t => {
+		t.expect( 5 );
+
+		const r = new Ractive({
+			el: fixture,
+			template: '<input type="checkbox" checked="{{foo.bar}}" />',
+			data: { foo: { bar: false } }
+		});
+		const input = r.find( 'input' );
+
+		fire( input, 'click' );
+		t.ok( input.checked, 'input checked by click' );
+		t.ok( r.get( 'foo.bar' ), 'model is true from click' );
+
+		r.get( 'foo' ).bar = false;
+		r.update();
+		t.ok( !input.checked, 'input unchecked by update' );
+
+		r.observe( 'foo', v => t.ok( v, 'new value true observed from click' ), { init: false } );
+		fire( input, 'click' );
+		t.ok( input.checked, 'input checked by click' );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
In certain circumstances, notably an update to a model not caused by a set, can cause the last value of a twoway binding to get out of sync. That will cause the binding not to fire a change the next time the user interacts with the element if the interaction causes the new value to be the same as the stale value.

This adds a step in Attribute update that sets the twoway binding last value to the bound interpolator value if the attribute is unlocked, meaning that the update was triggered from somewhere other than the binding.

**Fixes the following issues:**
#2643

**Is breaking:**
Nope
