### PR TITLE
Better perf for many (empty) components

### DIFF
--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -37,9 +37,11 @@ export default function construct ( ractive, options ) {
 	constructHook.fire( ractive, options );
 
 	// Add registries
-	registryNames.forEach( name => {
+	let i = registryNames.length;
+	while ( i-- ) {
+		const name = registryNames[ i ];
 		ractive[ name ] = extend( create( ractive.constructor[ name ] || null ), options[ name ] );
-	});
+	}
 
 	// Create a viewmodel
 	const viewmodel = new RootModel({
@@ -112,6 +114,7 @@ function initialiseProperties ( ractive ) {
 
 	// events
 	ractive._subs = create( null );
+	ractive._nsSubs = 0;
 
 	// storage for item configuration from instantiation to reset,
 	// like dynamic functions or original values

--- a/src/Ractive/prototype/off.js
+++ b/src/Ractive/prototype/off.js
@@ -18,10 +18,12 @@ export default function Ractive$off ( eventName, callback ) {
 				// a cancelled handler - this is _slightly_ hacky
 				( callback._proxy || callback ).off = true;
 				removeFromArray( subs, callback._proxy || callback );
+				if ( event.indexOf( '.' ) ) this._nsSubs--;
 			}
 
 			// otherwise, remove all listeners for this event
 			else if ( subs ) {
+				if ( event.indexOf( '.' ) ) this._nsSubs -= subs.length;
 				subs.length = 0;
 			}
 		});

--- a/src/Ractive/prototype/on.js
+++ b/src/Ractive/prototype/on.js
@@ -21,6 +21,7 @@ export default function Ractive$on ( eventName, callback ) {
 			const names = k.split( ' ' ).map( trim ).filter( notEmptyString );
 			names.forEach( n => {
 				( this._subs[ n ] || ( this._subs[ n ] = [] ) ).push( caller );
+				if ( n.indexOf( '.' ) ) this._nsSubs++;
 				events.push( [ n, caller ] );
 			});
 		}

--- a/src/global/TransitionManager.js
+++ b/src/global/TransitionManager.js
@@ -48,7 +48,7 @@ export default class TransitionManager {
 	}
 
 	ready () {
-		detachImmediate( this );
+		if ( this.detachQueue.length ) detachImmediate( this );
 	}
 
 	remove ( transition ) {
@@ -127,18 +127,25 @@ function detachImmediate ( manager ) {
 	}
 }
 
-function collectAllOutros ( manager, list ) {
+function collectAllOutros ( manager, _list ) {
+	let list = _list;
+
+	// if there's no list, we're starting at the root to build one
 	if ( !list ) {
 		list = [];
 		let parent = manager;
 		while ( parent.parent ) parent = parent.parent;
 		return collectAllOutros( parent, list );
 	} else {
+		// grab all outros from child managers
 		let i = manager.children.length;
 		while ( i-- ) {
 			list = collectAllOutros( manager.children[i], list );
 		}
-		list = list.concat( manager.outros );
+
+		// grab any from this manager if there are any
+		if ( manager.outros.length ) list = list.concat( manager.outros );
+
 		return list;
 	}
 }

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -67,15 +67,12 @@ export function removeFromArray ( array, member ) {
 	}
 }
 
-export function combine ( first, ...rest ) {
-	const res = first.slice();
-	rest = rest.concat.apply( [], rest );
-
-	const len = rest.length;
-	for ( let i = 0; i < len; i++ ) {
-		if ( !~res.indexOf( rest[i] ) ) {
-			res.push( rest[i] );
-		}
+export function combine ( ...arrays ) {
+	const res = arrays.concat.apply( [], arrays );
+	let i = res.length;
+	while ( i-- ) {
+		const idx = res.indexOf( res[i] );
+		if ( ~idx && idx < i ) res.splice( i, 1 );
 	}
 
 	return res;

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -73,16 +73,18 @@ try {
 
 export { create, defineProperty, defineProperties };
 
-export function extend ( target, ...sources ) {
-	let prop;
+export function extend ( _target, ...sources ) {
+	const target = _target;
+	const len = sources.length;
 
-	sources.forEach( source => {
-		for ( prop in source ) {
+	for ( let i = 0; i < len; i++ ) {
+		const source = sources[i];
+		for ( const prop in source ) {
 			if ( hasOwn.call( source, prop ) ) {
 				target[ prop ] = source[ prop ];
 			}
 		}
-	});
+	}
 
 	return target;
 }


### PR DESCRIPTION
## Description of the pull request:
This is the result of me trying to figure out whether or not it makes sense to pursue #1376 and #1379 lightweight components any further. I've come to the conclusion that it's not really needed because the introduction of proper models in 0.8 basically killed the model-related overhead involved with components. They're still not super-lightweight because they're roughly 20x more expensive than a plain partial, but to be fair, partial performance is __way__ better than it was before 0.8. The only bits I could think to strip off of components are somewhat necessary to have an encapsulated widget anyways (its own potentially isolated model, registries, and lifecycle events).

When I started profiling with an iterated list of 1000 components with just the letter 'c' as their template and partials with just the letter 'p' as their content, the initial render for the components was ~240ms settling to ~140ms, and the initial render for the partials was ~27ms settling to ~4ms. That's a pretty wide gap. With these changes, the initial render for components goes to ~150ms settling to ~50ms, and the partial times stay about the same.

The biggest change comes from a slight refactor on the code that checks to see if elements can be detached at the end of a runloop, namely, if there are no nodes to detach, there's no need to try to gather outros to check against an empty list.

The second comes in the form of a slight event firing refactor wherein instances that have no namespaced events are entirely skipped during bubbling, so you don't pay a perf penalty unless you're actually using namespaced events. This only accounts for 5-7% of the gap.

The last bit comes from fixing some de-opts around `combine` and `extend` and re-jiggering a few hot codepaths to avoid extra function calls and whatnot.

My final test with 50000 iterations of each shows that for huge numbers of iterations, components are ~10x more expensive than partials on initial run. edge actually bails when trying with 50000, but 20000 took 23523ms where this took 1188ms. 50000 components on this takes ~2800ms. 20000 partials takes ~200ms on edge and ~160ms on this for the initial run.

Now, I'd imagine that components that _actually do something_ other than render a single character are probably even _more_ expensive than partials, but I was trying to get a feel for just how much overhead there is at the minimum implementation. I feel pretty good about this PR though, given the difference from edge when rendering 20000 components.

## Fixes the following issues:
To some extent, any pertaining to performance with lots of components.

## Is breaking:
Nope.