### PR TITLE
Add clean script, because it's handy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "url": "https://github.com/ractivejs/ractive.git"
   },
   "scripts": {
+    "clean": "rm -rfv .gobble .gobble-build build tmp",
     "test": "sh ./scripts/test.sh",
     "start": "node_modules/.bin/gobble",
     "build": "sh ./scripts/build.sh",


### PR DESCRIPTION
## Description of the pull request:

Adds a clean script in npm removing `.gobble`, `.gobble-build`, `build` and `tmp`.

## Is breaking:

No

## Reviewers:

Yes, if you want to add anything or tell me I'm just lazy. 😄 


