### PR TITLE
re-enable empty object and array in explicit {{#with ...}} sections

### DIFF
--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -87,7 +87,7 @@ export default class Section extends Mustache {
 	isTruthy () {
 		if ( this.subordinate && this.sibling.isTruthy() ) return true;
 		const value = !this.model ? undefined : this.model.isRoot ? this.model.value : this.model.get();
-		return !!value && !isEmpty( value );
+		return !!value && ( this.templateSectionType === SECTION_IF_WITH || !isEmpty( value ) );
 	}
 
 	rebinding ( next, previous, safe ) {
@@ -150,69 +150,35 @@ export default class Section extends Mustache {
 
 		let newFragment;
 
-		if ( this.sectionType === SECTION_EACH ) {
+		const fragmentShouldExist = this.sectionType === SECTION_EACH || // each always gets a fragment, which may have no iterations
+		                            this.sectionType === SECTION_WITH || // with (partial context) always gets a fragment
+		                            ( siblingFalsey && ( this.sectionType === SECTION_UNLESS ? !this.isTruthy() : this.isTruthy() ) ); // if, unless, and if-with depend on siblings and the condition
+
+		if ( fragmentShouldExist ) {
 			if ( this.fragment ) {
 				this.fragment.update();
 			} else {
-				// TODO can this happen?
-				newFragment = new RepeatedFragment({
-					owner: this,
-					template: this.template.f,
-					indexRef: this.template.i
-				}).bind( this.model );
-			}
-		}
-
-		// WITH is now IF_WITH; WITH is only used for {{>partial context}}
-		else if ( this.sectionType === SECTION_WITH ) {
-			if ( this.fragment ) {
-				this.fragment.update();
-			} else {
-				newFragment = new Fragment({
-					owner: this,
-					template: this.template.f
-				}).bind( this.model );
-			}
-		}
-
-		else if ( this.sectionType === SECTION_IF_WITH ) {
-			if ( this.fragment ) {
-				if ( isEmpty( value ) ) {
-					if ( this.rendered ) {
-						this.fragment.unbind().unrender( true );
-					}
-
-					this.fragment = null;
+				if ( this.sectionType === SECTION_EACH ) {
+					newFragment = new RepeatedFragment({
+						owner: this,
+						template: this.template.f,
+						indexRef: this.template.i
+					}).bind( this.model );
 				} else {
-					this.fragment.update();
+	 				// only with and if-with provide context - if and unless do not
+					const context = this.sectionType !== SECTION_IF && this.sectionType !== SECTION_UNLESS ? this.model : null;
+					newFragment = new Fragment({
+						owner: this,
+						template: this.template.f
+					}).bind( context );
 				}
-			} else if ( !isEmpty( value ) ) {
-				newFragment = new Fragment({
-					owner: this,
-					template: this.template.f
-				}).bind( this.model );
 			}
-		}
-
-		else {
-			const fragmentShouldExist = siblingFalsey && ( this.sectionType === SECTION_UNLESS ? isEmpty( value ) : !!value && !isEmpty( value ) );
-
-			if ( this.fragment ) {
-				if ( fragmentShouldExist ) {
-					this.fragment.update();
-				} else {
-					if ( this.rendered ) {
-						this.fragment.unbind().unrender( true );
-					}
-
-					this.fragment = null;
-				}
-			} else if ( fragmentShouldExist ) {
-				newFragment = new Fragment({
-					owner: this,
-					template: this.template.f
-				}).bind( null );
+		} else {
+			if ( this.fragment && this.rendered ) {
+				this.fragment.unbind().unrender( true );
 			}
+
+			this.fragment = null;
 		}
 
 		if ( newFragment ) {

--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -1299,12 +1299,6 @@ const renderTests = [
 		result: '1 42'
 	},
 	{
-		name: '{{#with obj}} doesn\'t render if obj is empty',
-		template: '{{#with obj}}foo{{/with}}',
-		data: { obj: {} },
-		result: ''
-	},
-	{
 		name: '{{#with obj}} doesn\'t render if obj is false/null/undefined',
 		template: '{{#with obj}}foo{{/with}}',
 		result: ''
@@ -1348,6 +1342,44 @@ const renderTests = [
 		result: '<span style="display: inline-block;"></span>',
 		new_data: { foo: true },
 		new_result: '<span style="display: block;"></span>'
+	},
+	{
+		name: `{{#with foo}} renders if foo is {} or [], but not any other form of falsey`,
+		template: '{{#with foo}}yep{{else}}nope{{/with}}',
+		result: 'nope',
+		steps: [
+			{
+				data: { foo: {} },
+				result: 'yep'
+			},
+			{
+				data: { foo: [] },
+				result: 'yep'
+			},
+			{
+				data: { foo: undefined },
+				result: 'nope'
+			}
+		]
+	},
+	{
+		name: `{{#foo}} doesn't render if foo is empty or falsey`,
+		template: '{{#foo}}yep{{else}}nope{{/}}',
+		result: 'nope',
+		steps: [
+			{
+				data: { foo: {} },
+				result: 'nope'
+			},
+			{
+				data: { foo: [] },
+				result: 'nope'
+			},
+			{
+				data: { foo: undefined },
+				result: 'nope'
+			}
+		]
 	}
 ];
 


### PR DESCRIPTION
## Description of the pull request:
This undoes _part_ of the change made in accordance with #1856, namely `{{#with foo}}` where `foo` is `{}` or `[]` seems like it should be a renderable situation. I think empty, non-falsey values should be considered legitimate context, and `with` exists only to add to the context chain. Any other falsey (0, false, null, undefined, '') values will still cause the section not to be rendered.

This is particularly noticeable where you're letting your bindings init state for you  e.g. `{{#with newUser}}<input value="{{.name}}" />{{/with}}`, where `newUser` comes from `ractive.set('newUser', {})`.

This does _not_ change `{{#foo}}`, which still considers `{}` and `[]` to be falsey. Plain old mustaches are a bit more complex, and I think the expected behavior would be more `if`y than `with`y.

Does that sound reasonable?

## Is breaking:
Yes? - the current behavior was introduced with 0.8.

## Reviewers:
@MartinKolarik @martypdx @fskreuz
