### PR TITLE
Allow target as a config alias for el - #1848

### DIFF
--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -49,7 +49,7 @@ export default function initialise ( ractive, userOptions, options ) {
 
 	if ( fragment ) {
 		// render automatically ( if `el` is specified )
-		const el = getElement( ractive.el );
+		const el = getElement( ractive.el || ractive.target );
 		if ( el ) {
 			let promise = ractive.render( el, ractive.append );
 

--- a/src/Ractive/render.js
+++ b/src/Ractive/render.js
@@ -21,7 +21,7 @@ export default function render ( ractive, target, anchor, occupants ) {
 
 	anchor = getElement( anchor ) || ractive.anchor;
 
-	ractive.el = target;
+	ractive.el = ractive.target = target;
 	ractive.anchor = anchor;
 
 	// ensure encapsulated CSS is up-to-date

--- a/test/browser-tests/init/config.js
+++ b/test/browser-tests/init/config.js
@@ -56,4 +56,15 @@ export default function() {
 		t.equal( ractive.foo, 'bar' );
 		t.ok( ractive.fumble() );
 	});
+
+	test( 'target element can be specified with target as well as el (#1848)', t => {
+		const r = new Ractive({
+			target: fixture,
+			template: 'yep'
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'yep' );
+		t.strictEqual( fixture, r.target );
+		t.strictEqual( fixture, r.el );
+	});
 }


### PR DESCRIPTION
**Description of the pull request:**
This allows a target element to be specified at init with `target` as well as `el` for consistency sake. We don't use abbreviations anywhere else, and this brings in a way to set el that matches the rest of the config params.

**Fixes the following issues:**
#1848

**Is breaking:**
Maybe, if you have `target` as a property on a component or instance.
