### PR TITLE
Include the whole keypath when checking pattern observers - #2682

### DIFF
--- a/src/Ractive/prototype/observe.js
+++ b/src/Ractive/prototype/observe.js
@@ -275,6 +275,7 @@ class PatternObserver {
 			// handle case where previously extant keypath no longer exists -
 			// observer should still fire, with undefined as new value
 			// TODO huh. according to the test suite that's not the case...
+			// NOTE: I don't think this will work with partial updates
 			// Object.keys( this.oldValues ).forEach( keypath => {
 			// 	this.newValues[ keypath ] = undefined;
 			// });
@@ -286,17 +287,23 @@ class PatternObserver {
 				});
 				this.partial = false;
 			} else {
+				let count = 0;
 				const ok = this.baseModel.isRoot ?
-					this.changed :
-					this.changed.map( key => this.baseModel.getKeypath( this.ractive ) + '.' + escapeKey( key ) );
+					this.changed.map( keys => keys.map( escapeKey ).join( '.' ) ) :
+					this.changed.map( keys => this.baseModel.getKeypath( this.ractive ) + '.' + keys.map( escapeKey ).join( '.' ) );
 
 				this.baseModel.findMatches( this.keys ).forEach( model => {
 					const keypath = model.getKeypath( this.ractive );
 					// is this model on a changed keypath?
-					if ( ok.filter( k => keypath.indexOf( k ) === 0 && ( keypath.length === k.length || keypath[k.length] === '.' ) ).length ) {
+					if ( ok.filter( k => keypath.indexOf( k ) === 0 || k.indexOf( keypath ) === 0 ).length ) {
+						count++;
 						this.newValues[ keypath ] = model.get();
 					}
 				});
+
+				// no valid change triggered, so bail to avoid breakage
+				if ( !count ) return;
+
 				this.partial = true;
 			}
 

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -191,12 +191,12 @@ export default class ModelBase {
 	}
 
 	notifyUpstream () {
-		let parent = this.parent, prev = this;
+		let parent = this.parent, path = [ this.key ];
 		while ( parent ) {
-			if ( parent.patternObservers.length ) parent.patternObservers.forEach( o => o.notify( prev.key ) );
+			if ( parent.patternObservers.length ) parent.patternObservers.forEach( o => o.notify( path.slice() ) );
+			path.unshift( parent.key );
 			parent.links.forEach( notifiedUpstream );
 			parent.deps.forEach( handleChange );
-			prev = parent;
 			parent = parent.parent;
 		}
 	}

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -1360,4 +1360,21 @@ export default function() {
 		t.equal( count, 1 );
 		t.htmlEqual( fixture.innerHTML, '{"str":"still yep"}{"str":"still yep"}' );
 	});
+
+	test( `pattern observers only fire once for matching keypaths (#2682)`, t => {
+		let count = 0;
+		const r = new Ractive({
+			el: fixture
+		});
+
+		r.observe( 'a.*.c.*', () => {
+			count++;
+			r.set( 'a.b.really.d', 1 );
+		});
+
+		r.set( 'a.b.c.d', 1 );
+		r.set( 'a.b.nope.d', 1 );
+
+		t.equal( count, 1 );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
If there're multiple wildcards in an observer, an unrelated, but partially overlapping keypath may trigger the observer to fire because the current code only considers the first key past the base model. This changes pattern observer notification to get the _whole_ keypath, which allows the observer to make sure that the originating model is actually a whole match and just not a partial match close to the base.

There's a bonus bug here, where a partial match can trigger the observer to dispatch again before the newValues object is reset if the observer callback triggers a fire on a partially matching keypath. That causes a double (or more) fire too. This works around it by not setting up a dispatch if no models actually matched the triggering models for a partial update.

There may be a better way to handle this, but there are a ton of corner cases involved, so I'm gonna punt on a better solution for this one that seems to work. It seems that the observer test suite is a little lacking, so lemme know if there are other issues that arise around this.

**Fixes the following issues:**
#2682

**Is breaking:**
Don't think so, but the observer test suite seems not to cover every angle.
