### PR TITLE
Node tests to use QUnit

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "karma-coverage": "~1.1",
     "karma-phantomjs-launcher": "~1.0",
     "karma-qunit": "~1.2",
-    "mocha": "^3.1.2",
     "phantomjs-prebuilt": "~2.1",
     "promises-aplus-tests": "^2.1.0",
     "qunit-cli": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "mocha": "^3.1.2",
     "phantomjs-prebuilt": "~2.1",
     "promises-aplus-tests": "^2.1.0",
+    "qunit-cli": "^0.2.0",
     "qunitjs": "~2.0",
     "rollup": "^0.25.0",
     "rollup-plugin-buble": "^0.4.0",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,7 +7,7 @@ MOD='node_modules/.bin'
 
 # run node.js tests
 echo "> running node.js-specific tests. working directory is $PWD"
-$MOD/mocha ./tmp/test/node-tests/index.js --reporter progress
+qunit-cli --quiet --code Ractive:./tmp/ractive.js ./tmp/test/node-tests/index.js
 
 # check ractive.runtime doesn't error (#1860)
 node tmp/ractive.runtime.js

--- a/test/node-tests/.eslintrc
+++ b/test/node-tests/.eslintrc
@@ -1,13 +1,15 @@
 {
 	"env": {
-		"node": true
+		"node": true,
+		"qunit": true
 	},
 	"globals": {
 		"Ractive": true,
 		"fixture": true
 	},
 	"rules": {
-		"no-var": 0,
-		"object-shorthand": 0
+		"no-var": "off",
+		"object-shorthand": "off",
+		"prefer-arrow-callback": "off"
 	}
 }

--- a/test/node-tests/basic.js
+++ b/test/node-tests/basic.js
@@ -1,11 +1,5 @@
-/*global require, describe, it */
+QUnit.module( 'Ractive' );
 
