### PR TITLE
Various debug logging changes - RFC - 0.8.1

### DIFF
--- a/src/Ractive/config/defaults.js
+++ b/src/Ractive/config/defaults.js
@@ -16,6 +16,7 @@ export default {
 	preserveWhitespace:     false,
 	sanitize:               false,
 	stripComments:          true,
+	contextLines:           0,
 
 	// data & binding:
 	data:                   {},

--- a/src/Ractive/config/runtime-parser.js
+++ b/src/Ractive/config/runtime-parser.js
@@ -13,7 +13,8 @@ const parseOptions = [
 	'interpolate',
 	'preserveWhitespace',
 	'sanitize',
-	'stripComments'
+	'stripComments',
+	'contextLines'
 ];
 
 const TEMPLATE_INSTRUCTIONS = `Either preparse or use a ractive runtime source that includes the parser. `;

--- a/src/parse/_parse.js
+++ b/src/parse/_parse.js
@@ -61,6 +61,8 @@ StandardParser = Parser.extend({
 			{ isStatic: true,  isTriple: true,  open: staticTripleDelimiters[0],  close: staticTripleDelimiters[1],  readers: TRIPLE_READERS }
 		];
 
+		this.contextLines = options.contextLines || 0;
+
 		this.sortMustacheTags();
 
 		this.sectionDepth = 0;

--- a/src/parse/converters/mustache/readSection.js
+++ b/src/parse/converters/mustache/readSection.js
@@ -82,9 +82,12 @@ export default function readSection ( parser, tag ) {
 
 	conditions = [];
 
+	let pos;
 	do {
+		pos = parser.pos;
 		if ( child = readClosing( parser, tag ) ) {
 			if ( expectedClose && child.r !== expectedClose ) {
+				parser.pos = pos;
 				parser.error( `Expected ${tag.open}/${expectedClose}${tag.close}` );
 			}
 

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -33,9 +33,14 @@ Found a bug? Raise an issue:
 `;
 
 	welcome = () => {
-		let hasGroup = !!console.groupCollapsed;
-		console[ hasGroup ? 'groupCollapsed' : 'log' ].apply( console, welcomeIntro );
-		console.log( welcomeMessage );
+		if ( Ractive.WELCOME_MESSAGE === false ) {
+			welcome = noop;
+			return;
+		}
+		const message = 'WELCOME_MESSAGE' in Ractive ? Ractive.WELCOME_MESSAGE : welcomeMessage;
+		const hasGroup = !!console.groupCollapsed;
+		if ( hasGroup ) console.groupCollapsed.apply( console, welcomeIntro );
+		console.log( message );
 		if ( hasGroup ) {
 			console.groupEnd( welcomeIntro );
 		}

--- a/test/__support/js/samples/parse.js
+++ b/test/__support/js/samples/parse.js
@@ -459,7 +459,7 @@ const parseTests = [
 		name: 'Illegal closing section for {{#if}}',
 		template: `{{#if (foo*5 < 20)}}foo{{/wrong}}`,
 		error:
-			'Expected {{/if}} at line 1 character 34:\n{{#if (foo*5 < 20)}}foo{{/wrong}}\n                                 ^----'
+			'Expected {{/if}} at line 1 character 24:\n{{#if (foo*5 < 20)}}foo{{/wrong}}\n                       ^----'
 	},
 	{
 		name: 'Unless syntax',

--- a/test/node-tests/basic.js
+++ b/test/node-tests/basic.js
@@ -1,6 +1,7 @@
 /*global require, describe, it */
 
 var Ractive = require( '../../ractive' );
+Ractive.WELCOME_MESSAGE = 'Ractive tests...';
 var assert = require( 'assert' );
 
 describe( 'Ractive', function () {


### PR DESCRIPTION
## Description of the pull request:
This does a few things:

1. Add a new parsing option `contextLines`, that when set to:
  * `-1` - only shows the message
  * `0` - the default - shows the line with the error and the ascii arrow thing beneath at the appropriate character
  * any positive integer `num` - get at most `num` lines from above and below the relevant line and wrap them around the line with the ascii arrow thing
2. Makes method call event deprecation stand out more by using the context helper from 1 above to throw out a message for each instance that needs to be updated. This will get really chatty, but un-prefixed methods are most likely going away in 0.9 entirely. It's kinda hard to find these because you can't just search for `decorator` or `transition` like the other deprecated things.
3. Makes proxy events with args warn for each instance, again with context like above. As with method events, it's harder to find instances of proxy events that are deprecated going forward.
4. Adds a new global `Ractive.WELCOME_MESSAGE` that can be used by tooling to skip or modify the welcome message with values:
  * `false` - just don't
  * some string `str` - display `str` instead of the default message. If there is group support on the `console`, it will still be collapsed when logged.

If there are no objections or issues, I'll land this tomorrow and push out 0.8.1, which already has a number of bug fixes queued.

## Fixes the following issues:
#2553 #2146 #2701

## Is breaking:
No, but it does take over `contextLines` if some instance happens to be using that as a flag somewhere in the wild.

## Reviewers:
@timoxley @dagnelies @fskreuz @MartinKolarik @martypdx @Rich-Harris and anyone else