### PR TITLE
Add support for naming attributes in component definitions - RFC (0.9)

### DIFF
--- a/src/Ractive/config/config.js
+++ b/src/Ractive/config/config.js
@@ -20,7 +20,7 @@ const defaultKeys = Object.keys( defaults );
 const isStandardKey = makeObj( defaultKeys.filter( key => !custom[ key ] ) );
 
 // blacklisted keys that we don't double extend
-const isBlacklisted = makeObj( defaultKeys.concat( registries.map( r => r.name ), [ 'on', 'observe' ] ) );
+const isBlacklisted = makeObj( defaultKeys.concat( registries.map( r => r.name ), [ 'on', 'observe', 'attributes' ] ) );
 
 const order = [].concat(
 	defaultKeys.filter( key => !registries[ key ] && !custom[ key ] ),

--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -11,7 +11,7 @@ import RootModel from '../model/RootModel';
 import Hook from '../events/Hook';
 import getComputationSignature from './helpers/getComputationSignature';
 import Ractive from '../Ractive';
-import { ATTRIBUTE } from '../config/types';
+import { ATTRIBUTE, INTERPOLATOR } from '../config/types';
 
 const constructHook = new Hook( 'construct' );
 
@@ -173,7 +173,13 @@ function handleAttributes ( ractive ) {
 		while ( i-- ) {
 			const a = attrs[i];
 			if ( a.t === ATTRIBUTE && !~all.indexOf( a.n ) ) {
-				partial.unshift( attrs.splice( i, 1 )[0] );
+				if ( attributes.mapAll ) {
+					// map the attribute if requested and make the extra attribute in the partial refer to the mapping
+					partial.unshift({ t: ATTRIBUTE, n: a.n, f: [{ t: INTERPOLATOR, r: `~/${a.n}` }] });
+				} else {
+					// transfer the attribute to the extra attributes partal
+					partial.unshift( attrs.splice( i, 1 )[0] );
+				}
 			}
 		}
 

--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -154,7 +154,8 @@ function handleAttributes ( ractive ) {
 	const attributes = ractive.constructor.attributes;
 
 	if ( attributes && component ) {
-		const attrs = component.template.m ? component.template.m.slice() : [];
+		const tpl = component.template;
+		const attrs = tpl.m ? tpl.m.slice() : [];
 
 		// grab all of the passed attribute names
 		const props = attrs.filter( a => a.t === ATTRIBUTE ).map( a => a.n );
@@ -183,7 +184,7 @@ function handleAttributes ( ractive ) {
 			}
 		}
 
-		if ( partial.length ) component.template.m = attrs;
+		if ( partial.length ) component.template = { t: tpl.t, e: tpl.e, f: tpl.f, m: attrs, p: tpl.p };
 		ractive._attributePartial = partial;
 	}
 }

--- a/src/extend/_extend.js
+++ b/src/extend/_extend.js
@@ -56,6 +56,24 @@ function extendOne ( Parent, options = {} ) {
 	Child._on = ( Parent._on || [] ).concat( toPairs( options.on ) );
 	Child._observe = ( Parent._observe || [] ).concat( toPairs( options.observe ) );
 
+	// attribute defs are not inherited, but they need to be stored
+	if ( options.attributes ) {
+		let attrs;
+
+		// allow an array of optional props or an object with arrays for optional and required props
+		if ( Array.isArray( options.attributes ) ) {
+			attrs = { optional: options.attributes, required: [] };
+		} else {
+			attrs = options.attributes;
+		}
+
+		// make sure the requisite keys actually store arrays
+		if ( !Array.isArray( attrs.required ) ) attrs.required = [];
+		if ( !Array.isArray( attrs.optional ) ) attrs.optional = [];
+
+		Child.attributes = attrs;
+	}
+
 	dataConfigurator.extend( Parent, proto, options );
 
 	if ( options.computed ) {

--- a/src/view/items/element/Attribute.js
+++ b/src/view/items/element/Attribute.js
@@ -8,6 +8,7 @@ import propertyNames from './attribute/propertyNames';
 import { safeAttributeString } from '../../../utils/dom';
 import { booleanAttributes } from '../../../utils/html';
 import hyphenateCamel from '../../../utils/hyphenateCamel';
+import { inAttributes } from './ConditionalAttribute';
 
 function lookupNamespace ( node, prefix ) {
 	const qualified = `xmlns:${prefix}`;
@@ -122,6 +123,8 @@ export default class Attribute extends Item {
 	}
 
 	toString () {
+		if ( inAttributes() ) return '';
+
 		const value = this.getValue();
 
 		// Special case - select and textarea values (should not be stringified)

--- a/src/view/items/element/ConditionalAttribute.js
+++ b/src/view/items/element/ConditionalAttribute.js
@@ -54,11 +54,11 @@ export default class ConditionalAttribute extends Item {
 
 		attributes = true;
 		if ( !this.rendered ) this.fragment.render();
-		attributes = false;
 
 		this.rendered = true;
 		this.dirty = true; // TODO this seems hacky, but necessary for tests to pass in browser AND node.js
 		this.update();
+		attributes = false;
 	}
 
 	toString () {
@@ -81,9 +81,10 @@ export default class ConditionalAttribute extends Item {
 		if ( this.dirty ) {
 			this.dirty = false;
 
+			const current = attributes;
 			attributes = true;
 			this.fragment.update();
-			attributes = false;
+			attributes = current || false;
 
 			if ( this.rendered && this.node ) {
 				str = this.fragment.toString();

--- a/test/browser-tests/components/attributes.js
+++ b/test/browser-tests/components/attributes.js
@@ -1,0 +1,108 @@
+import { test } from 'qunit';
+import { onWarn } from '../test-config';
+import { initModule } from '../test-config';
+
+export default function() {
+	initModule( 'components/attributes.js' );
+
+	test( `by default all attributes are mapped`, t => {
+		const cmp = Ractive.extend({
+			template: '{{foo}} {{bar}}'
+		});
+
+		t.equal( cmp.attributes, undefined );
+
+		new Ractive({
+			target: fixture,
+			template: '<cmp foo="{{baz}}" bar="{{bat}}" />',
+			components: { cmp },
+			data: {
+				baz: 1,
+				bat: 2
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, '1 2' );
+	});
+
+	test( `attributes as an array of strings are all optional`, t => {
+		const cmp = Ractive.extend({
+			attributes: [ 'foo', 'bar' ]
+		});
+
+		t.deepEqual( cmp.attributes, { optional: [ 'foo', 'bar' ], required: [] } );
+	});
+
+	test( `attributes may contain optional, required, neither, or both`, t => {
+		const optional = Ractive.extend({
+			attributes: { optional: [ 'foo' ] }
+		});
+		const required = Ractive.extend({
+			attributes: { required: [ 'bar' ] }
+		});
+		const both = Ractive.extend({
+			attributes: { optional: [ 'foo' ], required: [ 'bar' ] }
+		});
+		const neither = Ractive.extend({
+			attributes: {}
+		});
+
+		t.deepEqual( optional.attributes, { optional: [ 'foo' ], required: [] } );
+		t.deepEqual( required.attributes, { optional: [], required: [ 'bar' ] } );
+		t.deepEqual( both.attributes, { optional: [ 'foo' ], required: [ 'bar' ] } );
+		t.deepEqual( neither.attributes, { optional: [], required: [] } );
+	});
+
+	test( `only named attributes are mapped into component`, t => {
+		const cmp = Ractive.extend({
+			attributes: [ 'foo', 'bar' ],
+			template: '{{foo}} {{bar}} {{baz}}',
+			isolated: true
+		});
+		new Ractive({
+			target: fixture,
+			template: `<cmp foo="{{foo}}" bar="{{bar}}" baz="{{baz}}" />`,
+			components: { cmp },
+			data: {
+				foo: 'foo', bar: 'bar', baz: 'baz'
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'foo bar' );
+	});
+
+	test( `leaving off a required attribute issues a warning`, t => {
+		t.expect( 2 );
+		onWarn( msg => t.ok( /.*cmp.*requires attribute.*foo.*/.test( msg ) ) );
+		const cmp = Ractive.extend({
+			attributes: {
+				required: [ 'foo' ]
+			},
+			template: 'yep'
+		});
+		new Ractive({
+			target: fixture,
+			template: `<cmp />`,
+			components: { cmp }
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'yep' );
+	});
+
+	test( `extra attributes are collected into a partial and attached to the instance`, t => {
+		const cmp = Ractive.extend({
+			attributes: [ 'item', 'color' ],
+			template: `<div {{yield extra-attributes}} style-color="{{color}}">{{item}}</div>`,
+			data: { bar: 21 }
+		});
+
+		new Ractive({
+			target: fixture,
+			template: `<cmp class="big" data-foo="{{bar}}" item="{{item}}" color="green" />`,
+			components: { cmp },
+			data: { bar: 'yep', item: 'thing' }
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div class="big" data-foo="yep" style="color: green;">thing</div>' );
+	});
+}

--- a/test/browser-tests/components/attributes.js
+++ b/test/browser-tests/components/attributes.js
@@ -96,7 +96,7 @@ export default function() {
 			data: { bar: 21 }
 		});
 
-		new Ractive({
+		const r = new Ractive({
 			target: fixture,
 			template: `<cmp class="big" data-foo="{{bar}}" item="{{item}}" color="green" />`,
 			components: { cmp },
@@ -104,5 +104,34 @@ export default function() {
 		});
 
 		t.htmlEqual( fixture.innerHTML, '<div class="big" data-foo="yep" style="color: green;">thing</div>' );
+
+		const inst = r.findComponent( 'cmp' );
+		t.ok( inst.get( 'data-foo' ) === undefined );
+	});
+
+	test( `extra attributes may be mapped if requested and the partial will refer to the mapping`, t => {
+		const cmp = Ractive.extend({
+			attributes: {
+				optional: [ 'item' ],
+				mapAll: true
+			},
+			template: `<div {{> extra-attributes}}>{{item}}</div>`
+		});
+
+		const r = new Ractive({
+			target: fixture,
+			template: `<cmp class="big" item="{{item}}" data-foo="{{foo}}" />`,
+			components: { cmp },
+			data: { foo: 'yep', item: 'thing' }
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div class="big" data-foo="yep">thing</div>' );
+
+		const inst = r.findComponent( 'cmp' );
+		t.equal( inst.get( 'class' ), 'big' );
+		t.equal( inst.get( 'data-foo' ), 'yep' );
+
+		inst.set( 'data-foo', 'still yep' );
+		t.equal( r.get( 'foo' ), 'still yep' );
 	});
 }

--- a/test/browser-tests/components/attributes.js
+++ b/test/browser-tests/components/attributes.js
@@ -134,4 +134,19 @@ export default function() {
 		inst.set( 'data-foo', 'still yep' );
 		t.equal( r.get( 'foo' ), 'still yep' );
 	});
+
+	test( `multiple component renders with attributes all start with the initial template`, t => {
+		const cmp = Ractive.extend({
+			attributes: [],
+			template: '<div {{yield extra-attributes}} />'
+		});
+
+		new Ractive({
+			target: fixture,
+			template: '{{#each [1,1,1]}}<cmp class="foo" />{{/each}}',
+			components: { cmp }
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div class="foo"></div><div class="foo"></div><div class="foo"></div>' );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
This adds a new option to `Ractive.extend` that allows component authors to specify which attributes should be accepted in the component. If the component user fails to supply a `required` attributes, then a warning will be issued in `DEBUG` mode. The `attributes` option may be an array of strings, which translates into an array of `optional` attributes, or an object with `optional` and/or `required` keys with array of strings values.

Any attributes that are passed that are not found in either the `required` or `optional` attributes lists will _not_ be added to the component model. This keeps users from accidentally shadowing an internal property with a link/mapping. Further, these additional attributes are collected into a partial, named `extra-attributes`, which can then be yielded in a tag body to make passing html attributes to the main component element simpler. Note that unless there are no mapping-style attributes, the provided `extra-attributes` partial _must_ be yielded because the additional mappings will _not_ be created. Using `yield` keeps the references in the context of the calling instance so that they can resolve properly.

This option _only_ affects components that are instantiated by a template, which leaves out `new MyComponent()` and anchors.

`attributes` are not inherited from their parent component.

This is one of the last things on my list to address before moving 0.9 to alpha. I think there's some merit to pulling the bulk of #2766 into a helper library for more advanced cases, but it's just too heavy and independent to include here. It would also complement this PR for more advanced cases like splitting extra attributes across more than one element in the component body.

### Questions

1. Should there be an additional setting in the `attributes` object form that allows extra attributes to be mapped so that the `extra-attributes` partial ends up using references to the mappings? e.g. `<cmp foo="{{bar}}" />` with foo not specified as an attribute would still create a `foo` mapping to the owner's `bar`, and the extra partial would effectively be `foo="{{foo}}"` i.e. referencing the mapped value.
2. Are `attributes`, `required`, `optional`, and `extra-attributes` good names?
3. I also considered allowing the `required` array to be an object where the key is the option name and the value is a message to display if the attribute is elided. That seems like overkill for now though, right?

## Fixes the following issues:
#1535 and half of #1800

## Is breaking:
Only if you were already using `attributes` with `extend` to add it to the component prototype.

## Reviewers:
@dagnelies @fskreuz and anyone else interested in better control over component attributes