### PR TITLE
First swing at event delegation - RFC

### DIFF
--- a/src/config/types.js
+++ b/src/config/types.js
@@ -51,3 +51,4 @@ export const EVENT             = 70;
 export const DECORATOR         = 71;
 export const TRANSITION        = 72;
 export const BINDING_FLAG      = 73;
+export const EVENT_DELEGATE    = 74;

--- a/src/view/helpers/contextMethods.js
+++ b/src/view/helpers/contextMethods.js
@@ -38,9 +38,9 @@ function build ( el, keypath, value ) {
 
 // get relative keypaths and values
 function get ( keypath ) {
-	if ( !keypath ) return this._element.parentFragment.findContext().get( true );
+	if ( !keypath ) return this.proxy.parentFragment.findContext().get( true );
 
-	const model = resolveReference( this._element.parentFragment, keypath );
+	const model = resolveReference( this.proxy.parentFragment, keypath );
 
 	return model ? model.get( true ) : undefined;
 }
@@ -51,7 +51,7 @@ function resolve ( path, ractive ) {
 }
 
 function findModel ( el, path ) {
-	const frag = el._element.parentFragment;
+	const frag = el.proxy.parentFragment;
 
 	if ( typeof path !== 'string' ) {
 		return { model: frag.findContext(), instance: path };
@@ -92,13 +92,13 @@ function merge ( keypath, array, options ) {
 
 function observe ( keypath, callback, options = {} ) {
 	if ( isObject( keypath ) ) options = callback || {};
-	options.fragment = this._element.parentFragment;
+	options.fragment = this.proxy.parentFragment;
 	return this.ractive.observe( keypath, callback, options );
 }
 
 function observeOnce ( keypath, callback, options = {} ) {
 	if ( isObject( keypath ) ) options = callback || {};
-	options.fragment = this._element.parentFragment;
+	options.fragment = this.proxy.parentFragment;
 	return this.ractive.observeOnce( keypath, callback, options );
 }
 
@@ -111,10 +111,10 @@ function push ( keypath, ...values ) {
 }
 
 function raise ( name, event, ...args ) {
-	let element = this._element;
+	let element = this.proxy;
 
 	while ( element ) {
-		const events = element.events;
+		const events = element.events.concat( element.delegates );
 		for ( let i = 0; i < events.length; i++ ) {
 			const event = events[i];
 			if ( ~event.template.n.indexOf( name ) ) {
@@ -209,7 +209,7 @@ function getBinding () {
 }
 
 function getBindingModel ( ctx ) {
-	const el = ctx._element;
+	const el = ctx.proxy;
 	return { model: el.binding && el.binding.model, instance: el.parentFragment.ractive };
 }
 
@@ -220,7 +220,7 @@ function setBinding ( value ) {
 
 export function addHelpers ( obj, element ) {
 	Object.defineProperties( obj, {
-		_element: { value: element },
+		proxy: { value: element, writable: true },
 		ractive: { value: element.parentFragment.ractive },
 		resolve: { value: resolve },
 		get: { value: get },
@@ -255,7 +255,7 @@ export function addHelpers ( obj, element ) {
 		decorators: {
 			get () {
 				const items = {};
-				element.decorators.forEach( d => items[ d.name ] = d.intermediary );
+				this.proxy.decorators.forEach( d => items[ d.name ] = d.intermediary );
 				return items;
 			}
 		}

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -1,4 +1,4 @@
-import { ATTRIBUTE, BINDING_FLAG, DECORATOR, EVENT, TRANSITION } from '../../config/types';
+import { ATTRIBUTE, BINDING_FLAG, DECORATOR, EVENT, EVENT_DELEGATE, TRANSITION } from '../../config/types';
 import runloop from '../../global/runloop';
 import { ContainerItem } from './shared/Item';
 import Fragment from '../Fragment';
@@ -37,6 +37,7 @@ export default class Element extends ContainerItem {
 
 		this.decorators = [];
 		this.events = [];
+		this.delegates = [];
 
 		// create attributes
 		this.attributeByName = {};
@@ -49,6 +50,7 @@ export default class Element extends ContainerItem {
 				case BINDING_FLAG:
 				case DECORATOR:
 				case EVENT:
+				case EVENT_DELEGATE:
 				case TRANSITION:
 					this.attributes.push( createItem({
 						owner: this,

--- a/src/view/items/createItem.js
+++ b/src/view/items/createItem.js
@@ -1,5 +1,5 @@
 import { ALIAS, ANCHOR, COMPONENT, DOCTYPE, ELEMENT, INTERPOLATOR, PARTIAL, SECTION, TRIPLE, YIELDER } from '../../config/types';
-import { ATTRIBUTE, BINDING_FLAG, DECORATOR, EVENT, TRANSITION } from '../../config/types';
+import { ATTRIBUTE, BINDING_FLAG, DECORATOR, EVENT, EVENT_DELEGATE, TRANSITION } from '../../config/types';
 import Alias from './Alias';
 import Attribute from './element/Attribute';
 import BindingFlag from './element/BindingFlag';
@@ -38,6 +38,7 @@ constructors[ ATTRIBUTE ] = Attribute;
 constructors[ BINDING_FLAG ] = BindingFlag;
 constructors[ DECORATOR ] = Decorator;
 constructors[ EVENT ] = EventDirective;
+constructors[ EVENT_DELEGATE ] = EventDirective;
 constructors[ TRANSITION ] = Transition;
 
 const specialElements = {

--- a/src/view/items/element/ElementEvents.js
+++ b/src/view/items/element/ElementEvents.js
@@ -22,7 +22,8 @@ class DOMEvent {
 		node.addEventListener( name, this.handler = function( event ) {
 			directive.fire({
 				node,
-				original: event
+				original: event,
+				name
 			});
 		}, false );
 	}

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -1,4 +1,4 @@
-import { ANCHOR, COMPONENT } from '../../../config/types';
+import { ANCHOR, COMPONENT, EVENT_DELEGATE } from '../../../config/types';
 import fireEvent from '../../../events/fireEvent';
 import { splitKeypath } from '../../../shared/keypaths';
 import findElement from './findElement';
@@ -22,121 +22,154 @@ export default class EventDirective {
 		this.template = options.template;
 		this.parentFragment = options.parentFragment;
 		this.ractive = options.parentFragment.ractive;
+		this.delegated = this.template.t === EVENT_DELEGATE && this.template.f;
+		this.delegate = this.template.t === EVENT_DELEGATE && !this.template.f;
 
-		this.events = [];
+		// check for delegated event
+		if ( !this.delegated ) {
+			this.events = [];
 
-		if ( this.element.type === COMPONENT || this.element.type === ANCHOR ) {
-			this.template.n.forEach( n => {
-				this.events.push( new RactiveEvent( this.element, n ) );
-			});
-		} else {
-			this.template.n.forEach( n => {
-				const fn = findInViewHierarchy( 'events', this.ractive, n );
-				// we need to pass in "this" in order to get
-				// access to node when it is created.
-				this.events.push( fn ? new CustomEvent( fn, this.element ) : new DOMEvent( n, this.element ) );
-			});
+			if ( this.element.type === COMPONENT || this.element.type === ANCHOR ) {
+				this.template.n.forEach( n => {
+					this.events.push( new RactiveEvent( this.element, n ) );
+				});
+			} else {
+				this.template.n.forEach( n => {
+					const fn = findInViewHierarchy( 'events', this.ractive, n );
+					// we need to pass in "this" in order to get
+					// access to node when it is created.
+					this.events.push( fn ? new CustomEvent( fn, this.element ) : new DOMEvent( n, this.element ) );
+				});
+			}
 		}
 
 		// method calls
-		this.resolvers = null;
 		this.models = null;
 	}
 
 	bind () {
-		addToArray( this.element.events, this );
+		addToArray(
+			this.delegated ? this.element.delegates : this.element.events,
+			this
+		);
 
-		setupArgsFn( this, this.template );
-		if ( !this.fn ) this.action = this.template.f;
+		if ( !this.delegate ) {
+			setupArgsFn( this, this.template );
+			if ( !this.fn ) this.action = this.template.f;
+		}
 	}
 
 	destroyed () {
-		this.events.forEach( e => e.unlisten() );
+		if ( this.events ) this.events.forEach( e => e.unlisten() );
 	}
 
 	fire ( event, passedArgs = [] ) {
-		// augment event object
-		if ( event && !event.hasOwnProperty( '_element' ) ) {
-		   addHelpers( event, this.owner );
-		}
+		if ( this.delegate ) {
+			if ( event.original ) {
+				const end = this.element.node;
+				let node = event.original.target;
+				// starting with the event target, walk up to the delegate's node looking for delegated listeners
+				while ( node !== end ) {
+					const el = node._ractive && node._ractive.proxy;
+					let stop = false;
+					event.node = el.node;
+					el.delegates.forEach( d => {
+						if ( ~d.template.n.indexOf( event.name ) ) {
+							if ( d.fire( event, passedArgs ) === false ) {
+								stop = true;
+							}
+						}
+					});
 
-		if ( this.fn ) {
-			const values = [];
+					if ( stop ) node = end;
+					else node = event.node.parentNode;
+				}
+			}
+		} else {
+			// augment event object
+			if ( event && !event.hasOwnProperty( '_element' ) ) {
+				addHelpers( event, this.owner );
+			}
 
-			if ( event ) passedArgs.unshift( event );
+			if ( this.fn ) {
+				const values = [];
 
-			const models = resolveArgs( this, this.template, this.parentFragment, {
-				specialRef ( ref ) {
-					const specialMatch = specialPattern.exec( ref );
-					if ( specialMatch ) {
-						// on-click="foo(event.node)"
-						return {
-							special: specialMatch[1],
-							keys: specialMatch[2] ? splitKeypath( specialMatch[2].substr(1) ) : []
-						};
+				if ( event ) passedArgs.unshift( event );
+
+				const models = resolveArgs( this, this.template, this.parentFragment, {
+					specialRef ( ref ) {
+						const specialMatch = specialPattern.exec( ref );
+						if ( specialMatch ) {
+							// on-click="foo(event.node)"
+							return {
+								special: specialMatch[1],
+								keys: specialMatch[2] ? splitKeypath( specialMatch[2].substr(1) ) : []
+							};
+						}
+
+						const dollarMatch = dollarArgsPattern.exec( ref );
+						if ( dollarMatch ) {
+							// on-click="foo($1)"
+							return {
+								special: 'arguments',
+								keys: [ dollarMatch[1] - 1 ].concat( dollarMatch[2] ? splitKeypath( dollarMatch[2].substr( 1 ) ) : [] )
+							};
+						}
 					}
+				});
 
-					const dollarMatch = dollarArgsPattern.exec( ref );
-					if ( dollarMatch ) {
-						// on-click="foo($1)"
-						return {
-							special: 'arguments',
-							keys: [ dollarMatch[1] - 1 ].concat( dollarMatch[2] ? splitKeypath( dollarMatch[2].substr( 1 ) ) : [] )
-						};
+				if ( models ) {
+					models.forEach( model => {
+						if ( !model ) return values.push( undefined );
+
+						if ( model.special ) {
+							let obj = model.special === 'event' ? event : passedArgs;
+							const keys = model.keys.slice();
+
+							while ( keys.length ) obj = obj[ keys.shift() ];
+							return values.push( obj );
+						}
+
+						if ( model.wrapper ) {
+							return values.push( model.wrapperValue );
+						}
+
+						values.push( model.get() );
+					});
+				}
+
+				// make event available as `this.event`
+				const ractive = this.ractive;
+				const oldEvent = ractive.event;
+
+				ractive.event = event;
+				const result = this.fn.apply( ractive, values ).pop();
+
+				// Auto prevent and stop if return is explicitly false
+				if ( result === false ) {
+					const original = event ? event.original : undefined;
+					if ( original ) {
+						original.preventDefault && original.preventDefault();
+						original.stopPropagation && original.stopPropagation();
+					} else {
+						warnOnceIfDebug( `handler '${this.template.n.join( ' ' )}' returned false, but there is no event available to cancel` );
 					}
 				}
-			});
 
-			if ( models ) {
-				models.forEach( model => {
-					if ( !model ) return values.push( undefined );
+				ractive.event = oldEvent;
+				return result;
+			}
 
-					if ( model.special ) {
-						let obj = model.special === 'event' ? event : passedArgs;
-						const keys = model.keys.slice();
+			else {
+				let args = [];
+				if ( passedArgs.length ) args = args.concat( passedArgs );
+				if ( event ) event.name = this.action;
 
-						while ( keys.length ) obj = obj[ keys.shift() ];
-						return values.push( obj );
-					}
-
-					if ( model.wrapper ) {
-						return values.push( model.wrapperValue );
-					}
-
-					values.push( model.get() );
+				fireEvent( this.ractive, this.action, {
+					event,
+					args
 				});
 			}
-
-			// make event available as `this.event`
-			const ractive = this.ractive;
-			const oldEvent = ractive.event;
-
-			ractive.event = event;
-			const result = this.fn.apply( ractive, values ).pop();
-
-			// Auto prevent and stop if return is explicitly false
-			if ( result === false ) {
-				const original = event ? event.original : undefined;
-				if ( original ) {
-					original.preventDefault && original.preventDefault();
-					original.stopPropagation && original.stopPropagation();
-				} else {
-					warnOnceIfDebug( `handler '${this.template.n.join( ' ' )}' returned false, but there is no event available to cancel` );
-				}
-			}
-
-			ractive.event = oldEvent;
-		}
-
-		else {
-			let args = [];
-			if ( passedArgs.length ) args = args.concat( passedArgs );
-			if ( event ) event.name = this.action;
-
-			fireEvent( this.ractive, this.action, {
-				event,
-				args
-			});
 		}
 	}
 
@@ -144,17 +177,20 @@ export default class EventDirective {
 
 	render () {
 		// render events after everything else, so they fire after bindings
-		runloop.scheduleTask( () => this.events.forEach( e => e.listen( this ), true ) );
+		if ( this.events ) runloop.scheduleTask( () => this.events.forEach( e => e.listen( this ), true ) );
 	}
 
 	toString() { return ''; }
 
 	unbind () {
-		removeFromArray( this.element.events, this );
+		removeFromArray(
+			this.delegated ? this.element.delegates : this.element.events,
+			this
+		);
 	}
 
 	unrender () {
-		this.events.forEach( e => e.unlisten() );
+		if ( this.events ) this.events.forEach( e => e.unlisten() );
 	}
 }
 

--- a/test/browser-tests/events/delegate.js
+++ b/test/browser-tests/events/delegate.js
@@ -1,0 +1,73 @@
+import { test } from 'qunit';
+import { initModule } from '../test-config';
+import { fire } from 'simulant';
+
+export default function() {
+	initModule( 'events/delegate.js' );
+
+	test( `basic delegation`, t => {
+		t.expect( 6 );
+
+		const addEventListener = Element.prototype.addEventListener;
+		let count = 0;
+		Element.prototype.addEventListener = function () {
+			count++;
+			return addEventListener.apply( this, arguments );
+		};
+		const r = new Ractive({
+			target: fixture,
+			template: `<div delegate-click><div delegate-click="ev" /><div delegate-click="other" /></div>`,
+			on: {
+				ev() {
+					t.ok( true, 'event fired' );
+				},
+				other() {
+					t.ok( true, 'other event fired' );
+				}
+			}
+		});
+
+		t.equal( count, 1 );
+		Element.prototype.addEventListener = addEventListener;
+
+		const [ top, ev, other ] = r.findAll( 'div' );
+		t.ok( top._ractive.proxy.events.length );
+		t.ok( ev._ractive.proxy.delegates.length );
+		t.ok( other._ractive.proxy.delegates.length );
+		fire( top, 'click' );
+		fire( ev, 'click' );
+		fire( other, 'click' );
+	});
+
+	test( `library delegated event cancellation`, t => {
+		t.expect( 1 );
+
+		const r = new Ractive({
+			target: fixture,
+			template: `<div delegate-click><div delegate-click="nope"><div delegate-click="yep" /></div></div>`,
+			on: {
+				nope() { t.ok( false, 'should not fire' ); },
+				yep() { t.ok( true, 'should fire' ); return false; }
+			}
+		});
+
+		const yep = r.findAll( 'div' )[2];
+		fire( yep, 'click' );
+	});
+
+	test( `multiple delegated events don't interfere with each other`, t => {
+		t.expect( 1 );
+
+		const r = new Ractive({
+			target: fixture,
+			template: `<div delegate-mouseenter-mouseleave><div delegate-mouseenter="yep" /><div delegate-mouseleave="nope" /></div>`,
+			on: {
+				nope() { t.ok( false, 'should not fire' ); },
+				yep() { t.ok( true, 'should fire' ); }
+			}
+		});
+
+		const yep = r.findAll( 'div' )[1];
+		simulant.fire( yep, 'mouseenter' );
+	});
+}


### PR DESCRIPTION
## Description of the pull request:
Ractive events currently install a listener on their target node, which works out great most of the time, but if you have a large iterative section, attaching event listeners adds a fairly significant overhead. You can manage delegation manually, but it's a little bit painful, because getting in the correct context requires some strange boilerplate.

To address that, this adds support for setting a delegation target and specifying events to be delegated further downstream. To set a target, you add `delegate-click` as an attribute to the element. Then to specify a delegated event, you set `delegate-click="doSomething"` on the source element. When this sees a delegate target, it installs an (or all) appropriate event listener on the target element. When it sees a delegated event, it sets up the fire handler but does nothing further. When the target catches an event, it starts with the target element and walks back up the hierarchy until it reaches the target node while looking for and firing matching delegated event listeners.

Caveats: this only works with events that fire with an original event, so some custom event plugins may not work. It also doesn't really make sense to support component events as delegated, because they don't involve the DOM.

Example:
```html
<table delegate-click>
{{#each lotsOfRows}}
  <tr>
    <td><button delegate-click="@.select(.)">Select</button></td>
    <td>{{.description}}</td>
    <td>{{.something}}</td>
    <td><button delegate-click="event.splice('../../', @index, 1)">Remove</button></td>
  <tr>
{{/each}}
</table>
```

Note that the delegated handlers are written exactly the same as non-delegated handlers would be.

In a benchmark very similar to that example, using delegation reduces render time by ~25% on my machine with 1000 rows, going from 40ms to 30ms on average. Unrender is also a bit quicker on average, as the listeners don't also need to be removed.

### TODO
* [x] Tests

## Fixes the following issues:
The remaining bits of #846

## Is breaking:
Nope

## Reviewers:
Yep