### PR TITLE
Template inspection/manipulation helper - RFC WIP - 0.9

### DIFF
--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -12,6 +12,7 @@ import initialise from './Ractive/initialise';
 import { getCSS } from './global/css';
 import { escapeKey, unescapeKey } from './shared/keypaths';
 import { joinKeys, splitKeypath } from './Ractive/static/keypaths';
+import readTemplate from './view/helpers/template';
 
 export default function Ractive ( options ) {
 	if ( !( this instanceof Ractive ) ) return new Ractive( options );
@@ -56,6 +57,7 @@ defineProperties( Ractive, {
 	splitKeypath:   { value: splitKeypath },
 	unescapeKey:    { value: unescapeKey },
 	getCSS:         { value: getCSS },
+	template:       { value: readTemplate },
 
 	// support
 	enhance:        { writable: true, value: false },

--- a/src/view/helpers/template.js
+++ b/src/view/helpers/template.js
@@ -1,0 +1,237 @@
+import { ELEMENT, COMPONENT, PARTIAL, YIELDER, SECTION, INVERTED, INTERPOLATOR, ANCHOR, ALIAS, TRIPLE, ATTRIBUTE, EVENT, DECORATOR, BINDING_FLAG, TRANSITION } from '../../config/types';
+import { SECTION_IF, SECTION_IF_WITH, SECTION_EACH, SECTION_UNLESS } from '../../config/types';
+
+const delimiters = {
+	static:       [ '[[', ']]' ],
+	staticTriple: [ '[[[', ']]]' ],
+	plain:        [ '{{', '}}' ],
+	triple:       [ '{{{', '}}}' ]
+};
+
+class Template {
+	constructor ( fragment, owner ) {
+		if ( !fragment ) fragment = [];
+		if ( fragment.t ) {
+			this.expressions = fragment.e;
+			fragment = fragment.t;
+		}
+		this.owner = owner;
+
+		// start the root with a defensive copy so that any modifications don't affect other instances later
+		this.fragment = !owner ? JSON.parse( JSON.stringify( fragment ) ) : fragment;
+	}
+
+	get content () {
+		return this.fragment.map( i => {
+			if ( typeof i === 'string' ) return new Text( i, this );
+
+			switch ( i.t ) {
+				case ELEMENT:
+				case COMPONENT:
+				case ANCHOR:
+					return new Element( i, this );
+				case PARTIAL:
+				case INTERPOLATOR:
+				case TRIPLE:
+				case YIELDER:
+					return new Inline( i, this );
+				case SECTION:
+				case INVERTED:
+				case ALIAS:
+					return new Block( i, this );
+				case ATTRIBUTE:
+				case BINDING_FLAG:
+				case DECORATOR:
+				case EVENT:
+				case TRANSITION:
+					return new Attribute( i, this );
+			}
+		});
+	}
+
+	get elements () { return this.content.filter( i => i instanceof Element ); }
+
+	get root () {
+		if ( !this.owner ) return this;
+		return this.owner.root;
+	}
+
+	// stringify a template
+	toString ( options = {} ) {
+		// some attributes have an expression as their fragment
+		if ( this.fragment.s ) {
+			const list = refToString({ x: this.fragment });
+			return list.substring( 1, list.length - 1 );
+		}
+		return this.content.map( i => i.toString( options ) ).join( '' );
+	}
+
+	// clone this bit of template as a new base template
+	toTemplate () {
+		return { e: this.root.e, t: this.item ? [ this.item ] : this.fragment };
+	}
+}
+
+class Text extends Template {
+	get content () { return []; }
+
+	toString () {
+		return this.fragment;
+	}
+}
+
+class Element extends Template {
+	constructor ( item, owner ) {
+		super( item.f, owner );
+		this.item = item;
+	}
+
+	get attributes () { return this.attributeFragment.content.filter( i => i.isAttribute ); }
+	get attributeContent () { return this.attributeFragment.content; }
+	get events () { return this.attributeFragment.content.filter( i => i.isEvent ); }
+	get decorators () { return this.attributeFragment.content.filter( i => i.isDecorator ); }
+	get bindingFlags () { return this.attributeFragment.content.filter( i => i.isBindingFlag ); }
+	get transitions () { return this.attributeFragment.content.filter( i => i.isTransition ); }
+	get partials () {
+		const list = [];
+		if ( this.item.p ) {
+			for ( const name in this.item.p ) {
+				const fragment = this.item.p[name];
+				const partial = new Partial( name, fragment, this );
+				list.push( partial );
+				list[ name ] = partial;
+			}
+		}
+		return list;
+	}
+
+	get attributeFragment () {
+		return new Template( this.item.m || [], this );
+	}
+
+	get isAnchor () { return this.item.t === ANCHOR; }
+
+	get name () { return this.item.e; }
+	set name ( name ) { this.item.e = name; }
+
+	remove () {
+		this.owner.fragment.splice( this.owner.fragment.indexOf( this.item ), 1 )[0];
+		return this;
+	}
+
+	toString ( options = {} ) {
+		return `<${this.item.e}${this.attributeFragment.toString(options)}>${this.item.p ? this.partials.map(p => p.toString(options)).join('') : ''}${super.toString(options)}</${this.item.e}>`;
+	}
+}
+
+class Attribute extends Template {
+	constructor ( item, owner ) {
+		super( typeof item.f === 'string' ? [] : item.f, owner );
+		if ( typeof item.f === 'string' ) this.text = item.f;
+		this.item = item;
+	}
+
+	get isAttribute () { return this.item.t === ATTRIBUTE; }
+	get isEvent () { return this.item.t === EVENT; }
+	get isDecorator () { return this.item.t === DECORATOR; }
+	get isBindingFlag () { return this.item.t === BINDING_FLAG; }
+	get isTransition () { return this.item.t === TRANSITION; }
+
+	get name () { return this.item.n; }
+	set name ( name ) { return this.item.n = name; }
+
+	remove () {
+		const owner = this.owner.item ? this.owner.item.m || [] : this.owner.fragment;
+		owner.splice( owner.indexOf( this.item ), 1 );
+		return this;
+	}
+
+	toString ( options ) {
+		const name = this.isTransition ?
+			this.name + ( this.item.v === 't0' ? '-in-out' : this.item.v === 't1' ? '-in' : '-out' ) :
+			this.isDecorator ? `as-${this.name}` :
+			this.isEvent ? `on-${this.item.n.map(n => n.replace( /-/g, '\\-' )).join( '-' )}` :
+			this.name;
+		return ` ${name}="${this.text ? this.text : ''}${super.toString(options)}"`;
+	}
+}
+
+class Block extends Template {
+	constructor ( item, owner ) {
+		super( item.f, owner );
+		this.item = item;
+	}
+
+	get isAlias () { return this.item.t === ALIAS; }
+	get isEach () { return this.item.t === SECTION && this.item.n === SECTION_EACH; }
+	get isIf () { return this.item.t === SECTION && this.item.n === SECTION_IF; }
+	get isPlain () { return this.item.t === SECTION && !this.item.n; }
+	get isUnless () { return this.item.t === INVERTED || ( this.item.t === SECTION && this.item.n === SECTION_UNLESS ); }
+	get isWith () { return this.item.t === SECTION && this.item.n === SECTION_IF_WITH; }
+
+	get isStatic () { return this.item.s; }
+
+	toString ( options = {} ) {
+		const delims = !this.isStatic ?
+			options.delimiters || delimiters.plain :
+			options.staticDelimiters || delimiters.static;
+		const tag = this.isIf ? ( this.item.l ? 'elseif' : 'if' ) : this.isAlias || this.isWith ? 'with' : this.isUnless ? ( this.item.l ? 'else' : 'unless' ) : this.isEach ? 'each' : '';
+
+		return `${delims[0]}${tag !== 'else' && tag !== 'elseif' ? '#' : ''}${tag ? `${tag} ` : ''}${refToString(this.item)}${this.item.z && this.item.z.length ? ( this.isAlias ? '' : ' ' ) + aliasesToString(this.item) : ''}${this.item.i ? `:${this.item.i}` : ''}${delims[1]}${super.toString(options)}${delims[0]}/${tag}${delims[1]}`;
+	}
+}
+
+class Inline extends Template {
+	constructor ( item, owner ) {
+		super( [], owner );
+		this.item = item;
+	}
+
+	get isExpression () { return this.item.f && this.item.f.x; }
+	get isInterpolator () { return this.item.t === INTERPOLATOR; }
+	get isPartial () { return this.item.t === PARTIAL; }
+	get isReference () { return this.item.f && this.item.f.r; }
+	get isStatic () { return this.item.s; }
+	get isUnescaped () { return this.item.t === TRIPLE; }
+	get isYielder () { return this.item.t === YIELDER; }
+
+	toString ( options = {} ) {
+		const delims = !this.isStatic && !this.isUnescaped ?
+			( options.delimiters || delimiters.plain ) :
+			!this.isStatic && this.isUnescaped ?
+			( options.tripleDelimiters || delimiters.triple ) :
+			this.isStatic && !this.isUnescaped ?
+			( options.staticDelimiters || delimiters.static ) :
+			( options.staticTripleDelimiters || delimiters.staticTriple );
+
+		return `${delims[0]}${this.isPartial ? '> ' : this.isYielder ? 'yield ' : ''}${refToString(this.item)}${this.isPartial && this.item.c ? ` ${refToString(this.item.c)}` : ''}${this.item.z ? ` ${this.isYielder ? ' with ' : ' '}${aliasesToString(this.item)}` : ''}${delims[1]}`;
+	}
+}
+
+class Partial extends Template {
+	constructor ( name, fragment, owner ) {
+		super( fragment, owner );
+		this.name = name;
+	}
+
+	toString ( options = {} ) {
+		const delims = options.delimiters || delimiters.plain;
+		return `${delims[0]}#partial ${this.name}${delims[1]}${super.toString(options)}${delims[0]}/partial${delims[1]}`;
+	}
+}
+
+function refToString ( item ) {
+	if ( item.r ) return item.r;
+	else if ( item.rx ) return `${item.r}${item.m.map(r => `[${r}]`).join('')}`;
+	else if ( item.x ) return item.x.r.reduce( ( a, c, i ) => a.replace( `_${i}`, c ), item.x.s );
+	else return '';
+}
+
+function aliasesToString ( item ) {
+	if ( item.z ) return item.z.reduce( ( a, c ) => `${a}${a ? ', ' : ''}${refToString(c.x)} as ${c.n}`, '' );
+	else return '';
+}
+
+export default function readTemplate ( template ) {
+	return new Template( template );
+}


### PR DESCRIPTION
## Description of the pull request:
This is my first pass at a template inspection/manipulation helper. It adds a new method, `Ractive.template` that takes a template, or some portion thereof, and wraps it in a helper class that makes it easier to navigate a template hierarchy. For now, it also does a defensive copy, so you can't accidentally modify a template for future instances. Also bear in mind that this is a work in progress, so there are some rough edges. I'd like to get some feedback before I wander too far off.

I think the classes are fairly self-explanatory, and it's only one file to look at for what's available, so I'll just throw out some examples of what I'm aiming to do:
```js
// verify that certain attributes are passed to a component (in onconfig, I think)
const required = ['foo', 'bar', 'baz'];
const tpl = Ractive.template([this.component.template]).elements[0]; // this is actually the element on the component VDOM item that's creating this instance
const provided = tpl.attributes.map(a => a.name); // attributes are only top-level, non-conditional attributes (no events, decorators, etc as those have their own accessors)
required.forEach(attr => {
  if (!~provided.indexOf(attr)) console.warn(`Please supply ${this.component.name} with a ${attr} attribute.`);
});

// gather up non-config attrs and put them in a partial
// using tpl and required from above
// the create functionality is proposed - it's not implemented or even close to final
const extra = tpl.attributes.filter(a => ~require.indexOf(a.name)).map(a => tpl.create({ type: 'attribute', name: a.name, value: { type: 'interpolator', reference: a.name } }));
// we now have an array equivalent to `attrA="{{attrA}}" attrB="{{attrB}}"` etc
// we can turn it into a useful template (wrap up the fragment array) and assign it to a partial name using
this.partials.attributes = Ractive.template(extra).toTemplate();

// you can also access other handy stuff, like inline partials (<cmp>{{#partial foo}}...{{/partial}}</cmp>)
tpl.partials; // this is the array, but it also has named properties assigned
tpl.partials.foo; // this is the foo inline partial
```

For a theoretical tab component:
```html
<TabBox>
  <Tab title="Hello, {{name}}">See, I used your name in a template for this tab entitled "Hello, {{name}}". You could use the title template to do validation icons or message counts or whatever.</Tab>
  <Tab title="Tab 2">And here's another tab...</Tab>
  <Tab title="Yet another">I could go on, but I won't.</Tab>
</TabBox>
```
```js
// in the tab box onconfig
const tpl = Ractive.template(this.partials.content);
const tabs = [];
tpl.elements.forEach(e => {
  if (e.name === 'Tab') {
    const tab = { content: e.content.toTemplate() };
    tabs.push(tab);
    if (e.attributes.title) tab.title = e.attributes.title.value.toTemplate();
    else tab.title = Ractive.template([`Tab ${tabs.length}`]).toTemplate();
  }
});
// this component would use inline partial expressions ({{#each tabs}}...{{yield .title}}...{{yield .content}}...{{/each}}) to render given data
// you could also have an `addTab` function that accepted a title and content and just push them to the tabs array
// closing tabs would be as easy as splicing them out of the tabs array
this.set('tabs', tabs);
```

As you can see, there are still some rough places, and again, please throw in some feedback on how this could be improved or if it's even any better than just manually munging templates when you just have to.

The last thing that this gets you is a stringify for parsed templates, so you can go from `{v:4,t:[{t:2,...},...]}` to something that resembles your original template using `Ractive.template(someTemplate).toString()`. There are some corner cases probably won't ever come back, like method call spreads, but most of the common template constructs are covered.

Known TODOs:
* [ ] create/insert/append template items. Some mutation is available, but not much.
* [ ] Put `toTemplate` method on arrays of proxy objects e.g. `tpl.elements[0].content.toTemplate()`. Maybe add another helper that creates a new empty template.
* [ ] Fix `toString` of `if/elseif/else` sections
* [ ] Tests!

## Fixes the following issues:
#1535 #1786 #2001

## Is breaking:
No

## Reviewers:
Anyone interested in this sort of thing. I'm not sure that this isn't too heavy to add to core, but if components would use this heavily, it would be better in core than as a strange extra thing that lots of stuff required or tried to supply on their own.

After looking at it a bit, I'm definitely not sure that this is any better than manually munging templates. Then again, I'm familiar enough with the source code that it's not too hard for me to keep track of how the templates are formed and how they need to be abused to accomplish my goals :smile: