### PR TITLE
BREAKING: Allow escaping hyphens in on-event-name - #2730

### DIFF
--- a/src/parse/converters/element/readAttribute.js
+++ b/src/parse/converters/element/readAttribute.js
@@ -7,7 +7,7 @@ import flattenExpression from '../../utils/flattenExpression';
 
 const attributeNamePattern = /^[^\s"'>\/=]+/;
 const onPattern = /^on/;
-const eventPattern = /^on-([a-zA-Z\\*\\.$_][a-zA-Z\\*\\.$_0-9\-]+)$/;
+const eventPattern = /^on-([a-zA-Z\*\.$_]((?:[a-zA-Z\*\.$_0-9\-]|\\-)+))$/;
 const reservedEventNames = /^(?:change|reset|teardown|update|construct|config|init|render|complete|unrender|detach|insert|destruct|attachchild|detachchild)$/;
 const decoratorPattern = /^as-([a-z-A-Z][-a-zA-Z_0-9]*)$/;
 const transitionPattern = /^([a-zA-Z](?:(?!-in-out)[-a-zA-Z_0-9])*)-(in|out|in-out)$/;
@@ -18,6 +18,23 @@ const directives = {
 const unquotedAttributeValueTextPattern = /^[^\s"'=<>`]+/;
 const proxyEvent = /^[^\s"'=<>@\[\]()]*/;
 const whitespace = /^\s+/;
+
+const slashes = /\\/g;
+function splitEvent ( str ) {
+	const result = [];
+	let s = 0;
+
+	for ( let i = 0; i < str.length; i++ ) {
+		if ( str[i] === '-' && str[ i - 1 ] !== '\\' ) {
+			result.push( str.substring( s, i ).replace( slashes, '' ) );
+			s = i + 1;
+		}
+	}
+
+	result.push( str.substring( s ).replace( slashes, '' ) );
+
+	return result;
+}
 
 export default function readAttribute ( parser ) {
 	let name, i, nearest, idx;
@@ -210,7 +227,8 @@ export function readAttributeOrDirective ( parser ) {
 
 		// on-click etc
 	else if ( match = eventPattern.exec( attribute.n ) ) {
-		attribute.n = match[1];
+
+		attribute.n = splitEvent( match[1] );
 		attribute.t = EVENT;
 
 			// check for a proxy event

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -24,11 +24,11 @@ export default class EventDirective {
 		this.events = [];
 
 		if ( this.element.type === COMPONENT || this.element.type === ANCHOR ) {
-			this.template.n.split( '-' ).forEach( n => {
+			this.template.n.forEach( n => {
 				this.events.push( new RactiveEvent( this.element, n ) );
 			});
 		} else {
-			this.template.n.split( '-' ).forEach( n => {
+			this.template.n.forEach( n => {
 				const fn = findInViewHierarchy( 'events', this.ractive, n );
 				// we need to pass in "this" in order to get
 				// access to node when it is created.
@@ -123,7 +123,7 @@ export default class EventDirective {
 					original.preventDefault && original.preventDefault();
 					original.stopPropagation && original.stopPropagation();
 				} else {
-					warnOnceIfDebug( `handler '${this.template.n}' returned false, but there is no event available to cancel` );
+					warnOnceIfDebug( `handler '${this.template.n.join( ' ' )}' returned false, but there is no event available to cancel` );
 				}
 			}
 

--- a/test/__support/js/samples/parse.js
+++ b/test/__support/js/samples/parse.js
@@ -538,7 +538,7 @@ const parseTests = [
 	{
 		name: 'Empty event attribute',
 		template: `<p on-click=''></p>`,
-		parsed: {v:4,t:[{t:7,e:'p',m:[{n:'click',t:70,f:''}]}]}
+		parsed: {v:4,t:[{t:7,e:'p',m:[{n:['click'],t:70,f:''}]}]}
 	},
 	{
 		name: 'Reserved event names cannot be used for proxy events',
@@ -548,12 +548,12 @@ const parseTests = [
 	{
 		name: 'Reserved event names can be part of proxy event names',
 		template: `<div on-foo="thiswillchange"></div>`,
-		parsed: {v:4,t:[{t:7,e:'div',m:[{n:'foo',f:'thiswillchange',t:70}]}]}
+		parsed: {v:4,t:[{t:7,e:'div',m:[{n:['foo'],f:'thiswillchange',t:70}]}]}
 	},
 	{
 		name: 'Multiple proxy event names joined by "-"',
 		template: `<div on-foo-bar="baz"></div>`,
-		parsed: {v:4,t:[{t:7,e:'div',m:[{n:'foo-bar',f:'baz',t:70}]}]}
+		parsed: {v:4,t:[{t:7,e:'div',m:[{n:['foo','bar'],f:'baz',t:70}]}]}
 	},
 
 	// Illegal expressions
@@ -860,7 +860,7 @@ const parseTests = [
 		template: '{{x + 1}}<a {{#if x + 2}}data-id={{x + 3}}{{/if}} slide-in="x+4" on-click="proxy" on-focus="method(x + 5)">{{foo.bar[x + 6].baz}}</a>',
 		options: { csp: true },
 		parsed: {
-			v:4,t:[{t:2,x:{r:['x'],s:'_0+1'}},{t:7,e:'a',m:[{t:4,f:[{n:'data-id',f:[{t:2,x:{r:['x'],s:'_0+3'}}],t:13}],n:50,x:{r:['x'],s:'_0+2'}},{v:'t1',n:'slide',f:{s:'[_0+4]',r:['x']},t:72},{n:'click',f:'proxy',t:70},{n:'focus',f:{r:['method','x'],s:'[_0(_1+5)]'},t:70}],f:[{t:2,rx:{r:'foo.bar',m:[{r:['x'],s:'_0+6'},'baz']}}]}],
+			v:4,t:[{t:2,x:{r:['x'],s:'_0+1'}},{t:7,e:'a',m:[{t:4,f:[{n:'data-id',f:[{t:2,x:{r:['x'],s:'_0+3'}}],t:13}],n:50,x:{r:['x'],s:'_0+2'}},{v:'t1',n:'slide',f:{s:'[_0+4]',r:['x']},t:72},{n:['click'],f:'proxy',t:70},{n:['focus'],f:{r:['method','x'],s:'[_0(_1+5)]'},t:70}],f:[{t:2,rx:{r:'foo.bar',m:[{r:['x'],s:'_0+6'},'baz']}}]}],
 			// these are intentially made strings for testing purposes
 			// actual template has javascript function objects
 			e:{

--- a/test/browser-tests/events/basic.js
+++ b/test/browser-tests/events/basic.js
@@ -158,4 +158,20 @@ export default function() {
 		ractive.fire( 'foo' );
 		ractive.fire( 'foo' );
 	});
+
+	test( `hyphens in event names can be escaped`, t => {
+		const cmp = Ractive.extend();
+		const r = new Ractive({
+			target: fixture,
+			template: `<cmp on-foo\\-bar-baz="@.set('foo', 'yep')" />`,
+			components: { cmp }
+		});
+
+		r.findComponent( 'cmp' ).fire( 'foo-bar' );
+		t.equal( r.get( 'foo' ), 'yep' );
+
+		r.set( 'foo', 'nope' );
+		r.findComponent( 'cmp' ).fire( 'baz' );
+		t.equal( r.get( 'foo' ), 'yep' );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
As of 0.8, component events are treated the same way as element events, so `<cmp on-foo-bar="...">` subscribes to both `foo` and `bar` events like `<a on-click-tap="...">` subscribes to both `click` and `tap` events.

This adds support for escaping `-`s in event directives, so that hypenated event names can be subscribed in templates: `<cmp on-foo\-bar="...">` will subscribe to one event `foo-bar`.

I would have gone with just warning when you fire a hyphenated event, but this seems like it might be a better option.

Opinions?

## Fixes the following issues:
#2730

## Is breaking
:Yes, because event name splitting is moved to parse time, and the event VDOM node now has an array for `n` rather than a string. Templates are already broken between 0.8 and 0.9.

## Reviewers:
@MartinKolarik, Grand Wizard of the Order of Regex
Without negative lookbehind in js regexes, I'm at a bit of a disadvantage. I copied your keypath splitting, since it accomplishes roughly the same thing. There may be a better way, though. :smile: