### PR TITLE
Add support for priority in style attributes - fixes #2794

### DIFF
--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -235,7 +235,10 @@ function updateStyleAttribute ( reset ) {
 
 	let i = 0;
 	while ( i < keys.length ) {
-		if ( keys[i] in style ) style[ keys[i] ] = props[ keys[i] ];
+		if ( keys[i] in style ) {
+			const safe = props[ keys[i] ].replace( '!important', '' );
+			style.setProperty( keys[i], safe, safe.length !== props[ keys[i] ].length ? 'important' : '' );
+		}
 		i++;
 	}
 

--- a/test/browser-tests/attributes.js
+++ b/test/browser-tests/attributes.js
@@ -47,6 +47,20 @@ export default function () {
 		t.equal( span.style.color, '' );
 	});
 
+	test( `style attributes can correctly set an inline priority (#2794)`, t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `<span style="color: red !important" /><span style="color: green" />`,
+		});
+
+		const [ span1, span2 ] = r.findAll( 'span' );
+
+		t.equal( span1.style.getPropertyPriority( 'color' ), 'important' );
+		t.equal( span1.style.color, 'red' );
+		t.equal( span2.style.getPropertyPriority( 'color' ), '' );
+		t.equal( span2.style.color, 'green' );
+	});
+
 	test( `style attributes can be inline directives`, t => {
 		const r = new Ractive({
 			el: fixture,


### PR DESCRIPTION
## Description of the pull request:
This adds a check for `!important` when setting inline style values, and if present, sets the priority flag on the property accordingly.

## Fixes the following issues:
#2794

## Is breaking:
Don't think so.

## Reviewers:
@fskreuz @mpowell-atomic