### PR TITLE
Allow arrays to be merged with themselves - RFC

### DIFF
--- a/src/Ractive/prototype/merge.js
+++ b/src/Ractive/prototype/merge.js
@@ -21,9 +21,7 @@ export default function Ractive$merge ( keypath, array, options ) {
 	const promise = runloop.start( this, true );
 	const value = model.get();
 
-	if ( array === value ) {
-		throw new Error( 'You cannot merge an array with itself' ); // TODO link to docs
-	} else if ( !isArray( value ) || !isArray( array ) ) {
+	if ( !isArray( value ) || !isArray( array ) ) {
 		throw new Error( 'You cannot merge an array with a non-array' );
 	}
 

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -50,6 +50,7 @@ export default class Model {
 
 			if ( parent.value ) {
 				this.value = parent.value[ this.key ];
+				if ( isArray( this.value ) ) this.length = this.value.length;
 				this.adapt();
 			}
 		}
@@ -381,8 +382,12 @@ export default class Model {
 	}
 
 	merge ( array, comparator ) {
-		const oldArray = comparator ? this.value.map( comparator ) : this.value;
-		const newArray = comparator ? array.map( comparator ) : array;
+		let oldArray = this.value, newArray = array;
+		if ( oldArray === newArray ) oldArray = recreateArray( this );
+		if ( comparator ) {
+			oldArray = oldArray.map( comparator );
+			newArray = newArray.map( comparator );
+		}
 
 		const oldLength = oldArray.length;
 
@@ -414,7 +419,6 @@ export default class Model {
 		});
 
 		this.parent.value[ this.key ] = array;
-		this._merged = true;
 		this.shuffle( newIndices );
 	}
 
@@ -580,4 +584,14 @@ export function findBoundValue( list ) {
 			}
 		}
 	}
+}
+
+function recreateArray( model ) {
+	const array = [];
+
+	for ( let i = 0; i < model.length; i++ ) {
+		array[ i ] = model.childByKey[i].value;
+	}
+
+	return array;
 }

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -9,8 +9,6 @@ import Ticker from '../shared/Ticker';
 import getPrefixer from './helpers/getPrefixer';
 import { unescapeKey } from '../shared/keypaths';
 
-let originatingModel = null;
-
 export default class Model extends ModelBase {
 	constructor ( parent, key ) {
 		super( parent );
@@ -134,21 +132,17 @@ export default class Model extends ModelBase {
 		this.parent.clearUnresolveds();
 		this.clearUnresolveds();
 
-		// notify dependants
-		const previousOriginatingModel = originatingModel; // for the array.length special case
-		originatingModel = this;
+		// keep track of array length
+		if ( isArray( value ) ) this.length = value.length;
 
+		// notify dependants
 		this.links.forEach( handleChange );
 		this.children.forEach( mark );
 		this.deps.forEach( handleChange );
 
 		this.notifyUpstream();
 
-		originatingModel = previousOriginatingModel;
-
-		// keep track of array length
-		if ( isArray( value ) ) this.length = value.length;
-		else if ( this.key === 'length' && isArray( this.parent.value ) ) this.parent.length = this.parent.value.length;
+		if ( this.key === 'length' && isArray( this.parent.value ) ) this.parent.length = this.parent.value.length;
 	}
 
 	createBranch ( key ) {
@@ -313,7 +307,7 @@ function recreateArray( model ) {
 	const array = [];
 
 	for ( let i = 0; i < model.length; i++ ) {
-		array[ i ] = model.childByKey[i].value;
+		array[ i ] = (model.childByKey[i] || {}).value;
 	}
 
 	return array;

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -357,6 +357,7 @@ export default class RepeatedFragment {
 
 		newIndices.forEach( ( newIndex, oldIndex ) => {
 			const fragment = this.previousIterations[ oldIndex ];
+			this.previousIterations[ oldIndex ] = null;
 
 			if ( newIndex === -1 ) {
 				removed[ oldIndex ] = fragment;
@@ -369,6 +370,11 @@ export default class RepeatedFragment {
 					fragment.aliases[ this.owner.template.z[0].n ] = model;
 				}
 			}
+		});
+
+		// if the array was spliced outside of ractive, sometimes there are leftover fragments not in the newIndices
+		this.previousIterations.forEach( ( frag, i ) => {
+			if ( frag ) removed[ i ] = frag;
 		});
 
 		// create new/move existing iterations

--- a/test/browser-tests/methods/merge.js
+++ b/test/browser-tests/methods/merge.js
@@ -343,4 +343,51 @@ export default function() {
 		// is its parent
 		return !node.parentNode || node.parentNode instanceof HTMLDocument;
 	}
+
+	test( 'arrays merge safely with themselves', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{list.0.key}}{{#each list}}<span>{{.key}}</span>{{/each}}`,
+			data: {
+				list: [ { key: 'a' }, { key: 'b' } ]
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'a<span>a</span><span>b</span>' );
+		const [ spanA, spanB ] = r.findAll( 'span' );
+		spanA.myId = 'a';
+		spanB.myId = 'b';
+
+		const list = r.get( 'list' );
+		list.unshift({ key: 'c' });
+		let tmp = list[1];
+		list[1] = list[2];
+		list[2] = tmp;
+		r.merge( 'list', list );
+		t.htmlEqual( fixture.innerHTML, 'c<span>c</span><span>b</span><span>a</span>' );
+
+		const [ postC, postB, postA ] = r.findAll( 'span' );
+		t.equal( postA.myId, 'a' );
+		t.equal( postB.myId, 'b' );
+	});
+
+	test( 'arrays merge safely with themselves even if they are not rendered', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: '{{list.0.key}}',
+			data: {
+				list: [ { key: 'a' }, { key: 'b' } ]
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'a' );
+
+		const list = r.get( 'list' );
+		list.unshift({ key: 'c' });
+		let tmp = list[1];
+		list[1] = list[2];
+		list[2] = tmp;
+		r.merge( 'list', list );
+		t.htmlEqual( fixture.innerHTML, 'c' );
+	});
 }

--- a/test/browser-tests/methods/splice.js
+++ b/test/browser-tests/methods/splice.js
@@ -146,4 +146,18 @@ export default function() {
 		r.splice( 'arr', undefined, 2, 6, 5 );
 		t.htmlEqual( fixture.innerHTML, '654' );
 	});
+
+	test( 'splicing arrays that have been updated out of band doesn\'t create duplicates', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each list}}{{.name}}{{/each}}`,
+			data: {
+				list: [ { name: 'a' }, { name: 'b' }, { name: 'c' } ]
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'abc' );
+		r.unshift( 'list', r.get( 'list' ).pop() );
+		t.htmlEqual( fixture.innerHTML, 'cab' );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
Arrays are not currently allowed to merge with themselves, which means you can't modify them in place and then have a nice non-destructive shuffle for the DOM. Since the model representing the array can keep track of its length, and its children keep a reference to their value, the original array can be reconstructed pretty easily. This allows merging arrays with themselves by doing that.

There have been a few questions recently about how to move items in an array without tearing it down in one place and recreating it in another. I think this may be a reasonable way to achieve that.

**Is breaking:**
Nope