### PR TITLE
Add a way to get the source instance and path for links - RFC

### DIFF
--- a/src/Ractive/prototype.js
+++ b/src/Ractive/prototype.js
@@ -23,6 +23,7 @@ import on from './prototype/on';
 import once from './prototype/once';
 import pop from './prototype/pop';
 import push from './prototype/push';
+import readLink from './prototype/readLink';
 import render from './prototype/render';
 import reset from './prototype/reset';
 import resetPartial from './prototype/resetPartial';
@@ -73,6 +74,7 @@ export default {
 	once,
 	pop,
 	push,
+	readLink,
 	render,
 	reset,
 	resetPartial,

--- a/src/Ractive/prototype/readLink.js
+++ b/src/Ractive/prototype/readLink.js
@@ -1,0 +1,17 @@
+import { splitKeypath } from '../../shared/keypaths';
+
+export default function readLink ( keypath, options = {} ) {
+	const path = splitKeypath( keypath );
+
+	if ( this.viewmodel.has( path[0] ) ) {
+		let model = this.viewmodel.joinAll( path );
+
+		if ( !model.isLink ) return;
+
+		while ( ( model = model.target ) && options.canonical !== false ) {
+			if ( !model.isLink ) break;
+		}
+
+		if ( model ) return { ractive: model.root.ractive, keypath: model.getKeypath() };
+	}
+}

--- a/src/view/helpers/contextMethods.js
+++ b/src/view/helpers/contextMethods.js
@@ -128,6 +128,10 @@ function raise ( name, event, ...args ) {
 	}
 }
 
+function readLink ( keypath, options ) {
+	return this.ractive.readLink( this.resolve( keypath ), options );
+}
+
 function reverse ( keypath ) {
 	return modelReverse( findModel( this, keypath ).model, [] );
 }
@@ -231,6 +235,7 @@ export function addHelpers ( obj, element ) {
 		pop: { value: pop },
 		push: { value: push },
 		raise: { value: raise },
+		readLink: { value: readLink },
 		reverse: { value: reverse },
 		set: { value: set },
 		shift: { value: shift },

--- a/test/browser-tests/methods/readLink.js
+++ b/test/browser-tests/methods/readLink.js
@@ -1,0 +1,77 @@
+import { test } from 'qunit';
+import { initModule } from '../test-config';
+
+export default function() {
+	initModule( 'methods/readLink.js' );
+
+	test( `readLink returns the immediately linked path by default`, t => {
+		const r = new Ractive({
+			target: fixture
+		});
+		r.set( 'foo.bar.baz.bat', true );
+		r.link( 'foo.bar.baz.bat', 'bop' );
+
+		t.equal( r.get( 'foo.bar.baz.bat' ), true );
+		t.equal( r.get( 'bop' ), true );
+
+		t.equal( r.readLink( 'bop' ).keypath, 'foo.bar.baz.bat' );
+		t.ok( r.readLink( 'bop' ).ractive === r );
+	});
+
+	test( `readLink on a non-link returns undefined`, t => {
+		const r = new Ractive({
+			target: fixture
+		});
+		r.set( 'bop', true );
+
+		t.ok( r.readLink( 'bop' ) === undefined );
+	});
+
+	test( `readLink with a mapped path returns the source instance`, t => {
+		const cmp = Ractive.extend();
+		const r = new Ractive({
+			on: { init() { this.set( 'foo.bar.baz.bat', true ); } },
+			target: fixture,
+			components: { cmp },
+			template: `<cmp bop="{{foo.bar.baz.bat}}" />`
+		});
+
+		const child = r.findComponent( 'cmp' );
+		t.equal( child.readLink( 'bop' ).keypath, 'foo.bar.baz.bat' );
+		t.ok( child.readLink( 'bop' ).ractive === r );
+	});
+
+	test( `readLink is canonical by default`, t => {
+		const cmp1 = Ractive.extend({
+			template: '<cmp2 fizz="{{bop}}" />'
+		});
+		const cmp2 = Ractive.extend();
+		const r = new Ractive({
+			on: { init() { this.set( 'foo.bar.baz.bat', true ); } },
+			target: fixture,
+			components: { cmp1, cmp2 },
+			template: `<cmp1 bop="{{foo.bar.baz.bat}}" />`
+		});
+
+		const child = r.findComponent( 'cmp2' );
+		t.equal( child.readLink( 'fizz' ).keypath, 'foo.bar.baz.bat' );
+		t.ok( child.readLink( 'fizz' ).ractive === r );
+	});
+
+	test( `readLink can optionally be uncanonical`, t => {
+		const cmp1 = Ractive.extend({
+			template: '<cmp2 fizz="{{bop}}" />'
+		});
+		const cmp2 = Ractive.extend();
+		const r = new Ractive({
+			on: { init() { this.set( 'foo.bar.baz.bat', true ); } },
+			target: fixture,
+			components: { cmp1, cmp2 },
+			template: `<cmp1 bop="{{foo.bar.baz.bat}}" />`
+		});
+
+		const child = r.findComponent( 'cmp2' );
+		t.equal( child.readLink( 'fizz', { canonical: false } ).keypath, 'bop' );
+		t.ok( child.readLink( 'fizz', { canonical: false } ).ractive === r.findComponent( 'cmp1' ) );
+	});
+}

--- a/test/browser-tests/node-info.js
+++ b/test/browser-tests/node-info.js
@@ -237,7 +237,7 @@ export default function() {
 
 	test( 'node info link', t => {
 		const r = new Ractive({
-			el:fixture,
+			el: fixture,
 			template: `{{#with foo.bar}}<span />{{/with}}`,
 			data: { foo: { bar: { baz: 'hello' } } }
 		});
@@ -250,7 +250,7 @@ export default function() {
 
 	test( 'node info unlink', t => {
 		const r = new Ractive({
-			el:fixture,
+			el: fixture,
 			template: `{{#with foo.bar}}<span />{{/with}}`,
 			data: { foo: { bar: { baz: 'hello' } } }
 		});
@@ -262,6 +262,18 @@ export default function() {
 		info.unlink( 'str' );
 		info.set( '.baz', 'yep' );
 		t.ok( r.get( 'str' ) !== 'yep' );
+	});
+
+	test( `node info readLink`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: `{{#with bip}}<span />{{/with}}`,
+			data: { bip: {} }
+		});
+		r.set( 'foo.bar.baz.bat', true );
+		r.link( 'foo.bar.baz.bat', 'bip.bop' );
+
+		t.equal( r.getNodeInfo( 'span' ).readLink( '.bop' ).keypath, 'foo.bar.baz.bat' );
 	});
 
 	test( 'node info merge', t => {
@@ -547,9 +559,9 @@ export default function() {
 			template: `<div on-foo="wat" />`
 		});
 
-		r.on( 'wat', () => t.ok( true ) );
+		r.on( 'wat', ( ev, arg ) => t.equal( arg, 'bar' ) );
 
-		r.getNodeInfo( 'div' ).raise( 'foo' );
+		r.getNodeInfo( 'div' ).raise( 'foo', {}, 'bar' );
 	});
 
 	test( `context objects can trigger events on parent elements`, t => {


### PR DESCRIPTION
## Description of the pull request:
This adds a new prototype function `readLink` that when called with a keypath returns the source keypath and ractive instance for the link/mapping. If the keypath is not a link, it returns undefined. If you pass `{ canonical: false }`, then only the first level of links will be returned in the case of links to links (mappings).

The behavior of `readLink` is based on what the `readlink` command does with symlinks with some slight variation around canonicalization.

## Fixes the following issues:
#2657

## Is breaking:
Nope