### PR TITLE
Add a way to force ractive to register as a global - #2270

### DIFF
--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -40,6 +40,20 @@ export default function Ractive ( options ) {
 	initialise( this, options || {}, {} );
 }
 
+// check to see if we're being asked to force Ractive as a global for some weird environments
+if ( win && !win.Ractive ) {
+	let opts = '';
+	const script = document.currentScript || document.querySelector( 'script[data-ractive-options]' );
+
+	if ( script ) {
+		opts = script.getAttribute( 'data-ractive-options' ) || '';
+	}
+
+	if ( ~opts.indexOf( 'ForceGlobal' ) ) {
+		win.Ractive = Ractive;
+	}
+}
+
 extendObj( Ractive.prototype, proto, defaults );
 Ractive.prototype.constructor = Ractive;
 


### PR DESCRIPTION
## Description of the pull request:
This adds a way to force Ractive to be set on `window` regardless of the method used to load it (AMD, require-ish things). Whatever script contains Ractive should be linked with `RactiveForceGlobal` as a query param on the src e.g. `<script src="./ractive.min.js?RactiveForceGlobal"></script>` or `<script src="./mySpecialBundle.js?RactiveForceGlobal"></script>`. As long as the currently loading script tag has `RactiveForceGlobal` somewhere in the src, there's a window available, and it doesn't already have a `Ractive` member, this will set `window.Ractive` to the loading version of Ractive.

@Ghazgkull I tested this with a fake AMD environment, and it seemed to work fine. I _think_ browser support goes all the way back to IE9. Can you see if this will work for you? If it does, I think it should suffice for anyone else with a conflicted environment :smile:

## Fixes the following issues:
#2270

## Is breaking:
Only if you use a module loader, named your copy of Ractive `RactiveForceGlobal.js`, and have code that can't tolerate a global Ractive being set :smile:

## Reviewers:
@Ghazgkull @fskreuz

