### PR TITLE
Add support for template strings - RFC

### DIFF
--- a/gobblefile.js
+++ b/gobblefile.js
@@ -88,6 +88,7 @@ test = (function () {
 		qunit: 'QUnit',
 		simulant: 'simulant'
 	};
+	var external = [ 'qunit', 'simulant' ];
 
 	var browserTests = gobble( 'test/browser-tests' ).moveTo( 'browser-tests' ).transform( function bundleTests ( inputdir, outputdir, options ) {
 		testFiles.sort();
@@ -130,10 +131,8 @@ test = (function () {
 		entry: 'browser-tests/all.js',
 		moduleName: 'tests',
 		dest: 'all.js',
-		globals: {
-			qunit: 'QUnit',
-			simulant: 'simulant'
-		}
+		globals: globals,
+		external: external
 	});
 
 	return gobble([
@@ -154,12 +153,14 @@ test = (function () {
 							entry: inputDir + '/' + file,
 							plugins: [ rollupBuble(bubleOptions) ],
 							globals: globals,
+							external: external,
 							onwarn: noop
 						}).then( function ( bundle ) {
 							return bundle.write({
 								dest: outputDir + '/' + file,
 								format: 'cjs',
 								globals: globals,
+								external: external,
 								moduleName: 'tests'
 							});
 						});

--- a/src/parse/converters/expressions/primary/literal/readStringLiteral.js
+++ b/src/parse/converters/expressions/primary/literal/readStringLiteral.js
@@ -1,30 +1,17 @@
 import { STRING_LITERAL } from '../../../../../config/types';
 import makeQuotedStringMatcher from './stringLiteral/makeQuotedStringMatcher';
 
-const getSingleQuotedString = makeQuotedStringMatcher( `"` );
-const getDoubleQuotedString = makeQuotedStringMatcher( `'` );
+const singleMatcher = makeQuotedStringMatcher( `"` );
+const doubleMatcher = makeQuotedStringMatcher( `'` );
 
 export default function ( parser ) {
 	const start = parser.pos;
+	const quote = parser.matchString( `'` ) || parser.matchString( `"` );
 
-	if ( parser.matchString( '"' ) ) {
-		const string = getDoubleQuotedString( parser );
+	if ( quote ) {
+		const string = ( quote === `'` ? singleMatcher : doubleMatcher )( parser );
 
-		if ( !parser.matchString( '"' ) ) {
-			parser.pos = start;
-			return null;
-		}
-
-		return {
-			t: STRING_LITERAL,
-			v: string
-		};
-	}
-
-	if ( parser.matchString( `'` ) ) {
-		const string = getSingleQuotedString( parser );
-
-		if ( !parser.matchString( `'` ) ) {
+		if ( !parser.matchString( quote ) ) {
 			parser.pos = start;
 			return null;
 		}

--- a/src/parse/converters/expressions/primary/literal/readTemplateStringLiteral.js
+++ b/src/parse/converters/expressions/primary/literal/readTemplateStringLiteral.js
@@ -1,0 +1,93 @@
+import readExpression from '../../../readExpression';
+import { STRING_LITERAL, BRACKETED, INFIX_OPERATOR } from '../../../../../config/types';
+import { escapeSequencePattern, lineContinuationPattern } from './stringLiteral/makeQuotedStringMatcher';
+
+// Match one or more characters until: ", ', or \
+const stringMiddlePattern = /^[^`"\\\$]+?(?:(?=[`"\\\$]))/;
+
+const escapes = /[\r\n\t\b\f]/g;
+function getString ( literal ) {
+	return JSON.parse( `"${literal.replace( escapes, escapeChar )}"` );
+}
+
+function escapeChar ( c ) {
+	switch ( c ) {
+		case '\n': return '\\n';
+		case '\r': return '\\r';
+		case '\t': return '\\t';
+		case '\b': return '\\b';
+		case '\f': return '\\f';
+	}
+}
+
+export default function readTemplateStringLiteral ( parser ) {
+	if ( !parser.matchString( '`' ) ) return null;
+
+	let literal = '';
+	let done = false;
+	let next;
+	const parts = [];
+
+	while ( !done ) {
+		next = parser.matchPattern( stringMiddlePattern ) || parser.matchPattern( escapeSequencePattern ) ||
+			parser.matchString( '$' ) || parser.matchString( '"' );
+		if ( next ) {
+			if ( next === `"` ) {
+				literal += `\\"`;
+			} else if ( next === '\\`' ) {
+				literal += '`';
+			} else if ( next === '$' ) {
+				if ( parser.matchString( '{' ) ) {
+					parts.push({ t: STRING_LITERAL, v: getString( literal ) });
+					literal = '';
+
+					parser.allowWhitespace();
+					const expr = readExpression( parser );
+
+					if ( !expr ) parser.error( 'Expected valid expression' );
+
+					parts.push({ t: BRACKETED, x: expr });
+
+					parser.allowWhitespace();
+					if ( !parser.matchString( '}' ) ) parser.error( `Expected closing '}' after interpolated expression` );
+				} else {
+					literal += '$';
+				}
+			} else {
+				literal += next;
+			}
+		} else {
+			next = parser.matchPattern( lineContinuationPattern );
+			if ( next ) {
+				// convert \(newline-like) into a \u escape, which is allowed in JSON
+				literal += '\\u' + ( '000' + next.charCodeAt(1).toString(16) ).slice( -4 );
+			} else {
+				done = true;
+			}
+		}
+	}
+
+	if ( literal.length ) parts.push({ t: STRING_LITERAL, v: getString( literal ) });
+
+	if ( !parser.matchString( '`' ) ) parser.error( "Expected closing '`'" );
+
+	if ( parts.length === 1 ) {
+		return parts[0];
+	} else {
+		let result = parts.pop();
+		let part;
+
+		while ( part = parts.pop() ) {
+			result = {
+				t: INFIX_OPERATOR,
+				s: '+',
+				o: [ part, result ]
+			};
+		}
+
+		return {
+			t: BRACKETED,
+			x: result
+		};
+	}
+}

--- a/src/parse/converters/expressions/primary/literal/stringLiteral/makeQuotedStringMatcher.js
+++ b/src/parse/converters/expressions/primary/literal/stringLiteral/makeQuotedStringMatcher.js
@@ -3,10 +3,10 @@
 const stringMiddlePattern = /^(?=.)[^"'\\]+?(?:(?!.)|(?=["'\\]))/;
 
 // Match one escape sequence, including the backslash.
-const escapeSequencePattern = /^\\(?:['"\\bfnrt]|0(?![0-9])|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|(?=.)[^ux0-9])/;
+export const escapeSequencePattern = /^\\(?:[`'"\\bfnrt]|0(?![0-9])|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|(?=.)[^ux0-9])/;
 
 // Match one ES5 line continuation (backslash + line terminator).
-const lineContinuationPattern = /^\\(?:\r\n|[\u000A\u000D\u2028\u2029])/;
+export const lineContinuationPattern = /^\\(?:\r\n|[\u000A\u000D\u2028\u2029])/;
 
 // Helper for defining getDoubleQuotedString and getSingleQuotedString.
 export default function ( okQuote ) {

--- a/src/parse/converters/expressions/primary/readLiteral.js
+++ b/src/parse/converters/expressions/primary/readLiteral.js
@@ -1,15 +1,17 @@
 import readNumberLiteral from './literal/readNumberLiteral';
 import readBooleanLiteral from './literal/readBooleanLiteral';
 import readStringLiteral from './literal/readStringLiteral';
+import readTemplateStringLiteral from './literal/readTemplateStringLiteral';
 import readObjectLiteral from './literal/readObjectLiteral';
 import readArrayLiteral from './literal/readArrayLiteral';
 import readRegexpLiteral from './literal/readRegexpLiteral';
 
 export default function readLiteral ( parser ) {
-	return readNumberLiteral( parser )  ||
-	       readBooleanLiteral( parser ) ||
-	       readStringLiteral( parser )  ||
-	       readObjectLiteral( parser )  ||
-	       readArrayLiteral( parser )   ||
+	return readNumberLiteral( parser )         ||
+	       readBooleanLiteral( parser )        ||
+	       readStringLiteral( parser )         ||
+	       readTemplateStringLiteral( parser ) ||
+	       readObjectLiteral( parser )         ||
+	       readArrayLiteral( parser )          ||
 	       readRegexpLiteral( parser );
 }

--- a/test/__support/js/samples/parse.js
+++ b/test/__support/js/samples/parse.js
@@ -856,6 +856,21 @@ const parseTests = [
        ^----`
 	},
 	{
+		name: 'basic string templates',
+		template: '{{ `hello, ${name}!` }}',
+		parsed: {v:4,t:[{t:2,x:{r:['name'],s:'"hello, "+(_0)+"!"'}}]}
+	},
+	{
+		name: 'string templates with escaped chars',
+		template: '{{ `hello, ${ name }\r \n \t \b \f "\'\\`\\"` }}',
+		parsed: {v:4,t:[{t:2,x:{r:['name'],s:'"hello, "+(_0)+"\\r \\n \\t \\b \\f \\"\'`\\""'}}]}
+	},
+	{
+		name: 'string template with string template expression in interpolation',
+		template: '{{ `hello, ${names[`${name}Guy`]}!` }}',
+		parsed: {v:4,t:[{t:2,x:{r:['name','names'],s:'"hello, "+(_1[(""+(_0)+"Guy")])+"!"'}}]}
+	},
+	{
 		name: 'csp: true',
 		template: '{{x + 1}}<a {{#if x + 2}}data-id={{x + 3}}{{/if}} slide-in="x+4" on-click="proxy" on-focus="method(x + 5)">{{foo.bar[x + 6].baz}}</a>',
 		options: { csp: true },


### PR DESCRIPTION
## Description of the pull request:
This adds parser support for (non-tagged) template strings, because I've gotten used to using them. It basically takes the ` ``str ${v}`` ` format and converts it into an expression `"str "+v`, which is then used in the template. I think all of the supportable weird things are covered, like template string in an interpolator of a template string. Of course the usual things are covered too, like multiline strings, interpolators, not having to escape non-backtick quotes, and everything from the other string literal forms.

As an additional optimization, if there are no expression parts, the template becomes a plain old string literal rather than a bracketed expression.

The overall weight added is less than 1k after minification, and the runtime build actually gets a bit smaller as a result of some code drying in the plain string literal parser that is pulled in for all types of build.

## Fixes the following issues:
None that I know of

## Is breaking:
Shouldn't be