### PR TITLE
Make sure upstream propagation hits links too - #2675

### DIFF
--- a/src/model/LinkModel.js
+++ b/src/model/LinkModel.js
@@ -1,7 +1,7 @@
 import ModelBase, { fireShuffleTasks } from './ModelBase';
 import KeypathModel from './specials/KeypathModel';
 import { capture } from '../global/capture';
-import { handleChange, marked, teardown } from '../shared/methodCallers';
+import { handleChange, marked, notifiedUpstream, teardown } from '../shared/methodCallers';
 import { rebindMatch } from '../shared/rebind';
 
 export default class LinkModel extends ModelBase {
@@ -80,6 +80,11 @@ export default class LinkModel extends ModelBase {
 
 		this.deps.forEach( handleChange );
 		this.clearUnresolveds();
+	}
+
+	notifiedUpstream () {
+		this.links.forEach( notifiedUpstream );
+		this.deps.forEach( handleChange );
 	}
 
 	relinked () {

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -1,7 +1,7 @@
 import KeyModel from './specials/KeyModel';
 import KeypathModel from './specials/KeypathModel';
 import { escapeKey, unescapeKey } from '../shared/keypaths';
-import { handleChange } from '../shared/methodCallers';
+import { handleChange, notifiedUpstream } from '../shared/methodCallers';
 import { addToArray, removeFromArray } from '../utils/array';
 import { isArray, isObject } from '../utils/is';
 import runloop from '../global/runloop';
@@ -194,6 +194,7 @@ export default class ModelBase {
 		let parent = this.parent, prev = this;
 		while ( parent ) {
 			if ( parent.patternObservers.length ) parent.patternObservers.forEach( o => o.notify( prev.key ) );
+			parent.links.forEach( notifiedUpstream );
 			parent.deps.forEach( handleChange );
 			prev = parent;
 			parent = parent.parent;

--- a/src/shared/methodCallers.js
+++ b/src/shared/methodCallers.js
@@ -3,6 +3,7 @@ export function cancel             ( x ) { x.cancel(); }
 export function handleChange       ( x ) { x.handleChange(); }
 export function mark               ( x ) { x.mark(); }
 export function marked             ( x ) { x.marked(); }
+export function notifiedUpstream   ( x ) { x.notifiedUpstream(); }
 export function render             ( x ) { x.render(); }
 export function teardown           ( x ) { x.teardown(); }
 export function unbind             ( x ) { x.unbind(); }


### PR DESCRIPTION
**Description of the pull request:**
This adds upstream change propagation to links alongside normal model parents so that mapped paths fire observers correctly and notify whatever else may need to be notified. This typically only pops up in scenarios where there is a mapped path that hasn't had the child path accessed yet and the child on the source model changes - because the link child doesn't exist, the source child can't notify it of a change.

**Fixes the following issues:**
#2675

**Is breaking:**
Nope.