### PR TITLE
Handle template resets on components correctly - #2658

### DIFF
--- a/src/Ractive/prototype/resetTemplate.js
+++ b/src/Ractive/prototype/resetTemplate.js
@@ -33,7 +33,14 @@ export default function Ractive$resetTemplate ( template ) {
 
 	const docFrag = createDocumentFragment();
 	this.fragment.bind( this.viewmodel ).render( docFrag );
-	this.el.insertBefore( docFrag, this.anchor );
+
+	// if this is a component, its el may not be valid, so find a
+	// target based on the component container
+	if ( component ) {
+		this.fragment.findParentNode().insertBefore( docFrag, component.findNextNode() );
+	} else {
+		this.el.insertBefore( docFrag, this.anchor );
+	}
 
 	this.transitionsEnabled = transitionsEnabled;
 }

--- a/test/browser-tests/methods/reset.js
+++ b/test/browser-tests/methods/reset.js
@@ -310,4 +310,27 @@ export default function() {
 
 		t.equal( widget.get( 'foo' ), 'bar' );
 	});
+
+	test( 'resetting the template of a component (#2658)', t => {
+		const cmp = Ractive.extend({
+			template: 'hello'
+		});
+
+		const r = new Ractive({
+			el: fixture,
+			template: '<cmp />',
+			components: { cmp },
+			partials: {
+				cmp: '<cmp />'
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'hello' );
+		r.findComponent( 'cmp' ).resetTemplate( 'yep' );
+		t.htmlEqual( fixture.innerHTML, 'yep' );
+		r.resetTemplate( '{{>cmp}}' );
+		t.htmlEqual( fixture.innerHTML, 'hello' );
+		r.findComponent( 'cmp' ).resetTemplate( 'yep' );
+		t.htmlEqual( fixture.innerHTML, 'yep' );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
When a component doesn't have an actual element as a parent, it is usually rendered with a docfrag, which isn't a proper node. In that case, trying to re-render during a template reset will end up appending the component to a docfrag that is basically disposed causing the component to disappear. This adds a check for component and always looks up the appropriate parent node and anchor if the instance is a component.

**Fixes the following issues:**
#2658

**Is breaking:**
No

**Reviewers:**
@tomekmarchi
