### PR TITLE
Various toHTML-when-not-rendered-to-DOM fixes - #2727

### DIFF
--- a/src/view/items/Triple.js
+++ b/src/view/items/Triple.js
@@ -91,6 +91,9 @@ export default class Triple extends Mustache {
 			const anchor = this.parentFragment.findNextNode( this );
 
 			parentNode.insertBefore( docFrag, anchor );
+		} else {
+			// make sure to reset the dirty flag even if not rendered
+			this.dirty = false;
 		}
 	}
 }

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -6,7 +6,7 @@ import findElement from '../shared/findElement';
 import getUpdateDelegate from './attribute/getUpdateDelegate';
 import propertyNames from './attribute/propertyNames';
 import { isArray } from '../../../utils/is';
-import { safeAttributeString } from '../../../utils/dom';
+import { safeAttributeString, camelize } from '../../../utils/dom';
 import { booleanAttributes } from '../../../utils/html';
 
 function lookupNamespace ( node, prefix ) {
@@ -140,6 +140,16 @@ export default class Attribute extends Item {
 
 		// Special case - style and class attributes and directives
 		if ( this.owner === this.element && ( this.name === 'style' || this.name === 'class' || this.styleName || this.inlineClass ) ) {
+			return;
+		}
+
+		if ( !this.rendered && this.owner === this.element && ( !this.name.indexOf( 'style-' ) || !this.name.indexOf( 'class-' ) ) ) {
+			if ( !this.name.indexOf( 'style-' ) ) {
+				this.styleName = camelize( this.name.substr( 6 ) );
+			} else {
+				this.inlineClass = this.name.substr( 6 );
+			}
+
 			return;
 		}
 

--- a/src/view/items/element/specials/Option.js
+++ b/src/view/items/element/specials/Option.js
@@ -47,7 +47,7 @@ export default class Option extends Element {
 	bubble () {
 		// if we're using content as value, may need to update here
 		let value = this.getAttribute( 'value' );
-		if ( this.node.value !== value ) {
+		if ( this.node && this.node.value !== value ) {
 			this.node._ractive.value = value;
 		}
 		super.bubble();

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -472,13 +472,6 @@ const renderTests = [
 		template: '<p>{{^.foo}}this should appear{{/.foo}}</p>',
 		result: '<p>this should appear</p>'
 	},
-	// TODO: Remove when we don't support non-POJO roots
-	{
-		name: 'Data is an array',
-		template: '{{#.}}<p>{{name}}</p>{{/.}}',
-		data: [{ name: 'Alice' }, { name: 'Bob' }, { name: 'Charles' }],
-		result: '<p>Alice</p><p>Bob</p><p>Charles</p>'
-	},
 	{
 		name: 'Setting child properties of null values creates object',
 		template: '{{foo.bar}}',
@@ -1342,6 +1335,20 @@ const renderTests = [
 		new_data: { obj: { key1: true, key2: true, key3: true } },
 		new_result: 'key1,key1,0key2,key2,1key3,key3,2'
 	},
+	{
+		name: 'class directives',
+		template: '<span class-foo-bar="{{foo}}" class-otherBaz="{{bat === 0}}"></span>',
+		result: '<span></span>',
+		new_data: { foo: true, bat: 0 },
+		new_result: '<span class="foo-bar otherBaz"></span>'
+	},
+	{
+		name: 'style directives',
+		template: `<span style-display="{{ foo ? 'block' : 'inline-block' }}"></span>`,
+		result: '<span style="display: inline-block;"></span>',
+		new_data: { foo: true },
+		new_result: '<span style="display: block;"></span>'
+	}
 ];
 
 function max() { return Math.max.apply(Math, Array.prototype.slice.call(arguments, 0)); }

--- a/test/browser-tests/render/output.js
+++ b/test/browser-tests/render/output.js
@@ -16,38 +16,56 @@ export default function() {
 		if ( theTest.nodeOnly ) return;
 
 		[ false, true ].forEach( magic => {
-			test( `${theTest.name} (magic: ${magic})`, t => { const data = getData( theTest.data );
+			test( `${theTest.name} (magic: ${magic})`, t => {
 
-				// suppress warnings about non-POJOs
-				onWarn( msg => t.ok( /plain JavaScript object/.test( msg ) ) );
+				// suppress warnings about non-POJOs and failed computations
+				onWarn( msg => t.ok( /plain JavaScript object|Failed to compute/.test( msg ) ) );
 
+				// we don't render to an element initially, so we can see what would happen if this was happening server-side with no DOM
 				const ractive = new Ractive({
-					el: fixture,
-					data,
+					data: getData( theTest.data || {} ),
 					template: theTest.template,
 					partials: theTest.partials,
 					debug: true,
 					magic
 				});
 
-				t.htmlEqual( fixture.innerHTML, theTest.result, 'innerHTML should match result' );
-				t.htmlEqual( ractive.toHTML(), theTest.result, 'toHTML() should match result' );
+
+				t.htmlEqual( ractive.toHTML(), theTest.result, 'initial toHTML() should match result' );
 
 				if ( theTest.new_data ) {
-					const data = getData( theTest.new_data );
+					ractive.set( theTest.new_data );
 
-					ractive.set( data );
-
-					t.htmlEqual( fixture.innerHTML, theTest.new_result, 'innerHTML should match result' );
-					t.htmlEqual( ractive.toHTML(), theTest.new_result, 'toHTML() should match result' );
+					t.htmlEqual( ractive.toHTML(), theTest.new_result, 'new toHTML() should match result' );
 				} else if ( theTest.steps && theTest.steps.length ) {
-					theTest.steps.forEach( step => {
-						const data = getData( step.data );
+					theTest.steps.forEach( ( step, i ) => {
+						ractive.set( getData( step.data || {} ) );
 
-						ractive.set( data );
+						t.htmlEqual( ractive.toHTML(), step.result, `step ${i}: ` + ( step.message || 'toHTML() should match result' ) );
+					});
+				}
 
-						t.htmlEqual( fixture.innerHTML, step.result, step.message || 'innerHTML should match result' );
-						t.htmlEqual( ractive.toHTML(), step.result, step.message || 'toHTML() should match result' );
+				// some tests expect certain orderings that only happen when templates are unbound
+				// so we reset to empty and then reload the data before rendering
+				ractive.reset();
+				ractive.reset( getData( theTest.data ) );
+				ractive.render( fixture );
+
+				// we'll also check toHTML again, to make sure it still behaves as expected when rendered
+				t.htmlEqual( fixture.innerHTML, theTest.result, 'initial innerHTML should match result' );
+				t.htmlEqual( ractive.toHTML(), theTest.result, 'initial toHTML() should match result' );
+
+				if ( theTest.new_data ) {
+					ractive.set( theTest.new_data );
+
+					t.htmlEqual( fixture.innerHTML, theTest.new_result, 'new innerHTML should match result' );
+					t.htmlEqual( ractive.toHTML(), theTest.new_result, 'new toHTML() should match result' );
+				} else if ( theTest.steps && theTest.steps.length ) {
+					theTest.steps.forEach( ( step, i ) => {
+						ractive.set( getData( step.data || {} ) );
+
+						t.htmlEqual( fixture.innerHTML, step.result, `step ${i}: ` + ( step.message || 'innerHTML should match result' ) );
+						t.htmlEqual( ractive.toHTML(), step.result, `step ${i}: ` + ( step.message || 'toHTML() should match result' ) );
 					});
 				}
 


### PR DESCRIPTION
## Description of the pull request:

This modifies the render browser tests to run `toHTML` testing before rendering to the DOM to simulate what happens in node. The _main_ reason I did that was to track down the issue in #2727, but it also turned up a handful of other issues with code that expected a DOM environment where it shouldn't.

The issue #2727 is that the updateAttribute handler that is called on render sets up the special `styleName` and `inlineClass` properties on the `Attribute`. If it's never rendered, `Attribute.toString` won't realize that it's a special directive and render itself as a plain old string attribute. This PR adds a check for style- and class- directives and sets them up to be appropriately `toString`ed if they've not been rendered.

This also removes the test involving having an array as root data, as that has been deprecated for quite a while and was interfering with the way the test resets data now.
## Fixes the following issues:
#2727
## Is breaking:

Nope.
