### PR TITLE
Warn when event cannot be cancelled due to missing event-object

### DIFF
--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -121,10 +121,9 @@ export default class EventDirective {
 			const result = this.fn.apply( ractive, values ).pop();
 
 			// Auto prevent and stop if return is explicitly false
-			let original;
-
 			if ( result === false ) {
-				if ( event && ( original = event.original ) ) {
+				const original = event ? event.original : undefined;
+				if ( original ) {
 					original.preventDefault && original.preventDefault();
 					original.stopPropagation && original.stopPropagation();
 				} else {

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -12,7 +12,7 @@ import RactiveEvent from '../component/RactiveEvent';
 import runloop from '../../../global/runloop';
 import { addHelpers } from '../../helpers/contextMethods';
 import { setupArgsFn, teardownArgsFn } from '../shared/directiveArgs';
-import { warnIfDebug } from '../../../utils/log';
+import { warnOnceIfDebug } from '../../../utils/log';
 
 const specialPattern = /^(event|arguments)(\..+)?$/;
 const dollarArgsPattern = /^\$(\d+)(\..+)?$/;
@@ -127,7 +127,7 @@ export default class EventDirective {
 					original.preventDefault && original.preventDefault();
 					original.stopPropagation && original.stopPropagation();
 				} else {
-					warnIfDebug( 'Handler returns false, but no event object is available' );
+					warnOnceIfDebug( `handler '${this.template.n}' returned false, but there is no event available to cancel` );
 				}
 			}
 

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -12,6 +12,7 @@ import RactiveEvent from '../component/RactiveEvent';
 import runloop from '../../../global/runloop';
 import { addHelpers } from '../../helpers/contextMethods';
 import { setupArgsFn, teardownArgsFn } from '../shared/directiveArgs';
+import { warnIfDebug } from '../../../utils/log';
 
 const specialPattern = /^(event|arguments)(\..+)?$/;
 const dollarArgsPattern = /^\$(\d+)(\..+)?$/;
@@ -121,9 +122,14 @@ export default class EventDirective {
 
 			// Auto prevent and stop if return is explicitly false
 			let original;
-			if ( result === false && event && ( original = event.original ) ) {
-				original.preventDefault && original.preventDefault();
-				original.stopPropagation && original.stopPropagation();
+
+			if ( result === false ) {
+				if ( event && ( original = event.original ) ) {
+					original.preventDefault && original.preventDefault();
+					original.stopPropagation && original.stopPropagation();
+				} else {
+					warnIfDebug( 'Handler returns false, but no event object is available' );
+				}
 			}
 
 			ractive.event = oldEvent;

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -1092,7 +1092,11 @@ export default function() {
 	});
 
 	test( `returning false from a component event doesn't try to cancel something that doesn't exist (#2731)`, t => {
-		t.expect( 0 );
+		t.expect( 1 );
+
+		onWarn( msg => {
+			t.ok( msg );
+		});
 
 		const cmp = Ractive.extend({
 			template: '<button on-click="@this.asplode()">click me</button>',


### PR DESCRIPTION
## Description of the pull request:
97b0305 fixes #2731 by silently ignoring the users intent to cancel a component event. This PR just adds a little warning when the event cannot be cancelled due to a missing event-object.

I think otherwise people could get hurt, for example when they move functionality into a component, since
* plain ```<button on-click="@this.a()``` can be cancelled without passing the event
* docs say events can be cancelled by returning false.

## Fixes the following issues:
#2731 

## Is breaking:
Nope

## Reviewers:


