### PR TITLE
Make sure intro-outro on the intro side gets cleaned up as if it were an intro - #2609

### DIFF
--- a/src/view/items/element/Transition.js
+++ b/src/view/items/element/Transition.js
@@ -292,7 +292,7 @@ export default class Transition {
 			}
 
 			this.onComplete.forEach( fn => fn() );
-			if ( !noReset && this.eventName === 'intro' ) {
+			if ( !noReset && this.isIntro ) {
 				resetStyle( node, originalStyle);
 			}
 

--- a/test/browser-tests/plugins/transitions.js
+++ b/test/browser-tests/plugins/transitions.js
@@ -717,8 +717,36 @@ export default function() {
 		setTimeout( next, 50 );
 
 		setTimeout( () => {
-			t.htmlEqual( fixture.innerHTML, '<div style="opacity: 1;">foo 4</div>' );
+			t.htmlEqual( fixture.innerHTML, '<div>foo 4</div>' );
 			done();
 		}, 400);
+	});
+
+	test( `intro transitions don't leave styles hanging around`, t => {
+		const done = t.async();
+
+		function go ( trans ) {
+			const height = trans.getStyle( 'height' );
+			if ( trans.isIntro ) {
+				trans.setStyle( 'height', 0 );
+				trans.animateStyle( 'height', height, { duration: 100 } ).then( () => trans.complete() );
+			} else {
+				trans.setStyle( 'height', height );
+				trans.animateStyle( 'height', 0, { duration: 100 } ).then( () => trans.complete() );
+			}
+		}
+
+		const r = new Ractive({
+			template: '<style>div { height: 300px }</style><div go-in-out />',
+			transitions: { go }
+		});
+
+		r.render( fixture ).then( () => {
+			t.equal( r.find( 'div' ).style.height, '' );
+			t.ok( !( 'style' in r.find( 'div' ).attributes ) );
+			r.unrender().then( () => {
+				done();
+			});
+		});
 	});
 }


### PR DESCRIPTION
**Description of the pull request:**
The match for cleaning up styles was using the event name === "intro", which obviously doesn't match "intro-outro". This swaps the check to use `isIntro`, which is conveniently already set up and a boolean.

**Fixes the following issues:**
#2609 and probably #2632

**Is breaking:**
No