### PR TITLE
Binding and/or mutation of children of computations - take two - RFC

### DIFF
--- a/src/Ractive/config/defaults.js
+++ b/src/Ractive/config/defaults.js
@@ -21,6 +21,7 @@ export default {
 	// data & binding:
 	data:                   {},
 	computed:               {},
+	syncComputedChildren:   false,
 	magic:                  false,
 	modifyArrays:           false,
 	adapt:                  [],

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -118,27 +118,6 @@ export default class Computation extends Model {
 		return result;
 	}
 
-	handleChange () {
-		this.dirty = true;
-
-		this.links.forEach( marked );
-		this.deps.forEach( handleChange );
-		this.children.forEach( handleChange );
-		this.clearUnresolveds(); // TODO same question as on Model - necessary for primitives?
-	}
-
-	joinKey ( key ) {
-		if ( key === undefined || key === '' ) return this;
-
-		if ( !this.childByKey.hasOwnProperty( key ) ) {
-			const child = new ComputationChild( this, key );
-			this.children.push( child );
-			this.childByKey[ key ] = child;
-		}
-
-		return this.childByKey[ key ];
-	}
-
 	mark () {
 		this.handleChange();
 	}
@@ -149,7 +128,7 @@ export default class Computation extends Model {
 	}
 
 	set ( value ) {
-		if ( !this.signature.setter ) {
+		if ( this.isReadonly ) {
 			throw new Error( `Cannot set read-only computed value '${this.key}'` );
 		}
 
@@ -183,10 +162,9 @@ export default class Computation extends Model {
 		if ( this.root.computations[this.key] === this ) delete this.root.computations[this.key];
 		super.teardown();
 	}
-
-	unregister ( dependent ) {
-		super.unregister( dependent );
-		// tear down expressions with no deps, because they will be replaced when needed
-		if ( this.isExpression && this.deps.length === 0 ) this.teardown();
-	}
 }
+
+const prototype = Computation.prototype;
+const child = ComputationChild.prototype;
+prototype.handleChange = child.handleChange;
+prototype.joinKey = child.joinKey;

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -1,4 +1,5 @@
 import Model from '../../model/Model';
+import Computation from '../../model/Computation';
 import ComputationChild from '../../model/ComputationChild';
 import { handleChange, marked, unbind } from '../../shared/methodCallers';
 import getFunction from '../../shared/getFunction';
@@ -52,22 +53,8 @@ export default class ExpressionProxy extends Model {
 		this.keypath = undefined;
 
 		if ( actuallyChanged ) {
-			this.dirty = true;
 			this.handleChange();
 		}
-	}
-
-	get ( shouldCapture ) {
-		if ( shouldCapture ) capture( this );
-
-		if ( this.dirty ) {
-			this.dirty = false;
-			this.value = this.getValue();
-			if ( this.wrapper ) this.newWrapperValue = this.value;
-			this.adapt();
-		}
-
-		return shouldCapture && this.wrapper ? this.wrapperValue : this.value;
 	}
 
 	getKeypath () {
@@ -110,32 +97,6 @@ export default class ExpressionProxy extends Model {
 		return result;
 	}
 
-	handleChange () {
-		this.dirty = true;
-
-		this.links.forEach( marked );
-		this.deps.forEach( handleChange );
-		this.children.forEach( handleChange );
-
-		this.clearUnresolveds();
-	}
-
-	joinKey ( key ) {
-		if ( key === undefined || key === '' ) return this;
-
-		if ( !this.childByKey.hasOwnProperty( key ) ) {
-			const child = new ComputationChild( this, key );
-			this.children.push( child );
-			this.childByKey[ key ] = child;
-		}
-
-		return this.childByKey[ key ];
-	}
-
-	mark () {
-		this.handleChange();
-	}
-
 	rebinding ( next, previous, safe ) {
 		const idx = this.models.indexOf( previous );
 
@@ -171,3 +132,10 @@ export default class ExpressionProxy extends Model {
 		this.resolvers.forEach( unbind );
 	}
 }
+
+const prototype = ExpressionProxy.prototype;
+const computation = Computation.prototype;
+prototype.get = computation.get;
+prototype.handleChange = computation.handleChange;
+prototype.joinKey = computation.joinKey;
+prototype.mark = computation.mark;

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -1039,6 +1039,37 @@ export default function() {
 		r.set( 'bar', 'goof' );
 	});
 
+	test( `computations can have child values set when allowed`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: `
+				{{#each foo}}<i>{{.a}}</i>{{/each}}
+				{{#each foos()}}<i>{{.a}}</i>{{/each}}
+				{{#each list}}<i>{{.a}}</i>{{/each}}
+			`,
+			data: {
+				list: [ { a: 1 } ],
+				foos() { return this.get( 'list' ); }
+			},
+			computed: {
+				foo: {
+					get() { return this.get( 'list' ); }
+				}
+			},
+			syncComputedChildren: true
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<i>1</i><i>1</i><i>1</i>' );
+
+		const [ c, e ] = r.findAll( 'i' ).map( r.getNodeInfo );
+
+		c.set( '.a', 2 );
+		t.htmlEqual( fixture.innerHTML, '<i>2</i><i>2</i><i>2</i>' );
+
+		e.set( '.a', 3 );
+		t.htmlEqual( fixture.innerHTML, '<i>3</i><i>3</i><i>3</i>' );
+	});
+
 	// phantom just doesn't execute this test... no error, just nothing
 	// even >>> log messages don't come out. passes chrome and ff, though
 	if ( !/phantom/i.test( navigator.userAgent ) ) {

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -1072,123 +1072,123 @@ export default function() {
 	test( 'textarea with a single interpolator as content should set up a twoway binding (#2197)', t => {
 		const r = new Ractive({
 			el: fixture,
-				template: '<textarea>{{foo}}</textarea>',
-				data: { foo: 'bar' }
-				});
+			template: '<textarea>{{foo}}</textarea>',
+			data: { foo: 'bar' }
+		});
 
-				t.equal( r.find( 'textarea' ).value, 'bar' );
-				r.set( 'foo', 'baz' );
-				t.equal( r.find( 'textarea' ).value, 'baz' );
-				r.find( 'textarea' ).value = 'bop';
-				r.updateModel( 'foo' );
-				t.equal( r.get( 'foo' ), 'bop' );
-				});
+		t.equal( r.find( 'textarea' ).value, 'bar' );
+		r.set( 'foo', 'baz' );
+		t.equal( r.find( 'textarea' ).value, 'baz' );
+		r.find( 'textarea' ).value = 'bop';
+		r.updateModel( 'foo' );
+		t.equal( r.get( 'foo' ), 'bop' );
+	});
 
