### PR TITLE
add destruct hook, clean up a bit of cruft, and send the source insta…

### DIFF
--- a/src/events/Hook.js
+++ b/src/events/Hook.js
@@ -1,54 +1,19 @@
-import { warnIfDebug } from '../utils/log';
-
-// TODO: deprecate in future release
-const deprecations = {
-	construct: {
-		deprecated: 'beforeInit',
-		replacement: 'onconstruct'
-	},
-	render: {
-		deprecated: 'init',
-		message: 'The "init" method has been deprecated ' +
-			'and will likely be removed in a future release. ' +
-			'You can either use the "oninit" method which will fire ' +
-			'only once prior to, and regardless of, any eventual ractive ' +
-			'instance being rendered, or if you need to access the ' +
-			'rendered DOM, use "onrender" instead. ' +
-			'See http://docs.ractivejs.org/latest/migrating for more information.'
-	},
-	complete: {
-		deprecated: 'complete',
-		replacement: 'oncomplete'
-	}
-};
+import fireEvent from './fireEvent';
 
 export default class Hook {
 	constructor ( event ) {
 		this.event = event;
 		this.method = 'on' + event;
-		this.deprecate = deprecations[ event ];
-	}
-
-	call ( method, ractive, arg ) {
-		if ( ractive[ method ] ) {
-			arg ? ractive[ method ]( arg ) : ractive[ method ]();
-			return true;
-		}
 	}
 
 	fire ( ractive, arg ) {
-		this.call( this.method, ractive, arg );
-
-		// handle deprecations
-		if ( !ractive[ this.method ] && this.deprecate && this.call( this.deprecate.deprecated, ractive, arg ) ) {
-			if ( this.deprecate.message ) {
-				warnIfDebug( this.deprecate.message );
-			} else {
-				warnIfDebug( 'The method "%s" has been deprecated in favor of "%s" and will likely be removed in a future release. See http://docs.ractivejs.org/latest/migrating for more information.', this.deprecate.deprecated, this.deprecate.replacement );
-			}
+		if ( ractive[ this.method ] ) {
+			arg ? ractive[ this.method ]( arg ) : ractive[ this.method ]();
 		}
 
-		// TODO should probably use internal method, in case ractive.fire was overwritten
-		arg ? ractive.fire( this.event, arg ) : ractive.fire( this.event );
+		const options = { args: [] };
+		if ( arg ) options.args.push( arg );
+		options.args.push( ractive );
+		fireEvent( ractive, this.event, options );
 	}
 }

--- a/src/events/fireEvent.js
+++ b/src/events/fireEvent.js
@@ -30,7 +30,6 @@ function getWildcardNames ( eventName ) {
 }
 
 function fireEventAs  ( ractive, eventNames, event, args, initialFire = false ) {
-
 	let subscribers, i;
 	let bubble = true;
 

--- a/src/global/runloop.js
+++ b/src/global/runloop.js
@@ -8,12 +8,9 @@ const changeHook = new Hook( 'change' );
 let batch;
 
 const runloop = {
-	start ( instance, returnPromise ) {
-		let promise, fulfilPromise;
-
-		if ( returnPromise ) {
-			promise = new Promise( f => ( fulfilPromise = f ) );
-		}
+	start ( instance ) {
+		let fulfilPromise;
+		const promise = new Promise( f => ( fulfilPromise = f ) );
 
 		batch = {
 			previousBatch: batch,
@@ -23,7 +20,8 @@ const runloop = {
 			immediateObservers: [],
 			deferredObservers: [],
 			ractives: [],
-			instance
+			instance,
+			promise
 		};
 
 		return promise;
@@ -87,6 +85,17 @@ const runloop = {
 
 			_batch.tasks.push( task );
 		}
+	},
+
+	promise () {
+		if ( !batch ) return Promise.resolve();
+
+		let target = batch;
+		while ( target.previousBatch ) {
+			target = target.previousBatch;
+		}
+
+		return target.promise || Promise.resolve();
 	}
 };
 

--- a/src/parse/converters/element/readAttribute.js
+++ b/src/parse/converters/element/readAttribute.js
@@ -8,7 +8,7 @@ import flattenExpression from '../../utils/flattenExpression';
 const attributeNamePattern = /^[^\s"'>\/=]+/;
 const onPattern = /^on/;
 const eventPattern = /^on-([a-zA-Z\\*\\.$_][a-zA-Z\\*\\.$_0-9\-]+)$/;
-const reservedEventNames = /^(?:change|reset|teardown|update|construct|config|init|render|unrender|detach|insert)$/;
+const reservedEventNames = /^(?:change|reset|teardown|update|construct|config|init|render|complete|unrender|detach|insert|destruct|attachchild|detachchild)$/;
 const decoratorPattern = /^as-([a-z-A-Z][-a-zA-Z_0-9]*)$/;
 const transitionPattern = /^([a-zA-Z](?:(?!-in-out)[-a-zA-Z_0-9])*)-(in|out|in-out)$/;
 const directives = {
@@ -219,7 +219,7 @@ export function readAttributeOrDirective ( parser ) {
 			readArguments( parser, attribute, true );
 		} else if ( reservedEventNames.test( attribute.f ) ) {
 			parser.pos -= attribute.f.length;
-			parser.error( 'Cannot use reserved event names (change, reset, teardown, update, construct, config, init, render, unrender, detach, insert)' );
+			parser.error( 'Cannot use reserved event names (change, reset, teardown, update, construct, config, init, render, unrender, complete, detach, insert, destruct, attachchild, detachchild)' );
 		}
 	}
 

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -10,16 +10,14 @@ import { create, extend } from '../../utils/object';
 import { createDocumentFragment } from '../../utils/dom';
 import createItem from './createItem';
 import { removeFromArray } from '../../utils/array';
-import { bind, cancel, render as callRender, unbind, unrender, update } from '../../shared/methodCallers';
-import Hook from '../../events/Hook';
+import { bind, render as callRender, unbind, unrender, update } from '../../shared/methodCallers';
 import updateLiveQueries from './component/updateLiveQueries';
 import { updateAnchors } from '../../shared/anchors';
+import { teardown } from '../../Ractive/prototype/teardown';
 
 function makeDirty ( query ) {
 	query.makeDirty();
 }
-
-const teardownHook = new Hook( 'teardown' );
 
 export default class Component extends Item {
 	constructor ( options, ComponentConstructor ) {
@@ -216,16 +214,7 @@ export default class Component extends Item {
 
 			this.attributes.forEach( unbind );
 
-			const instance = this.instance;
-			instance.viewmodel.teardown();
-			instance.fragment.unbind();
-			instance._observers.forEach( cancel );
-
-			if ( instance.fragment.rendered && instance.el.__ractive_instances__ ) {
-				removeFromArray( instance.el.__ractive_instances__, instance );
-			}
-
-			teardownHook.fire( instance );
+			teardown( this.instance, () => runloop.promise() );
 		}
 	}
 

--- a/test/__support/js/samples/parse.js
+++ b/test/__support/js/samples/parse.js
@@ -543,8 +543,7 @@ const parseTests = [
 	{
 		name: 'Reserved event names cannot be used for proxy events',
 		template: `<div on-foo="change"></div>`,
-		error: 'Cannot use reserved event names (change, reset, teardown, update, construct, config, init, render, unrender, detach, insert) at line 1 character 15:\n' +
-			'<div on-foo=\"change\"></div>\n              ^----'
+		error: /Cannot use reserved event names/
 	},
 	{
 		name: 'Reserved event names can be part of proxy event names',
@@ -863,37 +862,37 @@ const parseTests = [
 	{
 		name: 'expression with numeric refinement #2325',
 		template: '{{foo[0].bar()}}',
-		parsed: {v:4,t:[{t:2,x:{r:["foo.0"],s:"_0.bar()"}}]}
+		parsed: {v:4,t:[{t:2,x:{r:['foo.0'],s:'_0.bar()'}}]}
 	},
 	{
 		name: 'expression with numeric refinement alt #2325',
 		template: '{{foo[0]()}}',
-		parsed: {v:4,t:[{t:2,x:{r:["foo.0"],s:"_0()"}}]}
+		parsed: {v:4,t:[{t:2,x:{r:['foo.0'],s:'_0()'}}]}
 	},
 	{
 		name: 'expression with multiple numeric refinement #2325',
 		template: '{{foo[0].bar()[10].baz.bat()}}',
-		parsed: {v:4,t:[{t:2,x:{r:["foo.0"],s:"_0.bar()[10].baz.bat()"}}]}
+		parsed: {v:4,t:[{t:2,x:{r:['foo.0'],s:'_0.bar()[10].baz.bat()'}}]}
 	},
 	{
 		name: 'expression with multiple numeric refinement alt #2325',
 		template: '{{foo[0].bar[10].baz["12"].bat()}}',
-		parsed: {v:4,t:[{t:2,x:{r:["foo.0.bar.10.baz"],s:"_0[\"12\"].bat()"}}]}
+		parsed: {v:4,t:[{t:2,x:{r:['foo.0.bar.10.baz'],s:'_0["12"].bat()'}}]}
 	},
 	{
 		name: 'expression with array spread',
 		template: '{{[foo, bar, ...baz, bat, bip, ...bop, boop, bar]}}',
-		parsed: {v:4,t:[{t:2,x:{r:["foo","baz","bat","bip","bop","boop","bar"],s:"[].concat([_0,_6],_1,[_2,_3],_4,[_5,_6])"}}]}
+		parsed: {v:4,t:[{t:2,x:{r:['foo','baz','bat','bip','bop','boop','bar'],s:'[].concat([_0,_6],_1,[_2,_3],_4,[_5,_6])'}}]}
 	},
 	{
 		name: 'expression with object spread',
 		template: '{{ { foo: "bar", baz: 10 + ref, ...bat, bip: "bop" } }}',
-		parsed: {v:4,t:[{t:2,x:{r:["ref","bat"],s:'Object.assign({},{foo:"bar",baz:10+_0},_1,{bip:"bop"})'}}]}
+		parsed: {v:4,t:[{t:2,x:{r:['ref','bat'],s:'Object.assign({},{foo:"bar",baz:10+_0},_1,{bip:"bop"})'}}]}
 	},
 	{
 		name: 'expression with spread args',
 		template: '{{ foo.bar.baz(baz, bat, ...bip, bop, ...boop) }}',
-		parsed: {v:4,t:[{t:2,x:{r:["foo.bar","baz","bat","bip","bop","boop"],s:'(function(){var x$0;return((x$0=_0.baz).apply(x$0,[].concat([_1,_2],_3,[_4],_5)));})()'}}]}
+		parsed: {v:4,t:[{t:2,x:{r:['foo.bar','baz','bat','bip','bop','boop'],s:'(function(){var x$0;return((x$0=_0.baz).apply(x$0,[].concat([_1,_2],_3,[_4],_5)));})()'}}]}
 	},
 	{
 		name: 'various spreads mixed',

--- a/test/browser-tests/init/hooks/misc.js
+++ b/test/browser-tests/init/hooks/misc.js
@@ -221,4 +221,23 @@ export default function() {
 			});
 		});
 	}
+
+	test( 'hooks include the source ractive instance as the last argument', t => {
+		const done = t.async();
+		t.expect( 3 );
+
+		const cmp = Ractive.extend();
+		const r = new Ractive({
+			template: '<cmp />',
+			components: { cmp }
+		});
+		const c = r.findComponent( 'cmp' );
+
+		r.on( 'cmp.render', inst => t.ok( c === inst ) );
+		r.on( 'cmp.complete', inst => { t.ok( c === inst ); done(); } );
+		r.on( 'cmp.teardown', inst => t.ok( c === inst ) );
+
+		r.render( fixture );
+		r.teardown();
+	});
 }

--- a/test/browser-tests/parse.js
+++ b/test/browser-tests/parse.js
@@ -34,7 +34,11 @@ export default function() {
 					if ( error.name !== 'ParseError' ) {
 						throw error;
 					}
-					t.equal( error.message, theTest.error );
+					if ( theTest.error.test ) {
+						t.ok( theTest.error.test( error.message ) );
+					} else {
+						t.equal( error.message, theTest.error );
+					}
 					return true;
 				}, 'Expected ParseError' );
 			} else {

--- a/test/node-tests/parse.js
+++ b/test/node-tests/parse.js
@@ -19,7 +19,11 @@ parseTests.forEach( function ( test ) {
 				if (error.name !== 'ParseError') {
 					throw error;
 				}
-				assert.equal( error.message, test.error );
+				if ( test.error.test ) {
+					assert.ok( test.error.test( error.message ) );
+				} else {
+					assert.equal( error.message, test.error );
+				}
 				return true;
 			}, 'Expected ParseError');
 		} else {


### PR DESCRIPTION
## Description of the pull request:
This does a bit of cleanup around hooks, including removing the deprecation warnings and support. It also adds a `destruct` hook that is the counterpart to `complete`. It fires after the transitions have finished on a component/instance teardown.

This also modifies hook events to pass along the ractive instance that originated the event as their last argument. `change` is the odd man out here, so it's `ractive.on('change', (changes, source) => ...)` whereas everything else is `ractive.on('change', source => ...)`.

## Fixes the following issues:
#2339 #2034

## Is breaking:
Well kinda, if you're using proxy events named `complete`, `destruct`, `attachchild`, or `detachchild`, because those are the additional events that are now checked during parse. So it's not possible to `<button on-click="complete">nope</button>`, but I'd think that would be pretty uncommon.