### PR TITLE
Don't hang internal use properties off of adaptor objects - #2714

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '6'
   - '5'
   - '4'
-script: set -e; mkdir -p build; npm run build; if [[ $(node --version) == v6* ]]; then npm run coveralls; chmod u+x scripts/deploy-edge-to-cdn.sh; ./scripts/deploy-edge-to-cdn.sh; fi
+script: set -e; mkdir -p build; npm run build; if [[ $(node --version) == v6* ]]; then npm run coveralls; fi
 env:
   global:
   - GH_REF: github.com/ractivejs/ractive.git
@@ -12,5 +12,5 @@ env:
   - secure: "nlnXJW/imf/w6qdTd7UCpRqLhLioxU6fllJPbP1DZr/9rp44HNVSPNxxGrA808VDXQ1ccpXBxIV9mgIi4Q/G0FUILA5NsSGYdQE00A+Lw3qnvv5FQ7Qoux44BKYi4L1W+4Zi3NEr7TAL+/dHCAk5k/ZKLTCCxiziAEw3M+akE4A="
 branches:
   only:
-    - master
+    - v0.8
     - dev

--- a/scripts/edge-release.sh
+++ b/scripts/edge-release.sh
@@ -1,12 +1,26 @@
 #!/bin/sh
 VERSION=$(cat package.json | grep "version" | sed 's/"version": "\(.*\)",/\1/' | sed 's/[[:space:]]//g')
+VERSION_NUM=$(echo $VERSION | sed 's/[^0-9\./\]//g')
 
-# make sure there is a build suffix on the version
-echo $VERSION | grep -- "-build-"
-if [ $? -ne 0 ]; then
-	echo "uh oh, you it looks like you haven't updated the package.json version number"
-	exit 2
+# find the last published build number for this series
+LAST=$(npm show ractive versions | grep "${VERSION_NUM}-build-" | tail -n 1 | grep "${VERSION_NUM}-build-")
+if [ $? -eq 0 ]; then
+	LAST=$(echo $LAST | sed 's/.*-build-\([0-9]*\).*/\1/')
+else
+	LAST=0
 fi
+LAST=$((LAST + 1))
+
+TARGET="${VERSION_NUM}-build-${LAST}"
+
+if [ -z $TAG ]; then
+	TAG='edge'
+fi
+
+echo
+printf "publishing $TARGET as tag $TAG, so if you want to cancel, you have 3 seconds"
+sleep 1; printf .; sleep 1; printf .; sleep 1; printf .
+echo
 
 # if anything fails, abort (errexit)
 set -e
