### PR TITLE
Fix multiple Select.js with null value

### DIFF
--- a/src/view/items/element/specials/Select.js
+++ b/src/view/items/element/specials/Select.js
@@ -61,7 +61,7 @@ export default class Select extends Element {
 
 		// If the <select> has a specified value, that should override
 		// these options
-		if ( selectValue !== undefined ) {
+		if ( selectValue !== undefined && selectValue !== null) {
 			let optionWasSelected;
 
 			options.forEach( o => {


### PR DESCRIPTION
## Description of the pull request:
I have a select element in template. The `value` value is `null` by default.

```
<select multiple as-chosen="'filterValue'" value="{{ value }}">
    {{ #each values }}
        <option value="{{ .value }}">{{ .text }}</option>
    {{ /each }}
</select>
```

After migrating from 0.7 to 0.8 I faced with the following error

> Uncaught TypeError: Cannot read property 'length' of null
>     at valueContains (http://static.clientobox.vagrant/js/ractive/ractive.js?vid=__hash__:14886:22)
>     at http://static.clientobox.vagrant/js/ractive/ractive.js?vid=__hash__:14954:38
>     at Array.forEach (native)
>     at Select.sync (http://static.clientobox.vagrant/js/ractive/ractive.js?vid=__hash__:14952:13)
>     at Select.render (http://static.clientobox.vagrant/js/ractive/ractive.js?vid=__hash__:14913:9)
>     at http://static.clientobox.vagrant/js/ractive/ractive.js?vid=__hash__:16471:55
>     at Array.forEach (native)
>     at Fragment.render (http://static.clientobox.vagrant/js/ractive/ractive.js?vid=__hash__:16471:14)
>     at Section.render (http://static.clientobox.vagrant/js/ractive/ractive.js?vid=__hash__:14775:39)

## Fixes the following issues:
## Is breaking:
I don't think so
## Reviewers:
@Rich-Harris 