### PR TITLE
Fix another observers modifying the observed value issue - #2668

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -130,7 +130,7 @@ class Observer {
 	dispatch () {
 		if ( !this.cancelled ) {
 			this.callback.call( this.context, this.newValue, this.oldValue, this.keypath );
-			this.oldValue = this.newValue;
+			this.oldValue = this.model ? this.model.get() : this.newValue;
 			this.dirty = false;
 		}
 	}

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -1253,4 +1253,28 @@ export default function() {
 			t.ok( false, e.message );
 		}
 	});
+
+	test( `observers that modify their observed keypath should fire again when set to the pre-observed value (#2668)`, t => {
+		let count = 0;
+
+		const r = new Ractive({
+			el: fixture,
+			template: '{{foo}}',
+			data: { foo: 'hello' }
+		});
+
+		r.observe( 'foo', function(v, o, k) {
+			count++;
+			this.set( k, v + '1' );
+		}, { init: false });
+
+		t.htmlEqual( fixture.innerHTML, 'hello' );
+		r.set( 'foo', 'hello' );
+		t.htmlEqual( fixture.innerHTML, 'hello' );
+		r.set( 'foo', 'yep' );
+		t.htmlEqual( fixture.innerHTML, 'yep1' );
+		r.set( 'foo', 'yep' );
+		t.htmlEqual( fixture.innerHTML, 'yep1' );
+		t.equal( count, 2 );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This sets observers to use their current model value, if available, as the value for future change comparison instead of the model value going into the observer dispatch. The net effect is the observers that change their observed value keep the fresh value cached, whereas current edge gets out of sync because observers can't cause themselves to fire again.

That all sounds right to me, and the test suite is ok with it. Have I missed a corner case somewhere?

**Fixes the following issues:**
#2668

**Is breaking:**
No

**Reviewers:**
@martypdx @kouts