-				test( 'conditional twoway should apply/unapply correctly', t => {
-				const r = new Ractive({
-				el: fixture,
-				template: `<input value="{{foo}}" {{#if twoway}}twoway{{/if}} /><span>{{foo}}</span>`,
-				data: { twoway: false },
-				twoway: false
-				});
+	test( 'conditional twoway should apply/unapply correctly', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `<input value="{{foo}}" {{#if twoway}}twoway{{/if}} /><span>{{foo}}</span>`,
+			data: { twoway: false },
+			twoway: false
+		});
 
-				const [ input, span ] = r.findAll( '*' );
+		const [ input, span ] = r.findAll( '*' );
 
-				r.set( 'foo', 'test' );
-				t.equal( input.value, 'test' );
+		r.set( 'foo', 'test' );
+		t.equal( input.value, 'test' );
 
-				input.value = 'foo';
-				fire( input, 'input' );
-				t.equal( span.innerHTML, 'test' );
+		input.value = 'foo';
+		fire( input, 'input' );
+		t.equal( span.innerHTML, 'test' );
 
-				r.set( 'twoway', true );
-				input.value = 'bar';
-				fire( input, 'input' );
-				t.equal( span.innerHTML, 'bar' );
-				});
+		r.set( 'twoway', true );
+		input.value = 'bar';
+		fire( input, 'input' );
+		t.equal( span.innerHTML, 'bar' );
+	});
 
-				test( 'bound twoway should apply/unapply correctly', t => {
-				const r = new Ractive({
-				el: fixture,
-				template: `<input value="{{foo}}" twoway="{{#if twoway}}true{{else}}false{{/if}}" /><span>{{foo}}</span>`,
-				data: { twoway: false },
-				twoway: false
-				});
+	test( 'bound twoway should apply/unapply correctly', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `<input value="{{foo}}" twoway="{{#if twoway}}true{{else}}false{{/if}}" /><span>{{foo}}</span>`,
+			data: { twoway: false },
+			twoway: false
+		});
 
-				const [ input, span ] = r.findAll( '*' );
+		const [ input, span ] = r.findAll( '*' );
 
-				r.set( 'foo', 'test' );
-				t.equal( input.value, 'test' );
+		r.set( 'foo', 'test' );
+		t.equal( input.value, 'test' );
 
-				input.value = 'foo';
-				fire( input, 'input' );
-				t.equal( span.innerHTML, 'test' );
+		input.value = 'foo';
+		fire( input, 'input' );
+		t.equal( span.innerHTML, 'test' );
 
-				r.set( 'twoway', true );
-				input.value = 'bar';
-				fire( input, 'input' );
-				t.equal( span.innerHTML, 'bar' );
-				});
+		r.set( 'twoway', true );
+		input.value = 'bar';
+		fire( input, 'input' );
+		t.equal( span.innerHTML, 'bar' );
+	});
 