-var Ractive = require( '../../ractive' );
-Ractive.WELCOME_MESSAGE = 'Ractive tests...';
-var assert = require( 'assert' );
-
-describe( 'Ractive', function () {
-	it( 'should be a function', function () {
-		assert.equal( typeof Ractive, 'function' );
-	});
+QUnit.test( 'should be a function', function ( assert ) {
+	assert.equal( typeof Ractive, 'function' );
 });

--- a/test/node-tests/components.js
+++ b/test/node-tests/components.js
@@ -18,11 +18,14 @@ QUnit.test( 'should render in a non-DOM environment', function ( assert ) {
 	assert.equal( ractive.toHTML(), '<p>foo-baz</p>' );
 });
 
-QUnit.test( 'should not fail if component has CSS', function () {
+QUnit.test( 'should not fail if component has CSS', function ( assert ) {
 	var Widget = Ractive.extend({
 		template: '<p>red</p>',
 		css: 'p { color: red; }'
 	});
 
 	new Widget();
+
+	// If the code reached this point, then the lines before it didn't blow up.
+	assert.ok(true);
 });

--- a/test/node-tests/components.js
+++ b/test/node-tests/components.js
@@ -1,32 +1,28 @@
-/*global require, describe, it */
-var Ractive = require( '../../ractive' );
-var assert = require( 'assert' );
+QUnit.module( 'Components' );
 
-describe( 'Components', function () {
-	it( 'should render in a non-DOM environment', function () {
-		var Widget = Ractive.extend({
-			template: '<p>foo-{{bar}}</p>'
-		});
-
-		var ractive = new Ractive({
-			template: '<widget/>',
-			data: {
-				bar: 'baz'
-			},
-			components: {
-				widget: Widget
-			}
-		});
-
-		assert.equal( ractive.toHTML(), '<p>foo-baz</p>' );
+QUnit.test( 'should render in a non-DOM environment', function ( assert ) {
+	var Widget = Ractive.extend({
+		template: '<p>foo-{{bar}}</p>'
 	});
 
-	it( 'should not fail if component has CSS', function () {
-		var Widget = Ractive.extend({
-			template: '<p>red</p>',
-			css: 'p { color: red; }'
-		});
-
-		new Widget();
+	var ractive = new Ractive({
+		template: '<widget/>',
+		data: {
+			bar: 'baz'
+		},
+		components: {
+			widget: Widget
+		}
 	});
+
+	assert.equal( ractive.toHTML(), '<p>foo-baz</p>' );
+});
+
+QUnit.test( 'should not fail if component has CSS', function () {
+	var Widget = Ractive.extend({
+		template: '<p>red</p>',
+		css: 'p { color: red; }'
+	});
+
+	new Widget();
 });

--- a/test/node-tests/getCSS.js
+++ b/test/node-tests/getCSS.js
@@ -1,9 +1,3 @@
-/*global require, describe, it */
-'use strict';
-
-var Ractive = require( '../../ractive' );
-var assert = require( 'assert' );
-
 function createComponentDefinition( Ractive ) {
 
 	return Ractive.extend( {
@@ -11,30 +5,29 @@ function createComponentDefinition( Ractive ) {
 	} );
 }
 
-describe( 'ractive.toCSS()', function() {
+QUnit.module( 'ractive.toCSS()' );
 
-	it( 'should render CSS with a single component definition', function() {
+QUnit.test( 'should render CSS with a single component definition', function( assert ) {
 
-		var Component = createComponentDefinition( Ractive );
+	var Component = createComponentDefinition( Ractive );
 
-		var cssId = Component.prototype.cssId;
-		var css = Ractive.getCSS();
+	var cssId = Component.prototype.cssId;
+	var css = Ractive.getCSS();
 
-		assert( !!~css.indexOf( '.green[data-ractive-css~="{' + cssId + '}"], [data-ractive-css~="{' + cssId + '}"] .green', '.green selector for ' + cssId + ' should exist' ) );
-	} );
+	assert.ok( !!~css.indexOf( '.green[data-ractive-css~="{' + cssId + '}"], [data-ractive-css~="{' + cssId + '}"] .green', '.green selector for ' + cssId + ' should exist' ) );
+} );
 
-	it( 'should render CSS with multiple components definition', function() {
+QUnit.test( 'should render CSS with multiple components definition', function( assert ) {
 
-		var ComponentA = createComponentDefinition( Ractive );
+	var ComponentA = createComponentDefinition( Ractive );
 
-		var ComponentB = createComponentDefinition( Ractive );
+	var ComponentB = createComponentDefinition( Ractive );
 
-		var cssIdA = ComponentA.prototype.cssId;
-		var cssIdB = ComponentB.prototype.cssId;
-		var css = Ractive.getCSS();
+	var cssIdA = ComponentA.prototype.cssId;
+	var cssIdB = ComponentB.prototype.cssId;
+	var css = Ractive.getCSS();
 
-		// Look for the selectors
-		assert( !!~css.indexOf( '.green[data-ractive-css~="{' + cssIdA + '}"], [data-ractive-css~="{' + cssIdA + '}"] .green' ), '.green selector for ' + cssIdA + ' should exist' );
-		assert( !!~css.indexOf( '.green[data-ractive-css~="{' + cssIdB + '}"], [data-ractive-css~="{' + cssIdB + '}"] .green' ), '.green selector for ' + cssIdB + ' should exist' );
-	} );
+	// Look for the selectors
+	assert.ok( !!~css.indexOf( '.green[data-ractive-css~="{' + cssIdA + '}"], [data-ractive-css~="{' + cssIdA + '}"] .green' ), '.green selector for ' + cssIdA + ' should exist' );
+	assert.ok( !!~css.indexOf( '.green[data-ractive-css~="{' + cssIdB + '}"], [data-ractive-css~="{' + cssIdB + '}"] .green' ), '.green selector for ' + cssIdB + ' should exist' );
 } );

--- a/test/node-tests/index.js
+++ b/test/node-tests/index.js
@@ -1,4 +1,5 @@
-/*global require */
+Ractive.DEBUG = false;
+
 require( './basic' );
 require( './components' );
 require( './parse' );

--- a/test/node-tests/parse.js
+++ b/test/node-tests/parse.js
@@ -1,34 +1,30 @@
-/*global require, describe, it */
-var Ractive = require( '../../ractive' );
-var assert = require( 'assert' );
 var parseTests = require( './samples/parse' );
 
-describe( 'Ractive.parse()', function () {
-	parseTests.forEach( function ( test ) {
+QUnit.module( 'Ractive.parse()' );
 
-		// disable for tests unless explicitly specified
-		// we can just test the signatures, so set csp false
-		test.options = test.options || { csp: false };
-		if ( !test.options.hasOwnProperty( 'csp' ) ) {
-			test.options.csp = false;
+parseTests.forEach( function ( test ) {
+
+	// disable for tests unless explicitly specified
+	// we can just test the signatures, so set csp false
+	test.options = test.options || { csp: false };
+	if ( !test.options.hasOwnProperty( 'csp' ) ) {
+		test.options.csp = false;
+	}
+
+	QUnit.test( test.name, function ( assert ) {
+		if (test.error) {
+			assert.throws( function () {
+				Ractive.parse( test.template, test.options );
+			}, function ( error ) {
+				if (error.name !== 'ParseError') {
+					throw error;
+				}
+				assert.equal( error.message, test.error );
+				return true;
+			}, 'Expected ParseError');
+		} else {
+			var parsed = Ractive.parse( test.template, test.options );
+			assert.deepEqual( parsed, test.parsed );
 		}
-
-		it( test.name, function () {
-			if (test.error) {
-				assert.throws( function () {
-					Ractive.parse( test.template, test.options );
-				}, function ( error ) {
-					if (error.name !== 'ParseError') {
-						throw error;
-					}
-					assert.equal( error.message, test.error );
-					return true;
-				}, 'Expected ParseError');
-			} else {
-				var parsed = Ractive.parse( test.template, test.options );
-				assert.deepEqual( parsed, test.parsed );
-			}
-		});
 	});
-
 });

--- a/test/node-tests/parse.js
+++ b/test/node-tests/parse.js
@@ -24,6 +24,23 @@ parseTests.forEach( function ( test ) {
 			}, 'Expected ParseError');
 		} else {
 			var parsed = Ractive.parse( test.template, test.options );
+
+			if (parsed.e && test.parsed.e) {
+				var expectedKeys = Object.keys(test.parsed.e);
+				var parsedKeys = Object.keys(parsed.e);
+
+				assert.deepEqual(parsedKeys, expectedKeys);
+
+				expectedKeys.forEach(key => {
+					// normalize function whitepace for browser vs phantomjs
+					var actual = parsed.e[key].toString().replace(') \{', ')\{');
+					assert.equal(actual, test.parsed.e[key]);
+				});
+
+				delete parsed.e;
+				delete test.parsed.e;
+			}
+
 			assert.deepEqual( parsed, test.parsed );
 		}
 	});

--- a/test/node-tests/toCSS.js
+++ b/test/node-tests/toCSS.js
@@ -1,80 +1,74 @@
-/*global require, describe, it */
-'use strict';
+QUnit.module( 'ractive.toCSS()' );
 
-var Ractive = require( '../../ractive' );
-var assert = require( 'assert' );
 
-describe( 'ractive.toCSS()', function() {
+QUnit.test( 'should render CSS with a single component instance', function( assert ) {
 
-	it( 'should render CSS with a single component instance', function() {
-
-		var Component = Ractive.extend( {
-			template: '<div></div>',
-			css: '\n\t\t\t\t.green {\n\t\t\t\t\tcolor: green\n\t\t\t\t}\n\t\t'
-		} );
-
-		var app = new Component( {} );
-
-		var cssId = Component.prototype.cssId;
-		var css = app.toCSS();
-
-		// Look for the selector
-		assert( !!~css.indexOf( '.green[data-ractive-css~="{' + cssId + '}"], [data-ractive-css~="{' + cssId + '}"] .green', '.green selector for ' + cssId + ' should exist' ) );
-
-		app.teardown();
+	var Component = Ractive.extend( {
+		template: '<div></div>',
+		css: '\n\t\t\t\t.green {\n\t\t\t\t\tcolor: green\n\t\t\t\t}\n\t\t'
 	} );
 
-	it( 'should render CSS with nested component instances', function() {
+	var app = new Component( {} );
 
-		var GrandChildComponent = Ractive.extend( {
-			template: '<div></div>',
-			css: '\n\t\t\t\t.green {\n\t\t\t\t\tcolor: green;\n\t\t\t\t}\n\t\t'
-		} );
+	var cssId = Component.prototype.cssId;
+	var css = app.toCSS();
 
-		var ChildComponent = Ractive.extend( {
-			template: '\n\t\t\t\t<div></div>\n\t\t\t\t<GrandChildComponent />\n\t\t\t',
-			css: '\n\t\t\t\t.red {\n\t\t\t\t\tcolor: red;\n\t\t\t\t}\n\t\t',
-			components: {
-				GrandChildComponent: GrandChildComponent
-			}
-		} );
+	// Look for the selector
+	assert.ok( !!~css.indexOf( '.green[data-ractive-css~="{' + cssId + '}"], [data-ractive-css~="{' + cssId + '}"] .green', '.green selector for ' + cssId + ' should exist' ) );
 
-		var ParentComponent = Ractive.extend( {
-			template: '\n\t\t\t\t<div></div>\n\t\t\t\t<ChildComponent />\n\t\t\t',
-			css: '\n\t\t\t\t.blue{\n\t\t\t\t\tcolor: blue;\n\t\t\t\t}\n\t\t\t',
-			components: {
-				ChildComponent: ChildComponent
-			}
-		} );
+	app.teardown();
+} );
 
-		var app = new ParentComponent( {} );
+QUnit.test( 'should render CSS with nested component instances', function( assert ) {
 
-		var css = app.toCSS();
-		var grandChildCssId = GrandChildComponent.prototype.cssId;
-		var childCssId = ChildComponent.prototype.cssId;
-		var parentCssId = ParentComponent.prototype.cssId;
-
-		// Look for the selectors
-		assert( !!~css.indexOf( '.green[data-ractive-css~="{' + grandChildCssId + '}"], [data-ractive-css~="{' + grandChildCssId + '}"] .green' ), '.green selector for ' + grandChildCssId + ' should exist' );
-
-		assert( !!~css.indexOf( '.red[data-ractive-css~="{' + childCssId + '}"], [data-ractive-css~="{' + childCssId + '}"] .red' ), '.red selector for ' + childCssId + ' should exist' );
-
-		assert( !!~css.indexOf( '.blue[data-ractive-css~="{' + parentCssId + '}"], [data-ractive-css~="{' + parentCssId + '}"] .blue' ), '.blue selector for ' + parentCssId + ' should exist' );
-
-		app.teardown();
+	var GrandChildComponent = Ractive.extend( {
+		template: '<div></div>',
+		css: '\n\t\t\t\t.green {\n\t\t\t\t\tcolor: green;\n\t\t\t\t}\n\t\t'
 	} );
 
-	it( 'should NEVER render CSS with a Ractive instance', function() {
-
-		var app = new Ractive( {
-			template: '<div></div>',
-			css: '\n\t\t\t\t.green {\n\t\t\t\t\tcolor: green\n\t\t\t\t}\n\t\t\t'
-		} );
-
-		var css = app.toCSS();
-
-		assert( !~css.indexOf( '.green[data-ractive-css~="{' + app.cssId + '}"], [data-ractive-css~="{' + app.cssId + '}"] .green', '.green selector for ' + app.cssId + ' should NEVER exist' ) );
-
-		app.teardown();
+	var ChildComponent = Ractive.extend( {
+		template: '\n\t\t\t\t<div></div>\n\t\t\t\t<GrandChildComponent />\n\t\t\t',
+		css: '\n\t\t\t\t.red {\n\t\t\t\t\tcolor: red;\n\t\t\t\t}\n\t\t',
+		components: {
+			GrandChildComponent: GrandChildComponent
+		}
 	} );
+
+	var ParentComponent = Ractive.extend( {
+		template: '\n\t\t\t\t<div></div>\n\t\t\t\t<ChildComponent />\n\t\t\t',
+		css: '\n\t\t\t\t.blue{\n\t\t\t\t\tcolor: blue;\n\t\t\t\t}\n\t\t\t',
+		components: {
+			ChildComponent: ChildComponent
+		}
+	} );
+
+	var app = new ParentComponent( {} );
+
+	var css = app.toCSS();
+	var grandChildCssId = GrandChildComponent.prototype.cssId;
+	var childCssId = ChildComponent.prototype.cssId;
+	var parentCssId = ParentComponent.prototype.cssId;
+
+	// Look for the selectors
+	assert.ok( !!~css.indexOf( '.green[data-ractive-css~="{' + grandChildCssId + '}"], [data-ractive-css~="{' + grandChildCssId + '}"] .green' ), '.green selector for ' + grandChildCssId + ' should exist' );
+
+	assert.ok( !!~css.indexOf( '.red[data-ractive-css~="{' + childCssId + '}"], [data-ractive-css~="{' + childCssId + '}"] .red' ), '.red selector for ' + childCssId + ' should exist' );
+
+	assert.ok( !!~css.indexOf( '.blue[data-ractive-css~="{' + parentCssId + '}"], [data-ractive-css~="{' + parentCssId + '}"] .blue' ), '.blue selector for ' + parentCssId + ' should exist' );
+
+	app.teardown();
+} );
+
+QUnit.test( 'should NEVER render CSS with a Ractive instance', function ( assert ) {
+
+	var app = new Ractive( {
+		template: '<div></div>',
+		css: '\n\t\t\t\t.green {\n\t\t\t\t\tcolor: green\n\t\t\t\t}\n\t\t\t'
+	} );
+
+	var css = app.toCSS();
+
+	assert.ok( !~css.indexOf( '.green[data-ractive-css~="{' + app.cssId + '}"], [data-ractive-css~="{' + app.cssId + '}"] .green', '.green selector for ' + app.cssId + ' should NEVER exist' ) );
+
+	app.teardown();
 } );

--- a/test/node-tests/toHTML.js
+++ b/test/node-tests/toHTML.js
@@ -1,6 +1,3 @@
-/*global require, describe, it */
-var Ractive = require( '../../ractive' );
-var assert = require( 'assert' );
 var renderTests = require( './samples/render' );
 var cheerio = require( 'cheerio' );
 
@@ -11,46 +8,6 @@ function normaliseHTML ( html ) {
 function getData ( data ) {
 	return typeof data === 'function' ? data() : deepClone( data );
 }
-
-describe( 'ractive.toHTML()', function () {
-	renderTests.forEach( function ( theTest ) {
-		[ false, true ].forEach( function ( magic ) {
-			it( theTest.name + " (magic: " + magic + ")", function () {
-				var data = getData( theTest.data );
-
-				var ractive = new Ractive({
-					template: theTest.template,
-					data: data,
-					partials: theTest.partials,
-					magic: magic
-				});
-
-				assert.equal( normaliseHTML( ractive.toHTML() ), normaliseHTML( theTest.result ) );
-
-				if ( theTest.new_data ) {
-					data = getData( theTest.new_data );
-
-					ractive.set( data );
-					assert.equal( normaliseHTML( ractive.toHTML() ), normaliseHTML( theTest.new_result ) );
-				}
-
-				// TODO array of data/expected
-
-				ractive.teardown();
-			});
-		});
-	});
-
-	it( 'doctype declarations handle updates (#2679)', function() {
-		// the select triggers an update during bind
-		var template = Ractive.parse('<!DOCTYPE html><html><select value="{{foo}}"><option value="bar">bar</option></select></html>');
-		var r = new Ractive({
-			template: template
-		});
-
-		r.teardown();
-	});
-});
 
 function deepClone ( source ) {
 	if ( !source || typeof source !== 'object' ) {
@@ -71,3 +28,43 @@ function deepClone ( source ) {
 
 	return target;
 }
+
+QUnit.module( 'ractive.toHTML()' );
+
+renderTests.forEach( function ( theTest ) {
+	[ false, true ].forEach( function ( magic ) {
+		QUnit.test( theTest.name + ' (magic: ' + magic + ')', function ( assert ) {
+			var data = getData( theTest.data );
+
+			var ractive = new Ractive({
+				template: theTest.template,
+				data: data,
+				partials: theTest.partials,
+				magic: magic
+			});
+
+			assert.equal( normaliseHTML( ractive.toHTML() ), normaliseHTML( theTest.result ) );
+
+			if ( theTest.new_data ) {
+				data = getData( theTest.new_data );
+
+				ractive.set( data );
+				assert.equal( normaliseHTML( ractive.toHTML() ), normaliseHTML( theTest.new_result ) );
+			}
+
+			// TODO array of data/expected
+
+			ractive.teardown();
+		});
+	});
+});
+
+QUnit.test( 'doctype declarations handle updates (#2679)', function() {
+	// the select triggers an update during bind
+	var template = Ractive.parse('<!DOCTYPE html><html><select value="{{foo}}"><option value="bar">bar</option></select></html>');
+	var r = new Ractive({
+		template: template
+	});
+
+	r.teardown();
+});

--- a/test/node-tests/toHTML.js
+++ b/test/node-tests/toHTML.js
@@ -59,12 +59,15 @@ renderTests.forEach( function ( theTest ) {
 	});
 });
 
-QUnit.test( 'doctype declarations handle updates (#2679)', function() {
+QUnit.test( 'doctype declarations handle updates (#2679)', function( assert ) {
 	// the select triggers an update during bind
 	var template = Ractive.parse('<!DOCTYPE html><html><select value="{{foo}}"><option value="bar">bar</option></select></html>');
 	var r = new Ractive({
 		template: template
 	});
+
+	// If the code reached this point, then the lines before it didn't blow up.
+	assert.ok(true);
 
 	r.teardown();
 });


### PR DESCRIPTION
## Description of the pull request:

Convert node tests to QUnit. 

- Less cognitive overhead when writing tests. You need not write tests in two different ways.
- Consistent setup. Similar to the browser, test code can assume QUnit and Ractive are present already.
- The `qunit-cli` module has a very nice colored checklist report format.

I could have gone the other way, write the browser tests in mocha. But QUnit is both runner and assertion lib, API is very consistent between node and browser... and there's lesser node tests to update. 😁 

## Is breaking:

Nope. But it is breaking some tests for some unknown reason.

## ToDo:

- [x] Remove Mocha as dependency.
- [x] Fix broken tests.
- [x] Update node tests to QUnit.
- [x] Replace Mocha with QUnit.
- [x] Suppress Ractive error logging when running tests (probably just turning off debug mode).

## Reviewers:

Anyone curious. 
