### PR TITLE
Lowercase element names if they are in the html namespace - #2821

### DIFF
--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -191,7 +191,8 @@ export default class Element extends ContainerItem {
 		}
 
 		if ( !node ) {
-			node = createElement( this.template.e, this.namespace, this.getAttribute( 'is' ) );
+			const name = this.template.e;
+			node = createElement( this.namespace === html ? name.toLowerCase() : name, this.namespace, this.getAttribute( 'is' ) );
 			this.node = node;
 		}
 


### PR DESCRIPTION
## Description of the pull request:
This lowercases element names when creating elements if they are in the html namespace. This should resolve #2821 and not affect other namespaces, like svg, that require case sensitive tag names.

There's not really a way to CI test this, other than the failing test on Edge mentioned in the linked issue, because webkit/blink-based browsers (PhantomJS) return lowercased elements regardless.

## Fixes the following issues:
#2821

## Is breaking:
Nope.

## Reviewers:
@fskreuz 
