### PR TITLE
Context helper expansion including observe and events - 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # 0.9.0 (unreleased)
 
+* Bug fixes
+	* Observers on uninitialized data may be added during the `config` event (#2725)
+
 * Breaking changes
 	* All deprecations have been removed, including proxy events with args, un-prefixed method events, decorator="...", transition="...", the ractive.data getter, partial comment definitions, and lifecycle methods like `init` and `beforeInit`.
 	* The template spec is now a bit simpler after the removal of deprecations, and templates parsed with previous versions of Ractive are no longer compatible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,15 @@
 	* There is a new option, `resolveInstanceMembers`, which defaults to `true`, and when enabled, it adds the instance scope `@this` to the end of the reference resolution process. This means that as long as there are no conflicting members in the context hierarchy, things like `<button on-click="set('foo', 'bar')">yep</button>` work as expected. Note that if the resolved function will only be bound to the instance if it contains a `this` reference, which can be a little strange if you're debugging.
 	* There is a new option, `warnAboutAmbiguity`, which defaults to `false`, and when set, it will issue a warning any time a reference fails to resolve at all or fails to resolve to a member in the immediate context.
 	* API methods can now handle things like `ractive.set('~/foo', 'bar')`, mirroring how context methods for `getNodeInfo` and `event`s are handled. Things like `ractive.set('.foo', 'bar')` will now issue a warning and do nothing rather than creating an incorrect keypath (`<empty string>.foo`).
+	* You can now trigger event listeners in the VDOM from event and node info objects e.g. with `<div on-foo="@global.alert('hello')" >` with `ractive.getNodeInfo('div').raise('foo');` will trigger an alert.
 
 * New features (stable)
 	* `target` is now an alias for `el` when creating a Ractive instance.
 	* You can now use spread expressions with array and object literals in expressions in addition to method calls. Object spreads will require `Object.assign` to be available.
 	* There is a new lifecycle hook, `destruct` that fires after teardown is complete and any related transitions have completed.
 	* Lifecycle events now receive the source Ractive instance as their last argument.
+	* You can now use context-relative `observe` and `observeOnce` from event and node info objects.
+	* You can now access decorator objects from event and node info objects using `obj.decorators.name`, where name is the decorator name as specified in the template e.g. `foo` in `<div as-foo />`.
 
 
 # 0.8.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 	* Special keypaths that resolve to Ractive instances now resolve using the proper model rather than a computation, so they now stay in sync.
 	* There is now a special key `data` on special keypaths that resolve to Ractive instances that resolves to the instance's root model. This allows things like `@.root.data.foo` to keep the root instance `foo` reference in sync throughout the component tree.
 	* There is a new Ractive-private shared store, `@shared`. This is roughly the same as `@global`, but it is not susceptible to interference from the global scope.
-	* There is a new option, `resolveInstanceMembers`, which defaults to `true`, and when enabled, it adds the instance scope `@this` to the end of the reference resolution process. This means that as long as there are no conflicting members in the context hierarchy, things like `<button on-click="set('foo', 'bar')">yep</button>` work as expected.
+	* There is a new option, `resolveInstanceMembers`, which defaults to `true`, and when enabled, it adds the instance scope `@this` to the end of the reference resolution process. This means that as long as there are no conflicting members in the context hierarchy, things like `<button on-click="set('foo', 'bar')">yep</button>` work as expected. Note that if the resolved function will only be bound to the instance if it contains a `this` reference, which can be a little strange if you're debugging.
 	* There is a new option, `warnAboutAmbiguity`, which defaults to `false`, and when set, it will issue a warning any time a reference fails to resolve at all or fails to resolve to a member in the immediate context.
 	* API methods can now handle things like `ractive.set('~/foo', 'bar')`, mirroring how context methods for `getNodeInfo` and `event`s are handled. Things like `ractive.set('.foo', 'bar')` will now issue a warning and do nothing rather than creating an incorrect keypath (`<empty string>.foo`).
 
@@ -29,6 +29,13 @@
 	* You can now use spread expressions with array and object literals in expressions in addition to method calls. Object spreads will require `Object.assign` to be available.
 	* There is a new lifecycle hook, `destruct` that fires after teardown is complete and any related transitions have completed.
 	* Lifecycle events now receive the source Ractive instance as their last argument.
+
+
+# 0.8.5
+
+* Bug fixes
+	* Form elements nested inside yielders now correctly find their parents. This includes options finding their parent select (#2754)
+	* Number bindings now record their initial value properly (#2671)
 
 
 # 0.8.4

--- a/src/view/helpers/contextMethods.js
+++ b/src/view/helpers/contextMethods.js
@@ -91,6 +91,18 @@ function merge ( keypath, array, options ) {
 	return protoMerge( this.ractive, findModel( this, keypath ).model, array, options );
 }
 
+function observe ( keypath, callback, options = {} ) {
+	if ( isObject( keypath ) ) options = callback || {};
+	options.fragment = this._element.parentFragment;
+	return this.ractive.observe( keypath, callback, options );
+}
+
+function observeOnce ( keypath, callback, options = {} ) {
+	if ( isObject( keypath ) ) options = callback || {};
+	options.fragment = this._element.parentFragment;
+	return this.ractive.observeOnce( keypath, callback, options );
+}
+
 function pop ( keypath ) {
 	return modelPop( findModel( this, keypath ).model, [] );
 }
@@ -197,6 +209,8 @@ export function addHelpers ( obj, element ) {
 		animate: { value: animate },
 		link: { value: link },
 		merge: { value: merge },
+		observe: { value: observe },
+		observeOnce: { value: observeOnce },
 		pop: { value: pop },
 		push: { value: push },
 		reverse: { value: reverse },

--- a/src/view/helpers/contextMethods.js
+++ b/src/view/helpers/contextMethods.js
@@ -215,6 +215,14 @@ export function addHelpers ( obj, element ) {
 		getBindingPath: { value: getBindingPath },
 		getBinding: { value: getBinding },
 		setBinding: { value: setBinding },
+
+		decorators: {
+			get () {
+				const items = {};
+				element.decorators.forEach( d => items[ d.name ] = d.intermediary );
+				return items;
+			}
+		}
 	});
 
 	return obj;

--- a/src/view/helpers/contextMethods.js
+++ b/src/view/helpers/contextMethods.js
@@ -111,6 +111,23 @@ function push ( keypath, ...values ) {
 	return modelPush( findModel( this, keypath ).model, values );
 }
 
+function raise ( name, event, ...args ) {
+	let element = this._element;
+
+	while ( element ) {
+		const events = element.events;
+		for ( let i = 0; i < events.length; i++ ) {
+			const event = events[i];
+			if ( ~event.template.n.indexOf( name ) ) {
+				event.fire( event, args );
+				return;
+			}
+		}
+
+		element = element.parent;
+	}
+}
+
 function reverse ( keypath ) {
 	return modelReverse( findModel( this, keypath ).model, [] );
 }
@@ -213,6 +230,7 @@ export function addHelpers ( obj, element ) {
 		observeOnce: { value: observeOnce },
 		pop: { value: pop },
 		push: { value: push },
+		raise: { value: raise },
 		reverse: { value: reverse },
 		set: { value: set },
 		shift: { value: shift },

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -74,6 +74,7 @@ export default class Component extends Item {
 
 		this.attributeByName = {};
 
+		this.events = [];
 		this.attributes = [];
 		const leftovers = [];
 		( this.template.m || [] ).forEach( template => {

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -37,6 +37,7 @@ export default class Element extends ContainerItem {
 		}
 
 		this.decorators = [];
+		this.events = [];
 
 		// create attributes
 		this.attributeByName = {};

--- a/src/view/items/element/ElementEvents.js
+++ b/src/view/items/element/ElementEvents.js
@@ -1,5 +1,4 @@
-import { missingPlugin } from '../../../config/errors';
-import { fatal, warnOnce } from '../../../utils/log';
+import { fatal } from '../../../utils/log';
 
 class DOMEvent {
 	constructor ( name, owner ) {
@@ -17,9 +16,8 @@ class DOMEvent {
 		const node = this.node = this.owner.node;
 		const name = this.name;
 
-		if ( !( `on${name}` in node ) ) {
-			warnOnce( missingPlugin( name, 'events' ) );
-		}
+		// this is probably a custom event fired from a decorator or manually
+		if ( !( `on${name}` in node ) ) return;
 
 		node.addEventListener( name, this.handler = function( event ) {
 			directive.fire({
@@ -30,7 +28,7 @@ class DOMEvent {
 	}
 
 	unlisten () {
-		this.node.removeEventListener( this.name, this.handler, false );
+		if ( this.handler ) this.node.removeEventListener( this.name, this.handler, false );
 	}
 }
 

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -9,6 +9,7 @@ import runloop from '../../../global/runloop';
 import { addHelpers } from '../../helpers/contextMethods';
 import { setupArgsFn, teardownArgsFn } from '../shared/directiveArgs';
 import { warnOnceIfDebug } from '../../../utils/log';
+import { addToArray, removeFromArray } from '../../../utils/array';
 
 const specialPattern = /^(event|arguments)(\..+)?$/;
 const dollarArgsPattern = /^\$(\d+)(\..+)?$/;
@@ -42,6 +43,8 @@ export default class EventDirective {
 	}
 
 	bind () {
+		addToArray( this.element.events, this );
+
 		setupArgsFn( this, this.template, this.parentFragment, {
 			specialRef ( ref ) {
 				const specialMatch = specialPattern.exec( ref );
@@ -163,6 +166,8 @@ export default class EventDirective {
 	toString() { return ''; }
 
 	unbind () {
+		removeFromArray( this.element.events, this );
+
 		teardownArgsFn( this, this.template );
 	}
 

--- a/test/browser-tests/events/custom-proxy-events.js
+++ b/test/browser-tests/events/custom-proxy-events.js
@@ -1,6 +1,5 @@
 import { test } from 'qunit';
 import { fire } from 'simulant';
-import { hasUsableConsole, onWarn } from '../test-config';
 import { initModule } from '../test-config';
 
 export default function() {
@@ -47,19 +46,4 @@ export default function() {
 		ractive.unrender();
 		fire( span, 'click' );
 	});
-
-	if ( hasUsableConsole ) {
-		test( 'Missing event plugin', t => {
-			t.expect( 1 );
-
-			onWarn( msg => {
-				t.ok( /Missing "foo" events plugin/.test( msg ) );
-			});
-
-			new Ractive({
-				el: fixture,
-				template: '<div on-foo="">missing</div>',
-			});
-		});
-	}
 }

--- a/test/browser-tests/methods/link.js
+++ b/test/browser-tests/methods/link.js
@@ -140,7 +140,7 @@ export default function() {
 		parent.link( '', 'child.path', { ractive: child } );
 
 		t.equal( parent.get( 'child.path.foo.bar' ), 'baz' );
-		parent.observe( 'child.path.foo', () => t.ok( true, 'parent notified' ) );
+		parent.observe( 'child.path.foo', () => t.ok( true, 'parent notified' ), { init: false } );
 		child.set( 'foo.bar', 'yep' );
 	});
 }

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -1398,4 +1398,20 @@ export default function() {
 		t.equal( count1, 1 );
 		t.equal( count2, 1 );
 	});
+
+	test( `observeOnce works from the config event, even if the data is initialized - #2725`, t => {
+		let count = 0;
+		const r = new Ractive({
+			target: fixture,
+			onconfig () {
+				this.observeOnce( 'foo', () => count++ );
+				this.set( 'foo', 'yep' );
+			}
+		});
+
+		t.equal( count, 1 );
+
+		r.set( 'foo', 'bar' );
+		t.equal( count, 1 );
+	});
 }

--- a/test/browser-tests/node-info.js
+++ b/test/browser-tests/node-info.js
@@ -453,4 +453,26 @@ export default function() {
 
 		t.equal( r.getNodeInfo( '#baz' ).resolve(), 'foo.bar' );
 	});
+
+	test( `decorator objects are available from node info objects`, t => {
+		let flag = false;
+		const r = new Ractive({
+			target: fixture,
+			template: '<div as-foo />',
+			decorators: {
+				foo () {
+					return {
+						teardown () {},
+						method () {
+							flag = true;
+						}
+					};
+				}
+			}
+		});
+
+		r.getNodeInfo( 'div' ).decorators.foo.method();
+
+		t.ok( flag );
+	});
 }

--- a/test/browser-tests/node-info.js
+++ b/test/browser-tests/node-info.js
@@ -538,4 +538,33 @@ export default function() {
 		r.set( 'foo.bar.baz.bip', 'yep' );
 		t.equal( count, 3 );
 	});
+
+	test( `context objects can trigger events on their element`, t => {
+		t.expect( 1 );
+
+		const r = new Ractive({
+			target: fixture,
+			template: `<div on-foo="wat" />`
+		});
+
+		r.on( 'wat', () => t.ok( true ) );
+
+		r.getNodeInfo( 'div' ).raise( 'foo' );
+	});
+
+	test( `context objects can trigger events on parent elements`, t => {
+		t.expect( 1 );
+
+		const cmp = Ractive.extend({
+			template: '{{yield}}'
+		});
+		const r = new Ractive({
+			target: fixture,
+			template: `<div on-foo="@.foo()"><div><cmp><span /></cmp></div></div>`,
+			components: { cmp },
+			foo () { t.ok( true ); }
+		});
+
+		r.getNodeInfo( 'span' ).raise( 'foo' );
+	});
 }

--- a/test/browser-tests/node-info.js
+++ b/test/browser-tests/node-info.js
@@ -475,4 +475,67 @@ export default function() {
 
 		t.ok( flag );
 	});
+
+	test( `context observe resolves using the context fragment`, t => {
+		let count = 0;
+		const r = new Ractive({
+			target: fixture,
+			template: '{{#with foo}}{{#with bar}}<div />{{/with}}{{/with}}',
+			data: {
+				foo: { bar: {} }
+			}
+		});
+
+		r.getNodeInfo( 'div' ).observe( '.foo', () => count++, { init: false } );
+
+		r.set( 'foo.bar.foo', 'yep' );
+		t.equal( count, 1 );
+	});
+
+	test( `context observe works with a map and wildcards`, t => {
+		let count = 0;
+		const r = new Ractive({
+			target: fixture,
+			template: '{{#with foo}}{{#with bar}}<div />{{/with}}{{/with}}',
+			data: {
+				foo: { bar: {} }
+			}
+		});
+
+		r.getNodeInfo( 'div' ).observe({
+			'.foo': () => count++,
+			'.*': () => count++
+		}, { init: false } );
+
+		r.set( 'foo.bar.foo', 'yep' );
+		t.equal( count, 2 );
+
+		r.set( 'foo.bar.baz.bat', 'yep' );
+		t.equal( count, 3 );
+	});
+
+	test( `context observeOnce resolves using the context fragment`, t => {
+		let count = 0;
+		const r = new Ractive({
+			target: fixture,
+			template: `{{#with foo.bar}}<div />{{/with}}`,
+			data: {
+				foo: { bar: {} }
+			}
+		});
+
+		r.getNodeInfo( 'div' ).observeOnce({
+			'.foo': () => count++,
+			'.*': () => count++
+		});
+
+		r.set( 'foo.bar.foo', 'yep' );
+		r.set( 'foo.bar.foo', 'yep' );
+		t.equal( count, 2 );
+
+		r.getNodeInfo( 'div' ).observeOnce('.*', () => count++);
+		r.set( 'foo.bar.baz.bar', 'yep' );
+		r.set( 'foo.bar.baz.bip', 'yep' );
+		t.equal( count, 3 );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:

This does a few different things with context objects (event and `getNodeInfo` results), mostly looking to fill in some gaps with decorator support. It also refactors a bit in the observer code and updates the changelog a bit. (I'm trying to avoid non-code only commits outside of a PR since we're now publishing to npm automatically with each push to dev.)

1. You can get to decorators to interact with them using event and node info objects e.g. `ractive.getNodeInfo('div').decorators.someDecorator` will give you access to the decorator return object from `<div as-someDecorator />`.
2. There are context-relative `observe` and `observeOnce` methods that can take relative keypaths. This makes observation from within a computed context possible.
3. There's an experimental `raise` method (`raise(eventName, eventObject, ...args)`) available on context objects, so you can trigger events on VDOM elements. So if you have `<div on-foo="@.set('foo', 'bar')" as-fooable />`, then the `fooable` decorator can do `this.getNodeInfo(node).raise('foo');` to trigger the on-foo event on the VDOM node. Note that these are _not_ DOM events. They only look up the VDOM tree for a handler, and while they will look at parent elements until they find a handler, they don't bubble beyond the first handler in this implementation.

## Fixes the following issues:
#2217

## Is breaking:
No
