### PR TITLE
Inherit parent adaptors when initializing a component - #2723

### DIFF
--- a/src/Ractive/static/adaptors/array/patch.js
+++ b/src/Ractive/static/adaptors/array/patch.js
@@ -36,7 +36,8 @@ mutatorMethods.forEach( methodName => {
 	};
 
 	defineProperty( patchedArrayProto, methodName, {
-		value: method
+		value: method,
+		configurable: true
 	});
 });
 


### PR DESCRIPTION
## Description of the pull request:
This checks for a parent instance during config, and if there is one, copies its adaptors to the end of the instance adaptor list. Apparently this changed some time between 0.7 and 0.8. This is my first foray into the construct code, so I'm not positive this is the best way to handle this.

There's also some question as to whether or not components should inherit their parent's adaptors. I think it makes sense for an app that's working with special data to have the component be able to work with it as well. Mapping aren't affected, since the mapping defers wrapping to the source, but any other setting of data is.

This also makes the prototype overrides on arrays from the builtin array adaptor configurable per #2721.

## Fixes the following issues:
#2723 #2721

## Is breaking:
No?

## Reviewers:
Anyone familiar with adaptors.
