### PR TITLE
Try to fix up some outstanding adaptor weirdness - #2693

### DIFF
--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -5,7 +5,11 @@ import { splitKeypath } from '../../shared/keypaths';
 const updateHook = new Hook( 'update' );
 
 export function update ( ractive, model ) {
-	if ( model.parent && model.parent.wrapper ) return update( ractive, model.parent );
+	// if the parent is wrapped, the adaptor will need to be updated before
+	// updating on this keypath
+	if ( model.parent && model.parent.wrapper ) {
+		model.parent.adapt();
+	}
 
 	const promise = runloop.start( ractive, true );
 

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -77,6 +77,7 @@ export default class Computation extends Model {
 		if ( this.dirty ) {
 			this.dirty = false;
 			this.value = this.getValue();
+			if ( this.wrapper ) this.wrapper.newValue = this.value;
 			this.adapt();
 		}
 

--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -173,7 +173,7 @@ export default class RootModel extends Model {
 	}
 
 	retrieve () {
-		return this.value;
+		return this.wrapper ? this.wrapper.get() : this.value;
 	}
 
 	update () {

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -64,6 +64,7 @@ export default class ExpressionProxy extends Model {
 		if ( this.dirty ) {
 			this.dirty = false;
 			this.value = this.getValue();
+			if ( this.wrapper ) this.wrapper.newValue = this.value;
 			this.adapt();
 		}
 

--- a/test/__support/js/helpers/Model.js
+++ b/test/__support/js/helpers/Model.js
@@ -116,6 +116,10 @@ Model.adaptor = {
 				setting = false;
 			},
 			reset ( newData ) {
+				if ( setting ) {
+					return;
+				}
+
 				if ( newData instanceof Model ) {
 					return false; // teardown
 				}
@@ -124,8 +128,10 @@ Model.adaptor = {
 					return false;
 				}
 
+				setting = true;
 				object.reset( newData );
 				ractive.update( keypath );
+				setting = false;
 			}
 		};
 	}

--- a/test/browser-tests/render/output.js
+++ b/test/browser-tests/render/output.js
@@ -15,43 +15,44 @@ export default function() {
 		if ( !svg && theTest.svg ) return;
 		if ( theTest.nodeOnly ) return;
 
-		test( theTest.name, t => {
-			const data = getData( theTest.data );
+		[ false, true ].forEach( magic => {
+			test( `${theTest.name} (magic: ${magic})`, t => { const data = getData( theTest.data );
 
-			// suppress warnings about non-POJOs
-			onWarn( msg => t.ok( /plain JavaScript object/.test( msg ) ) );
+				// suppress warnings about non-POJOs
+				onWarn( msg => t.ok( /plain JavaScript object/.test( msg ) ) );
 
-			const ractive = new Ractive({
-				el: fixture,
-				data,
-				template: theTest.template,
-				partials: theTest.partials,
-				handlebars: theTest.handlebars, // TODO remove this if handlebars mode becomes default
-				debug: true
-			});
+				const ractive = new Ractive({
+					el: fixture,
+					data,
+					template: theTest.template,
+					partials: theTest.partials,
+					debug: true,
+					magic
+				});
 
-			t.htmlEqual( fixture.innerHTML, theTest.result, 'innerHTML should match result' );
-			t.htmlEqual( ractive.toHTML(), theTest.result, 'toHTML() should match result' );
+				t.htmlEqual( fixture.innerHTML, theTest.result, 'innerHTML should match result' );
+				t.htmlEqual( ractive.toHTML(), theTest.result, 'toHTML() should match result' );
 
-			if ( theTest.new_data ) {
-				const data = getData( theTest.new_data );
-
-				ractive.set( data );
-
-				t.htmlEqual( fixture.innerHTML, theTest.new_result, 'innerHTML should match result' );
-				t.htmlEqual( ractive.toHTML(), theTest.new_result, 'toHTML() should match result' );
-			} else if ( theTest.steps && theTest.steps.length ) {
-				theTest.steps.forEach( step => {
-					const data = getData( step.data );
+				if ( theTest.new_data ) {
+					const data = getData( theTest.new_data );
 
 					ractive.set( data );
 
-					t.htmlEqual( fixture.innerHTML, step.result, step.message || 'innerHTML should match result' );
-					t.htmlEqual( ractive.toHTML(), step.result, step.message || 'toHTML() should match result' );
-				});
-			}
+					t.htmlEqual( fixture.innerHTML, theTest.new_result, 'innerHTML should match result' );
+					t.htmlEqual( ractive.toHTML(), theTest.new_result, 'toHTML() should match result' );
+				} else if ( theTest.steps && theTest.steps.length ) {
+					theTest.steps.forEach( step => {
+						const data = getData( step.data );
 
-			ractive.teardown();
+						ractive.set( data );
+
+						t.htmlEqual( fixture.innerHTML, step.result, step.message || 'innerHTML should match result' );
+						t.htmlEqual( ractive.toHTML(), step.result, step.message || 'toHTML() should match result' );
+					});
+				}
+
+				ractive.teardown();
+			});
 		});
 	});
 

--- a/test/node-tests/toHTML.js
+++ b/test/node-tests/toHTML.js
@@ -14,15 +14,14 @@ function getData ( data ) {
 
 describe( 'ractive.toHTML()', function () {
 	renderTests.forEach( function ( theTest ) {
-		it( theTest.name, function () {
-			[ false, true ].forEach( function ( magic ) {
+		[ false, true ].forEach( function ( magic ) {
+			it( theTest.name + " (magic: " + magic + ")", function () {
 				var data = getData( theTest.data );
 
 				var ractive = new Ractive({
 					template: theTest.template,
 					data: data,
 					partials: theTest.partials,
-					handlebars: theTest.handlebars, // TODO remove this if handlebars becomes default
 					magic: magic
 				});
 


### PR DESCRIPTION
**Description of the pull request:**
Turns out that there were a handful of issues with various parts of the adaptor support in edge, including the filter parameters not being passed in the correct order. I _think_ I've got just about everything sorted, but it's hard to say. I ran the ractive-ractive test suite against this branch and it only failed on the downstream deep path tests, a merge test, and a reset on child test.

This adds a check for an existing wrapper when trying to adapt a new value on a model, and if one is present, a `newValue` is set on the wrapper so that the reset fires against the right value. Up to now, edge has been trying to reset with the result of `wrapper.get()`. Oops. Fixing that surfaced an interesting bug in the adaptor test suite where `reset` was calling `set`, which was triggering a `reset`, and so forth until the stack gave up. Adding a setting check in reset to match the one in set resolved that nicely, but I don't know if any wild adaptors will break in the same way.

**Fixes the following issues:**
#2693

**Is breaking:**
I hope not.

**Reviewers:**
Anyone familiar with adaptors?