@@ -20,8 +34,10 @@ set -e
 echo '> publishing to npm...'
 
 ( cd build
+	# set the correct package version
+	node -e "var package = JSON.parse(fs.readFileSync('./package.json')); package.version = '${TARGET}'; fs.writeFileSync('./package.json', JSON.stringify(package, null, '  '));"
 	# ...and to npm
-	npm publish --tag edge
+	npm publish --tag $TAG
 )
 
 echo '> release complete'

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -77,12 +77,12 @@ export default class Computation extends Model {
 		if ( this.dirty ) {
 			this.dirty = false;
 			this.value = this.getValue();
-			if ( this.wrapper ) this.wrapper.newValue = this.value;
+			if ( this.wrapper ) this.newWrapperValue = this.value;
 			this.adapt();
 		}
 
 		// if capturing, this value needs to be unwrapped because it's for external use
-		return shouldCapture && this.wrapper ? this.wrapper.value : this.value;
+		return shouldCapture && this.wrapper ? this.wrapperValue : this.value;
 	}
 
 	getValue () {

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -36,7 +36,7 @@ export default class Model extends ModelBase {
 		// Exit early if no adaptors
 		if ( len === 0 ) return;
 
-		const value = this.wrapper ? ( 'newValue' in this.wrapper ? this.wrapper.newValue : this.wrapper.value ) : this.value;
+		const value = this.wrapper ? ( 'newWrapperValue' in this ? this.newWrapperValue : this.wrapperValue ) : this.value;
 
 		// TODO remove this legacy nonsense
 		const ractive = this.root.ractive;
@@ -44,7 +44,7 @@ export default class Model extends ModelBase {
 
 		// tear previous adaptor down if present
 		if ( this.wrapper ) {
-			const shouldTeardown = this.wrapper.value === value ? false : !this.wrapper.reset || this.wrapper.reset( value ) === false;
+			const shouldTeardown = this.wrapperValue === value ? false : !this.wrapper.reset || this.wrapper.reset( value ) === false;
 
 			if ( shouldTeardown ) {
 				this.wrapper.teardown();
@@ -56,8 +56,8 @@ export default class Model extends ModelBase {
 					if ( parentValue[ this.key ] !== value ) parentValue[ this.key ] = value;
 				}
 			} else {
-				delete this.wrapper.newValue;
-				this.wrapper.value = value;
+				delete this.newWrapperValue;
+				this.wrapperValue = value;
 				this.value = this.wrapper.get();
 				return;
 			}
@@ -69,7 +69,7 @@ export default class Model extends ModelBase {
 			const adaptor = adaptors[i];
 			if ( adaptor.filter( value, keypath, ractive ) ) {
 				this.wrapper = adaptor.wrap( ractive, value, keypath, getPrefixer( keypath ) );
-				this.wrapper.value = value;
+				this.wrapperValue = value;
 				this.wrapper.__model = this; // massive temporary hack to enable array adaptor
 
 				this.value = this.wrapper.get();
@@ -117,10 +117,10 @@ export default class Model extends ModelBase {
 			this.parent.value = this.parent.wrapper.get();
 
 			this.value = this.parent.value[ this.key ];
-			if ( this.wrapper ) this.wrapper.newValue = this.value;
+			if ( this.wrapper ) this.newWrapperValue = this.value;
 			this.adapt();
 		} else if ( this.wrapper ) {
-			this.wrapper.newValue = value;
+			this.newWrapperValue = value;
 			this.adapt();
 		} else {
 			const parentValue = this.parent.value || this.parent.createBranch( this.key );
@@ -158,7 +158,7 @@ export default class Model extends ModelBase {
 		if ( shouldCapture ) capture( this );
 		// if capturing, this value needs to be unwrapped because it's for external use
 		if ( opts && opts.virtual ) return this.getVirtual( false );
-		return ( shouldCapture || ( opts && opts.unwrap ) ) && this.wrapper ? this.wrapper.value : this.value;
+		return ( shouldCapture || ( opts && opts.unwrap ) ) && this.wrapper ? this.wrapperValue : this.value;
 	}
 
 	getKeypathModel ( ractive ) {
@@ -196,7 +196,7 @@ export default class Model extends ModelBase {
 
 			// make sure the wrapper stays in sync
 			if ( old !== value || this.rewrap ) {
-				if ( this.wrapper ) this.wrapper.newValue = value;
+				if ( this.wrapper ) this.newWrapperValue = value;
 				this.adapt();
 			}
 

--- a/src/view/helpers/processItems.js
+++ b/src/view/helpers/processItems.js
@@ -22,7 +22,7 @@ export default function processItems ( items, values, guid, counter = 0 ) {
 
 		values[ placeholderId ] = model ?
 			model.wrapper ?
-				model.wrapper.value :
+				model.wrapperValue :
 				model.get() :
 			undefined;
 

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -155,7 +155,7 @@ export default class EventDirective {
 					}
 
 					if ( model.wrapper ) {
-						return values.push( model.wrapper.value );
+						return values.push( model.wrapperValue );
 					}
 
 					values.push( model.get() );

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -64,11 +64,11 @@ export default class ExpressionProxy extends Model {
 		if ( this.dirty ) {
 			this.dirty = false;
 			this.value = this.getValue();
-			if ( this.wrapper ) this.wrapper.newValue = this.value;
+			if ( this.wrapper ) this.newWrapperValue = this.value;
 			this.adapt();
 		}
 
-		return shouldCapture && this.wrapper ? this.wrapper.value : this.value;
+		return shouldCapture && this.wrapper ? this.wrapperValue : this.value;
 	}
 
 	getKeypath () {


### PR DESCRIPTION
## Description of the pull request:
This moves internal tracking of adaptor values from `this.wrapper.value` to `this.wrapperValue` and `this.wrapper.newValue` to `this.newWrapperValue`. I _think_ this will fix the issues with the backbone adaptor, and we probably shouldn't be doing stuff like that anyway.

This also stops edge deployment through surge. I'm hoping to get automated npm deployment set up soon. There's a helper script that I'll test out with this build to see if automated build publishing will work once I figure out how to safely include an npm auth token.

## Fixes the following issues:
_Hopefully_ #2714

## Is breaking:
No