### PR TITLE
Second swing at event delegation - RFC

### DIFF
--- a/src/Ractive/config/defaults.js
+++ b/src/Ractive/config/defaults.js
@@ -1,7 +1,8 @@
 export default {
 	// render placement:
 	el:                     void 0,
-	append:				    false,
+	append:                 false,
+	delegate:               true,
 
 	// template:
 	template:               null,
@@ -11,7 +12,7 @@ export default {
 	tripleDelimiters:       [ '{{{', '}}}' ],
 	staticDelimiters:       [ '[[', ']]' ],
 	staticTripleDelimiters: [ '[[[', ']]]' ],
-	csp: 					true,
+	csp:                    true,
 	interpolate:            false,
 	preserveWhitespace:     false,
 	sanitize:               false,

--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -34,6 +34,11 @@ export default function construct ( ractive, options ) {
 	initialiseProperties( ractive );
 	handleAttributes( ractive );
 
+	// if there's not a delegation setting, inherit from parent if it's not default
+	if ( !options.hasOwnProperty( 'delegate' ) && ractive.parent && ractive.parent.delegate !== ractive.delegate ) {
+		ractive.delegate = false;
+	}
+
 	// TODO don't allow `onconstruct` with `new Ractive()`, there's no need for it
 	constructHook.fire( ractive, options );
 

--- a/src/config/types.js
+++ b/src/config/types.js
@@ -51,3 +51,4 @@ export const EVENT             = 70;
 export const DECORATOR         = 71;
 export const TRANSITION        = 72;
 export const BINDING_FLAG      = 73;
+export const DELEGATE_FLAG     = 74;

--- a/src/parse/converters/element/readAttribute.js
+++ b/src/parse/converters/element/readAttribute.js
@@ -1,4 +1,4 @@
-import { ATTRIBUTE, DECORATOR, BINDING_FLAG, TRANSITION, EVENT } from '../../../config/types';
+import { ATTRIBUTE, DECORATOR, DELEGATE_FLAG, BINDING_FLAG, TRANSITION, EVENT } from '../../../config/types';
 import getLowestIndex from '../utils/getLowestIndex';
 import readMustache from '../readMustache';
 import { decodeCharacterReferences } from '../../../utils/html';
@@ -13,7 +13,8 @@ const decoratorPattern = /^as-([a-z-A-Z][-a-zA-Z_0-9]*)$/;
 const transitionPattern = /^([a-zA-Z](?:(?!-in-out)[-a-zA-Z_0-9])*)-(in|out|in-out)$/;
 const directives = {
 	lazy: { t: BINDING_FLAG, v: 'l' },
-	twoway: { t: BINDING_FLAG, v: 't' }
+	twoway: { t: BINDING_FLAG, v: 't' },
+	'no-delegation': { t: DELEGATE_FLAG }
 };
 const unquotedAttributeValueTextPattern = /^[^\s"'=<>\/`]+/;
 const proxyEvent = /^[^\s"'=<>@\[\]()]*/;

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -20,6 +20,7 @@ export default class Fragment {
 		this.ractive = options.ractive || ( this.isRoot ? options.owner : this.parent.ractive );
 
 		this.componentParent = ( this.isRoot && this.ractive.component ) ? this.ractive.component.parentFragment : null;
+		this.delegate = this.parent ? this.parent.delegate : ( this.componentParent && this.componentParent.delegate );
 
 		this.context = null;
 		this.rendered = false;

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -3,6 +3,7 @@ import { createDocumentFragment } from '../utils/dom';
 import { isObject } from '../utils/is';
 import { findMap } from '../utils/array';
 import { toEscapedString, toString, destroyed, shuffled, unbind, unrender, unrenderAndDestroy, update } from '../shared/methodCallers';
+import findElement from './items/shared/findElement';
 
 export default class RepeatedFragment {
 	constructor ( options ) {
@@ -13,6 +14,7 @@ export default class RepeatedFragment {
 		this.parentFragment = this;
 		this.owner = options.owner;
 		this.ractive = this.parent.ractive;
+		this.delegate = this.parent.delegate || findElement( options.owner );
 
 		// encapsulated styles should be inherited until they get applied by an element
 		this.cssIds = 'cssIds' in options ? options.cssIds : ( this.parent ? this.parent.cssIds : null );
@@ -76,10 +78,10 @@ export default class RepeatedFragment {
 			template: this.template
 		});
 
-		// TODO this is a bit hacky
 		fragment.key = key;
 		fragment.index = index;
 		fragment.isIteration = true;
+		fragment.delegate = this.delegate;
 
 		const model = this.context.joinKey( key );
 

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -15,6 +15,8 @@ export default class RepeatedFragment {
 		this.owner = options.owner;
 		this.ractive = this.parent.ractive;
 		this.delegate = this.parent.delegate || findElement( options.owner );
+		// delegation disabled by directive
+		if ( this.delegate && this.delegate.delegate === false ) this.delegate = false;
 
 		// encapsulated styles should be inherited until they get applied by an element
 		this.cssIds = 'cssIds' in options ? options.cssIds : ( this.parent ? this.parent.cssIds : null );

--- a/src/view/helpers/contextMethods.js
+++ b/src/view/helpers/contextMethods.js
@@ -38,9 +38,9 @@ function build ( el, keypath, value ) {
 
 // get relative keypaths and values
 function get ( keypath ) {
-	if ( !keypath ) return this._element.parentFragment.findContext().get( true );
+	if ( !keypath ) return this.proxy.parentFragment.findContext().get( true );
 
-	const model = resolveReference( this._element.parentFragment, keypath );
+	const model = resolveReference( this.proxy.parentFragment, keypath );
 
 	return model ? model.get( true ) : undefined;
 }
@@ -51,7 +51,7 @@ function resolve ( path, ractive ) {
 }
 
 function findModel ( el, path ) {
-	const frag = el._element.parentFragment;
+	const frag = el.proxy.parentFragment;
 
 	if ( typeof path !== 'string' ) {
 		return { model: frag.findContext(), instance: path };
@@ -92,13 +92,13 @@ function merge ( keypath, array, options ) {
 
 function observe ( keypath, callback, options = {} ) {
 	if ( isObject( keypath ) ) options = callback || {};
-	options.fragment = this._element.parentFragment;
+	options.fragment = this.proxy.parentFragment;
 	return this.ractive.observe( keypath, callback, options );
 }
 
 function observeOnce ( keypath, callback, options = {} ) {
 	if ( isObject( keypath ) ) options = callback || {};
-	options.fragment = this._element.parentFragment;
+	options.fragment = this.proxy.parentFragment;
 	return this.ractive.observeOnce( keypath, callback, options );
 }
 
@@ -111,7 +111,7 @@ function push ( keypath, ...values ) {
 }
 
 function raise ( name, event, ...args ) {
-	let element = this._element;
+	let element = this.proxy;
 
 	while ( element ) {
 		const events = element.events;
@@ -209,7 +209,7 @@ function getBinding () {
 }
 
 function getBindingModel ( ctx ) {
-	const el = ctx._element;
+	const el = ctx.proxy;
 	return { model: el.binding && el.binding.model, instance: el.parentFragment.ractive };
 }
 
@@ -220,7 +220,7 @@ function setBinding ( value ) {
 
 export function addHelpers ( obj, element ) {
 	Object.defineProperties( obj, {
-		_element: { value: element },
+		proxy: { value: element, writable: true },
 		ractive: { value: element.parentFragment.ractive },
 		resolve: { value: resolve },
 		get: { value: get },

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -12,6 +12,7 @@ import createItem from './createItem';
 import { html, svg } from '../../config/namespaces';
 import findElement from './shared/findElement';
 import selectBinding from './element/binding/selectBinding';
+import { DelegateProxy } from './shared/EventDirective';
 
 function makeDirty ( query ) {
 	query.makeDirty();
@@ -108,6 +109,9 @@ export default class Element extends ContainerItem {
 
 	destroyed () {
 		this.attributes.forEach( destroyed );
+		for ( const ev in this.delegates ) {
+			this.delegates[ev].unlisten();
+		}
 		if ( this.fragment ) this.fragment.destroyed();
 	}
 
@@ -240,6 +244,9 @@ export default class Element extends ContainerItem {
 		}
 
 		this.attributes.forEach( render );
+		for ( const ev in this.delegates ) {
+			this.delegates[ev].listen( DelegateProxy );
+		}
 
 		if ( this.binding ) this.binding.render();
 

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -239,13 +239,15 @@ export default class Element extends ContainerItem {
 			let i = node.attributes.length;
 			while ( i-- ) {
 				const name = node.attributes[i].name;
-				if ( !( name in this.attributeByName ) ) node.removeAttribute( name );
+				if ( !( name in this.attributeByName ) )node.removeAttribute( name );
 			}
 		}
 
 		this.attributes.forEach( render );
-		for ( const ev in this.delegates ) {
-			this.delegates[ev].listen( DelegateProxy );
+		if ( this.delegates ) {
+			for ( const ev in this.delegates ) {
+				this.delegates[ev].listen( DelegateProxy );
+			}
 		}
 
 		if ( this.binding ) this.binding.render();

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -1,4 +1,4 @@
-import { ATTRIBUTE, BINDING_FLAG, DECORATOR, EVENT, TRANSITION } from '../../config/types';
+import { ATTRIBUTE, BINDING_FLAG, DECORATOR, DELEGATE_FLAG, EVENT, TRANSITION } from '../../config/types';
 import runloop from '../../global/runloop';
 import { ContainerItem } from './shared/Item';
 import Fragment from '../Fragment';
@@ -56,6 +56,10 @@ export default class Element extends ContainerItem {
 						parentFragment: this.parentFragment,
 						template
 					}) );
+					break;
+
+				case DELEGATE_FLAG:
+				  this.delegate = false;
 					break;
 
 				default:

--- a/src/view/items/element/ElementEvents.js
+++ b/src/view/items/element/ElementEvents.js
@@ -22,7 +22,8 @@ class DOMEvent {
 		node.addEventListener( name, this.handler = function( event ) {
 			directive.fire({
 				node,
-				original: event
+				original: event,
+				name
 			});
 		}, false );
 	}
@@ -33,9 +34,10 @@ class DOMEvent {
 }
 
 class CustomEvent {
-	constructor ( eventPlugin, owner ) {
+	constructor ( eventPlugin, owner, name ) {
 		this.eventPlugin = eventPlugin;
 		this.owner = owner;
+		this.name = name;
 		this.handler = null;
 	}
 
@@ -43,6 +45,7 @@ class CustomEvent {
 		const node = this.owner.node;
 
 		this.handler = this.eventPlugin( node, ( event = {} ) => {
+			event.name = this.name;
 			event.node = event.node || node;
 			directive.fire( event );
 		});

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -15,6 +15,41 @@ import noop from '../../../utils/noop';
 const specialPattern = /^(event|arguments)(\..+)?$/;
 const dollarArgsPattern = /^\$(\d+)(\..+)?$/;
 
+export const DelegateProxy = {
+	fire ( event, passedArgs = [] ) {
+		if ( event && event.original ) {
+			const ev = event.original;
+
+			// TODO if IE<9 needs to be supported here, could probably walk to the element with a ractive proxy with a delegates property
+			const end = ev.currentTarget;
+			let node = ev.target;
+			const name = event.name;
+			let bubble = true;
+
+			// starting with the origin node, walk up the DOM looking for ractive nodes with a matching event listener
+			while ( bubble && node !== end ) {
+				const el = node._ractive && node._ractive.proxy;
+				if ( el ) {
+
+					// set up the context for the handler
+					event.node = el.node;
+					event.name = name;
+
+					el.events.forEach( ev => {
+						if ( ~ev.template.n.indexOf( name ) ) {
+							bubble = ev.fire( event, passedArgs ) !== false && bubble;
+						}
+					});
+
+					node = node.parentNode;
+				}
+			}
+
+			return bubble;
+		}
+	}
+};
+
 export default class EventDirective {
 	constructor ( options ) {
 		this.owner = options.owner || options.parentFragment.owner || findElement( options.parentFragment );
@@ -22,7 +57,7 @@ export default class EventDirective {
 		this.template = options.template;
 		this.parentFragment = options.parentFragment;
 		this.ractive = options.parentFragment.ractive;
-
+		const delegate = this.delegate = options.parentFragment.delegate;
 		this.events = [];
 
 		if ( this.element.type === COMPONENT || this.element.type === ANCHOR ) {
@@ -30,11 +65,25 @@ export default class EventDirective {
 				this.events.push( new RactiveEvent( this.element, n ) );
 			});
 		} else {
+			// make sure the delegate element has a storag object
+			if ( delegate && !delegate.delegates ) delegate.delegates = {};
+
 			this.template.n.forEach( n => {
 				const fn = findInViewHierarchy( 'events', this.ractive, n );
-				// we need to pass in "this" in order to get
-				// access to node when it is created.
-				this.events.push( fn ? new CustomEvent( fn, this.element ) : new DOMEvent( n, this.element ) );
+				if ( fn ) {
+					this.events.push( new CustomEvent( fn, this.element, n ) );
+				} else {
+					if ( delegate ) {
+						if ( !delegate.delegates[n] ) {
+							const ev = new DOMEvent( n, delegate );
+							delegate.delegates[n] = ev;
+							// if the element is already rendered, render the event too
+							if ( delegate.rendered ) ev.listen( DelegateProxy );
+						}
+					} else {
+						this.events.push( new DOMEvent( n, this.element ) );
+					}
+				}
 			});
 		}
 
@@ -55,8 +104,9 @@ export default class EventDirective {
 
 	fire ( event, passedArgs = [] ) {
 		// augment event object
-		if ( event && !event.hasOwnProperty( '_element' ) ) {
-		   addHelpers( event, this.owner );
+		if ( event ) {
+		   if ( !event.hasOwnProperty( 'proxy' ) ) addHelpers( event, this.owner );
+		   else event.proxy = this.owner;
 		}
 
 		if ( this.fn ) {
@@ -125,6 +175,8 @@ export default class EventDirective {
 			}
 
 			ractive.event = oldEvent;
+
+			return result;
 		}
 
 		else {
@@ -132,7 +184,7 @@ export default class EventDirective {
 			if ( passedArgs.length ) args = args.concat( passedArgs );
 			if ( event ) event.name = this.action;
 
-			fireEvent( this.ractive, this.action, {
+			return fireEvent( this.ractive, this.action, {
 				event,
 				args
 			});

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -57,7 +57,7 @@ export default class EventDirective {
 		this.template = options.template;
 		this.parentFragment = options.parentFragment;
 		this.ractive = options.parentFragment.ractive;
-		const delegate = this.delegate = options.parentFragment.delegate;
+		const delegate = this.delegate = this.ractive.delegate && options.parentFragment.delegate;
 		this.events = [];
 
 		if ( this.element.type === COMPONENT || this.element.type === ANCHOR ) {

--- a/test/browser-tests/events/delegate.js
+++ b/test/browser-tests/events/delegate.js
@@ -178,4 +178,33 @@ export default function() {
 		t.ok( ev._ractive.proxy.events[0].events.length === 1 );
 		t.ok( other._ractive.proxy.events[0].events.length === 1 );
 	});
+
+	test( `delegation can be turned off for specific elements with no-delegation`, t => {
+		const addEventListener = Element.prototype.addEventListener;
+		let count = 0;
+		Element.prototype.addEventListener = function () {
+			count++;
+			return addEventListener.apply( this, arguments );
+		};
+
+		const cmp = Ractive.extend({
+			template: `<div>{{#each [1]}}<div on-click="ev" /><div on-click="other" />{{/each}}</div>`
+		});
+		const r = new Ractive({
+			target: fixture,
+			template: `<div no-delegation>{{#each arr}}<div on-click="outer" /><cmp />{{/each}}</div>`,
+			components: { cmp },
+			data: { arr: [ 1 ] }
+		});
+
+		t.equal( count, 2 );
+		Element.prototype.addEventListener = addEventListener;
+
+		const [ top, outer, , ev, other ] = r.findAll( 'div' );
+		t.ok( top._ractive.proxy.delegate === false );
+		t.ok( !top._ractive.proxy.delegates );
+		t.ok( outer._ractive.proxy.events[0].events.length === 1 );
+		t.ok( ev._ractive.proxy.events[0].events.length === 0 );
+		t.ok( other._ractive.proxy.events[0].events.length === 0 );
+	});
 }

--- a/test/browser-tests/events/delegate.js
+++ b/test/browser-tests/events/delegate.js
@@ -1,0 +1,152 @@
+import { test } from 'qunit';
+import { initModule } from '../test-config';
+import { fire } from 'simulant';
+
+export default function() {
+	initModule( 'events/delegate.js' );
+
+	test( `basic delegation`, t => {
+		t.expect( 6 );
+
+		const addEventListener = Element.prototype.addEventListener;
+		let count = 0;
+		Element.prototype.addEventListener = function () {
+			count++;
+			return addEventListener.apply( this, arguments );
+		};
+		const r = new Ractive({
+			target: fixture,
+			template: `<div>{{#each [1]}}<div on-click="ev" /><div on-click="other" />{{/each}}</div>`,
+			on: {
+				ev() {
+					t.ok( true, 'event fired' );
+				},
+				other() {
+					t.ok( true, 'other event fired' );
+				}
+			}
+		});
+
+		t.equal( count, 1 );
+		Element.prototype.addEventListener = addEventListener;
+
+		const [ top, ev, other ] = r.findAll( 'div' );
+		t.ok( Object.keys( top._ractive.proxy.delegates ).length );
+		t.ok( ev._ractive.proxy.events[0].events.length === 0 );
+		t.ok( other._ractive.proxy.events[0].events.length === 0 );
+		fire( top, 'click' );
+		fire( ev, 'click' );
+		fire( other, 'click' );
+	});
+
+	test( `delegated method event`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: `<div>{{#each [1]}}{{#with ~/foo}}<div on-click="event.set('.bar', 42)" />{{/with}}{{/each}}</div>`,
+			data: { foo: {} }
+		});
+
+		const div = r.findAll( 'div' )[1];
+		simulant.fire( div, 'click' );
+		t.equal( r.get( 'foo.bar' ), 42 );
+	});
+
+	test( `library delegated event cancellation`, t => {
+		t.expect( 1 );
+
+		const r = new Ractive({
+			target: fixture,
+			template: `<div>{{#each [1]}}<div on-click="nope"><div on-click="yep" /></div>{{/each}}</div>`,
+			on: {
+				nope() { t.ok( false, 'should not fire' ); },
+				yep() { t.ok( true, 'should fire' ); return false; }
+			}
+		});
+
+		const yep = r.findAll( 'div' )[2];
+		fire( yep, 'click' );
+	});
+
+	test( `multiple delegated events don't interfere with each other`, t => {
+		t.expect( 1 );
+
+		const r = new Ractive({
+			target: fixture,
+			template: `<div>{{#each [1]}}<div on-mouseenter="yep" /><div on-mouseleave="nope" />{{/each}}</div>`,
+			on: {
+				nope() { t.ok( false, 'should not fire' ); },
+				yep() { t.ok( true, 'should fire' ); }
+			}
+		});
+
+		const yep = r.findAll( 'div' )[1];
+		simulant.fire( yep, 'mouseenter' );
+	});
+
+	test( `delegated event context is correct`, t => {
+		t.expect( 2 );
+
+		const r = new Ractive({
+			target: fixture,
+			template: `<div>{{#each [1]}}{{#with ~/foo}}<div on-click="outer">{{#with bar}}<div on-click="inner" />{{/with}}</div>{{/with}}{{/each}}</div>`,
+			data: { foo: { bar: {} } },
+			on: {
+				outer(ev) { t.equal( ev.resolve(), 'foo' ); },
+				inner(ev) { t.equal( ev.resolve(), 'foo.bar' ); }
+			}
+		});
+
+		const inner = r.findAll( 'div' )[2];
+		fire( inner, 'click' );
+	});
+
+	test( `delegated events can also be raised`, t => {
+		t.expect( 1 );
+
+		const r = new Ractive({
+			target: fixture,
+			template: '<div>{{#each [1]}}<div on-click="yep" />{{/each}}</div>',
+			on: {
+				yep() { t.ok( true, 'event should fire' ); }
+			}
+		});
+
+		r.getNodeInfo( r.findAll( 'div' )[1] ).raise( 'click', {} );
+	});
+
+	test( `dom events within components can also be delegated`, t => {
+		const addEventListener = Element.prototype.addEventListener;
+		let count = 0;
+		Element.prototype.addEventListener = function () {
+			count++;
+			return addEventListener.apply( this, arguments );
+		};
+		const cmp = Ractive.extend({
+			template: `<div on-click="ev" /><div on-click="other" />`
+		});
+		const r = new Ractive({
+			target: fixture,
+			template: `<div>{{#each [1]}}<cmp />{{/each}}</div>`,
+			on: {
+				'*.ev'() {
+					t.ok( true, 'event fired' );
+				},
+				'*.other'() {
+					t.ok( true, 'other event fired' );
+				}
+			},
+			components: { cmp }
+		});
+
+		t.equal( count, 1 );
+		Element.prototype.addEventListener = addEventListener;
+
+		const [ top, ev, other ] = r.findAll( 'div' );
+		t.ok( Object.keys( top._ractive.proxy.delegates ).length );
+		t.ok( ev._ractive.proxy.events[0].events.length === 0 );
+		t.ok( other._ractive.proxy.events[0].events.length === 0 );
+		fire( top, 'click' );
+		fire( ev, 'click' );
+		fire( other, 'click' );
+	});
+}

--- a/test/browser-tests/events/delegate.js
+++ b/test/browser-tests/events/delegate.js
@@ -149,4 +149,33 @@ export default function() {
 		fire( ev, 'click' );
 		fire( other, 'click' );
 	});
+
+	test( `delegation can be turned off`, t => {
+		const addEventListener = Element.prototype.addEventListener;
+		let count = 0;
+		Element.prototype.addEventListener = function () {
+			count++;
+			return addEventListener.apply( this, arguments );
+		};
+
+		const cmp = Ractive.extend({
+			template: `<div on-click="ev" /><div on-click="other" />`
+		});
+		const r = new Ractive({
+			target: fixture,
+			delegate: false,
+			template: `<div>{{#each arr}}<div on-click="outer" /><cmp />{{/each}}</div>`,
+			components: { cmp },
+			data: { arr: [ 1 ] }
+		});
+
+		t.equal( count, 3 );
+		Element.prototype.addEventListener = addEventListener;
+
+		const [ top, outer, ev, other ] = r.findAll( 'div' );
+		t.ok( !top._ractive.proxy.delegates );
+		t.ok( outer._ractive.proxy.events[0].events.length === 1 );
+		t.ok( ev._ractive.proxy.events[0].events.length === 1 );
+		t.ok( other._ractive.proxy.events[0].events.length === 1 );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
This is the follow-on to #2841, where instead of adding manual insertion points for delegates, iterative sections that are nested within an element automatically set their containing element as the delegate target. Fragments automatically inherit their parent delegate, and there's special casing for handling components.

Unlike the first swing, this does not allow delegating custom events because there's really no way to control exactly which events should be delegated. As such, the event directive has to check to see if there is a matching custom event in the hierarchy. This adds a bit of overhead over the first swing too, so it looks like the performance gap drops from 20-30% to 15-25%. On the plus side, you can't accidentally break custom events, because they will still be rendered on the element containing the directive where the DOM events may be shuffled upstream.

To be clear, any events that are within an iterative section that is within an element will automatically be delegated. If there's not a wrapping element, then there's nowhere to install real listener. Nested iterative sections inherit their parent delegate target, so there's only one target element. Turning off delegation is still a TODO.

To complete the comparison, here's the adjusted example from the first swing

```html
<table>
{{#each lotsOfRows}}
  <tr>
    <td><button on-click="@.select(.)">Select</button></td>
    <td>{{.description}}</td>
    <td>{{.something}}</td>
    <td><button on-click="event.splice('../../', @index, 1)">Remove</button></td>
  <tr>
{{/each}}
</table>
```

### Questions

1. Does tracking the delegate target element seem lightweight enough to justify the render gains?
2. The search for ractive events to fire should be pretty darn fast, but I've heard rumors that delegation can cause lag with things like touch scrolling. Would that be a problem here? With jquery, I believe the delegated events have to execute a query selector, which is where the lag generally comes from?
3. If this is ok, should it go out defaulted to on or off?
4. If lag could be a problem, would having a directive for elements to disable delegation be useful? Something like `<div no-delegate>{{#each ...}}...{{/each}}</div>`, perhaps.

### TODO

* [x] Add an instance flag to disable delegation
* [ ] Maybe have a directive for enabling/disabling delegation explicitly at one point (element containing iteration)?
* [x] Tests for disabling delegation

## Fixes the following issues:
The remaining bits of #846

## Is breaking:
Kinda sorta... if delegation defaults to off, it's not breaking. If it defaults to on, it _may_ be a little breaking due to the way bubbling can get out of order.

## Reviewers:
Yep