-				test( 'conditional lazy should apply/unapply correctly', t => {
-				const r = new Ractive({
-				el: fixture,
-				template: `<input value="{{foo}}" {{#if lazy}}lazy{{/if}} /><span>{{foo}}</span>`,
-				data: { lazy: false },
-				lazy: false
-				});
+	test( 'conditional lazy should apply/unapply correctly', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `<input value="{{foo}}" {{#if lazy}}lazy{{/if}} /><span>{{foo}}</span>`,
+			data: { lazy: false },
+			lazy: false
+		});
 
-				const [ input, span ] = r.findAll( '*' );
+		const [ input, span ] = r.findAll( '*' );
 
-				r.set( 'foo', 'test' );
-				t.equal( input.value, 'test' );
+		r.set( 'foo', 'test' );
+		t.equal( input.value, 'test' );
 
-				input.value = 'foo';
-				fire( input, 'input' );
-				t.equal( span.innerHTML, 'foo' );
+		input.value = 'foo';
+		fire( input, 'input' );
+		t.equal( span.innerHTML, 'foo' );
 
-				r.set( 'lazy', true );
-				input.value = 'bar';
-				fire( input, 'input' );
-				t.equal( span.innerHTML, 'foo' );
+		r.set( 'lazy', true );
+		input.value = 'bar';
+		fire( input, 'input' );
+		t.equal( span.innerHTML, 'foo' );
 
-				try {
-				fire( input, 'blur' );
-				t.equal( span.innerHTML, 'bar' );
-				} catch ( err ) {
-				t.ok( true ); // phantom...
-				}
-				});
+		try {
+			fire( input, 'blur' );
+			t.equal( span.innerHTML, 'bar' );
+		} catch ( err ) {
+			t.ok( true ); // phantom...
+		}
+	});
 
