### PR TITLE
Add support for spread arrays and objects and merge with call spreads - RFC - 0.9

### DIFF
--- a/src/parse/converters/expressions/primary/literal/readArrayLiteral.js
+++ b/src/parse/converters/expressions/primary/literal/readArrayLiteral.js
@@ -14,7 +14,7 @@ export default function ( parser ) {
 		return null;
 	}
 
-	expressionList = readExpressionList( parser );
+	expressionList = readExpressionList( parser, true );
 
 	if ( !parser.matchString( ']' ) ) {
 		parser.pos = start;

--- a/src/parse/converters/expressions/primary/readReference.js
+++ b/src/parse/converters/expressions/primary/readReference.js
@@ -15,10 +15,9 @@ const legalReference = /^(?:[a-zA-Z$_0-9]|\\\.)+(?:(?:\.(?:[a-zA-Z$_0-9]|\\\.)+)
 const relaxedName = /^[a-zA-Z_$][-\/a-zA-Z_$0-9]*/;
 const specials = /^@(?:keypath|rootpath|index|key|this|global)/;
 const specialCall = /^\s*\(/;
-const spreadPattern = /^\s*\.{3}/;
 
 export default function readReference ( parser ) {
-	var startPos, prefix, name, global, reference, fullLength, lastDotIndex, spread;
+	var startPos, prefix, name, global, reference, fullLength, lastDotIndex;
 
 	startPos = parser.pos;
 
@@ -35,8 +34,6 @@ export default function readReference ( parser ) {
 			name += `(${ref.n})`;
 		}
 	}
-
-	spread = !name && parser.spreadArgs && parser.matchPattern( spreadPattern );
 
 	if ( !name ) {
 		prefix = parser.matchPattern( prefixPattern ) || '';
@@ -69,11 +66,11 @@ export default function readReference ( parser ) {
 
 		return {
 			t: GLOBAL,
-			v: ( spread ? '...' : '' ) + global
+			v: global
 		};
 	}
 
-	fullLength = ( spread ? 3 : 0 ) + ( prefix || '' ).length + name.length;
+	fullLength = ( prefix || '' ).length + name.length;
 	reference = ( prefix || '' ) + normalise( name );
 
 	if ( parser.matchString( '(' ) ) {
@@ -93,6 +90,6 @@ export default function readReference ( parser ) {
 
 	return {
 		t: REFERENCE,
-		n: ( spread ? '...' : '' ) + reference.replace( /^this\./, './' ).replace( /^this$/, '.' )
+		n: reference.replace( /^this\./, './' ).replace( /^this$/, '.' )
 	};
 }

--- a/src/parse/converters/expressions/readMemberOrInvocation.js
+++ b/src/parse/converters/expressions/readMemberOrInvocation.js
@@ -21,10 +21,7 @@ export default function ( parser ) {
 
 		else if ( parser.matchString( '(' ) ) {
 			parser.allowWhitespace();
-			let start = parser.spreadArgs;
-			parser.spreadArgs = true;
-			const expressionList = readExpressionList( parser );
-			parser.spreadArgs = start;
+			const expressionList = readExpressionList( parser, true );
 
 			parser.allowWhitespace();
 

--- a/src/parse/converters/expressions/shared/patterns.js
+++ b/src/parse/converters/expressions/shared/patterns.js
@@ -1,1 +1,2 @@
-export var name = /^[a-zA-Z_$][a-zA-Z_$0-9]*/;
+export const name = /^[a-zA-Z_$][a-zA-Z_$0-9]*/;
+export const spreadPattern = /^\s*\.{3}/;

--- a/test/__support/js/samples/parse.js
+++ b/test/__support/js/samples/parse.js
@@ -879,7 +879,28 @@ const parseTests = [
 		name: 'expression with multiple numeric refinement alt #2325',
 		template: '{{foo[0].bar[10].baz["12"].bat()}}',
 		parsed: {v:4,t:[{t:2,x:{r:["foo.0.bar.10.baz"],s:"_0[\"12\"].bat()"}}]}
+	},
+	{
+		name: 'expression with array spread',
+		template: '{{[foo, bar, ...baz, bat, bip, ...bop, boop, bar]}}',
+		parsed: {v:4,t:[{t:2,x:{r:["foo","baz","bat","bip","bop","boop","bar"],s:"[].concat([_0,_6],_1,[_2,_3],_4,[_5,_6])"}}]}
+	},
+	{
+		name: 'expression with object spread',
+		template: '{{ { foo: "bar", baz: 10 + ref, ...bat, bip: "bop" } }}',
+		parsed: {v:4,t:[{t:2,x:{r:["ref","bat"],s:'Object.assign({},{foo:"bar",baz:10+_0},_1,{bip:"bop"})'}}]}
+	},
+	{
+		name: 'expression with spread args',
+		template: '{{ foo.bar.baz(baz, bat, ...bip, bop, ...boop) }}',
+		parsed: {v:4,t:[{t:2,x:{r:["foo.bar","baz","bat","bip","bop","boop"],s:'(function(){var x$0;return((x$0=_0.baz).apply(x$0,[].concat([_1,_2],_3,[_4],_5)));})()'}}]}
+	},
+	{
+		name: 'various spreads mixed',
+		template: '{{ foo( qux, ...[ bar, ...baz, { bat: 1, bip: 2, ...bop, ...zip( fizz, ...fuzz ), ...{ why: not } }, boop ] ) }}',
+		parsed: {v:4,t:[{t:2,x:{r:['foo','qux','bar','baz','bop','zip','fizz','fuzz','not','boop'],s:'(function(){var x$1,x$0;return((x$0=_0).apply(x$0,[].concat([_1],[].concat([_2],_3,[Object.assign({},{bat:1,bip:2},_4,(x$1=_5).apply(x$1,[].concat([_6],_7)),{why:_8}),_9]))));})()'}}]}
 	}
+
 ];
 
 export default parseTests;

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -1038,4 +1038,36 @@ export default function() {
 		expected = 'foogoof';
 		r.set( 'bar', 'goof' );
 	});
+
+	// phantom just doesn't execute this test... no error, just nothing
+	// even >>> log messages don't come out. passes chrome and ff, though
+	if ( !/phantom/i.test( navigator.userAgent ) ) {
+		test( `various spread expressions compute correctly`, t => {
+			const r = new Ractive({
+				el: fixture,
+				template: `{{ JSON.stringify([ foo, bar, ...baz, ...bat( { bip, bop: 42, ...whimmy.wham( ...[ zat, wozzle, ...qux, bar ], zip ), bif: 84 } ), bar, foo ]) }}`,
+				data: {
+					foo: 1,
+					bar: 2,
+					baz: [ 'a', 'b', 'c' ],
+					bat ( obj ) { return [ obj, 123 ]; },
+					bip: 99,
+					whimmy: {
+						wham ( ...args ) {
+							return args.slice(2).reduce( ( a, c, i ) => {
+								a[ i + 'a' ] = c;
+								return a;
+							}, {} );
+						}
+					},
+					zat: true,
+					wozzle: false,
+					qux: [ 'z', 26, 'y', 25 ],
+					zip: 'zip'
+				}
+			});
+
+			t.htmlEqual( fixture.innerHTML, `[1,2,"a","b","c",{"bip":99,"bop":42,"0a":"z","1a":26,"2a":"y","3a":25,"4a":2,"5a":"zip","bif":84},123,2,1]` );
+		});
+	}
 }


### PR DESCRIPTION
## Description of the pull request:
In the process of working on the tutorial site, I had the desire to have an options object for a decorator that included the keys from another object. Of course, you can already do that with `Object.assign` where available, but the es201x syntax is so much better: `{ foo: 'bar', baz: 'bat', ...someObj, ...otherObj }` === `Object.assign( {}, { foo: 'bar', baz: 'bat' }, someObj, otherObj )`. (_Note_: the empty first object is only there for equivalence to transpiled code - it's not strictly necessary) We already support spread args for calls, but not lists and objects. I also needed a break from docs.

This adds support for spread arrays `[ foo, bar, ...baz, bat, bip, ...bop ]`, spread objects from above, and simplifies the spread arguments code a bit by using the spread array helpers. All of these are nestable, and spreads can now apply to expressions here as well as the existing support for references, so you can `[ foo, ...bar.baz( why, ...not ) ]`. Array spreads are converted to a concat on an empty array `[].concat([foo, bar], baz, [bat, bip], bop)`. Argument spreads are still handled with an IIFE so that the function can be called with the correct context.

This does add about 1k to the compiled codebase and about 350b to the minified code. I've been trying to slim down the code a bit, so I thought I'd ask for opinions on whether es201x features that make sense are worth the extra weight. What say you Ractive users who watch the issue tracker?

## Fixes the following issues:
Not all of es201x that could be supported is supported. :smile:

## Is breaking:
Don't think so.

## Reviewers:
Yes please.