-				test( 'bound lazy should apply/unapply correctly', t => {
-				const r = new Ractive({
-				el: fixture,
-				template: `<input value="{{foo}}" lazy="{{#if lazy}}true{{else}}false{{/if}}" /><span>{{foo}}</span>`,
-				data: { lazy: false },
-				lazy: false
-				});
+	test( 'bound lazy should apply/unapply correctly', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `<input value="{{foo}}" lazy="{{#if lazy}}true{{else}}false{{/if}}" /><span>{{foo}}</span>`,
+			data: { lazy: false },
+			lazy: false
+		});
 
-				const [ input, span ] = r.findAll( '*' );
+		const [ input, span ] = r.findAll( '*' );
 
-				r.set( 'foo', 'test' );
-				t.equal( input.value, 'test' );
+		r.set( 'foo', 'test' );
+		t.equal( input.value, 'test' );
 
-				input.value = 'foo';
-				fire( input, 'input' );
-				t.equal( span.innerHTML, 'foo' );
+		input.value = 'foo';
+		fire( input, 'input' );
+		t.equal( span.innerHTML, 'foo' );
 
-				r.set( 'lazy', true );
-				input.value = 'bar';
-				fire( input, 'input' );
-				t.equal( span.innerHTML, 'foo' );
+		r.set( 'lazy', true );
+		input.value = 'bar';
+		fire( input, 'input' );
+		t.equal( span.innerHTML, 'foo' );
 
-				try {
-				fire( input, 'blur' );
-				t.equal( span.innerHTML, 'bar' );
-				} catch ( err ) {
-				t.ok( true ); // phantom...
-				}
-				});
+		try {
+			fire( input, 'blur' );
+			t.equal( span.innerHTML, 'bar' );
+		} catch ( err ) {
+			t.ok( true ); // phantom...
+		}
+	});
 
 	test( 'textarea with a single static interpolator as content should not set up a twoway binding', t => {
 		const r = new Ractive({
@@ -1203,6 +1203,103 @@ export default function() {
 		r.find( 'textarea' ).value = 'bop';
 		r.updateModel( 'foo' );
 		t.equal( r.get( 'foo' ), 'baz' );
+	});
+
+	test( 'ComputationChild will allow bindings if requested', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each some.expr()}}<div>{{.val}}</div><input value="{{.val}}" />{{/each}}`,
+			data: {
+				array: [ { val: 'a' } ]
+			},
+			syncComputedChildren: true
+		});
+		r.set( 'some.expr', function() { return r.get('array'); } );
+
+		const input = r.find( 'input' );
+		const label = r.find( 'div' );
+
+		t.equal( label.innerHTML, 'a' );
+		input.value = 'test1';
+		fire( input, 'change' );
+		t.equal( label.innerHTML, 'test1' );
+	});
+
+	test( 'ComputationChild bindings also notify other interested parties when changed', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#each some.expr()}}<input value="{{.val}}" />{{/each}}<div>{{'yep' + JSON.stringify(some.expr())}}</div>`,
+			data: {
+				array: [ { val: 'a' } ]
+			},
+			syncComputedChildren: true
+		});
+		r.set( 'some.expr', function() { return r.get('array'); } );
+
+		const input = r.find( 'input' );
+		const label = r.find( 'div' );
+
+		t.equal( label.innerHTML, 'yep[{"val":"a"}]' );
+		input.value = 'test1';
+		fire( input, 'change' );
+		t.equal( label.innerHTML, 'yep[{"val":"test1"}]' );
+	});
+
+	test( 'ComputationChild name bindings work for checkboxes', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#with foos()}}<input type="checkbox" name="{{.array}}" value="{{+1}}" /><input type="checkbox" name="{{.array}}" value="{{+2}}" />{{/with}}`,
+			data: {
+				foo: { array: [ 1, 2 ] }
+			},
+			syncComputedChildren: true
+		});
+
+		r.set( 'foos',function() { return r.get( 'foo' ); });
+
+		const [ check1, check2 ] = r.findAll( 'input' );
+
+		t.equal( check1.checked, true );
+		t.equal( check2.checked, true );
+
+		r.set( 'foo.array', [] );
+
+		t.equal( check1.checked, false );
+		t.equal( check2.checked, false );
+
+		fire( check1, 'click' );
+		fire( check2, 'click' );
+
+		t.equal( r.get( 'foo.array.0' ), 1 );
+		t.equal( r.get( 'foo.array.1' ), 2 );
+	});
+
+	test( 'ComputationChild name bindings work for radio buttons', t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `{{#with foos()}}<input type="radio" name="{{.value}}" value="{{+1}}" /><input type="radio" name="{{.value}}" value="{{+2}}" />{{/with}}`,
+			data: {
+				foo: { value: 1 },
+				foos () { return this.get( 'foo' ); }
+			},
+			syncComputedChildren: true
+		});
+
+		const [ radio1, radio2 ] = r.findAll( 'input' );
+
+		t.equal( radio1.checked, true );
+		t.equal( radio2.checked, false );
+
+		r.set( 'foo.value', 2 );
+
+		t.equal( radio1.checked, false );
+		t.equal( radio2.checked, true );
+
+		fire( radio1, 'click' );
+		t.equal( r.get( 'foo.value' ), 1 );
+
+		fire( radio2, 'click' );
+		t.equal( r.get( 'foo.value' ), 2 );
 	});
 
 	test( 'textareas with non-model context should still bind correctly (#2099)', t => {


### PR DESCRIPTION
## Description of the pull request:

This is a port of #2331 to edge. It actually takes less code now :smile:

**Definition**: For this PR, "computed" means a value that isn't directly in data, so any `computed` entries from instance init and any expression in the template.

Starting with 0.8, binding/setting in children of computed values e.g. `<input value="{{computed.some.child}}" />` was disallowed because it can cause references outside of the computation to get out of sync with their model. See #2123 for more details.

This introduces a new flag `syncComputedChildren`, which defaults to false, that sets up children of computed paths to be mutable. When a child mutates, it causes an updated on all of the computation's dependencies, which makes sure any other references outside of the computation stay in sync. That should cover the most common use-cases for child mutation, like binding fields on objects in a filtered list to inputs and having the change propagate anywhere else the objects are bound.

I changed the name from `derivedBindings` to `syncComputedChildren` because, to me, it is a bit easier to suss out what the flag means/will do.

The reason the flag is defaulted to false is if you're not careful, you can murder the performance of your app by causing a ton of unnecessary cascade updates.
### Bonus

I also DRYed up some of the computation code. ExpressionProxy, Computation, and ComputationChild now use the same function from the appropriate prototype instead of having the same code duplicated.

I also added value caching to ComputationChild, so that they don't _always_ ask for values all the way up to the computation for _every_ access. This should make complex computed structures a bit faster.
## Fixes the following issues:

#2123

## Is breaking:

Nope
