### PR TITLE
Support non-destructive sets in conditional sections - RFC

### DIFF
--- a/perf/src/app/runSuite.js
+++ b/perf/src/app/runSuite.js
@@ -157,6 +157,7 @@ function runTest ( context, test, version, ractiveUrl, callback ) {
 function runStep ( context, test, callback ) {
 	let start = now(), count = 0, runStart;
 	let duration = 0, totalDuration = 0;
+	const times = [];
 
 	console.group( test.name );
 
@@ -170,17 +171,24 @@ function runStep ( context, test, callback ) {
 			return callback( e, { name: test.name } );
 		}
 
-		duration += now() - runStart;
-		totalDuration = now() - start;
+		const end = now();
+		duration += end - runStart;
+		totalDuration = end - start;
+		times.push( end - runStart );
 
 		if ( test.maxCount && count >= test.maxCount ) break;
 	}
 
+	const avg = times.reduce( ( a, c ) => a + c, 0 ) / times.length;
 	callback(null, {
 		name: test.name,
 		duration,
 		count,
-		average: duration / count
+		first: times[0],
+		average: avg,
+		variation: times.reduce( ( a, c ) => a + Math.abs( avg - c ), 0 ) / times.length,
+		minimum: Math.min.apply( null, times ),
+		maximum: Math.max.apply( null, times )
 	});
 
 	console.groupEnd( test.name );

--- a/perf/src/templates/testpage.html
+++ b/perf/src/templates/testpage.html
@@ -135,16 +135,16 @@
 			{{/if}}
 			{{#if results}}
 				<table>
-					<thead><tr><th>test name</th><th>iterations</th><th>avg. duration</th></tr></thead>
+					<thead><tr><th>test name</th><th>iterations</th><th>first duration</th><th>avg</th><th>variation</th><th>min</th><th>max</th></tr></thead>
 
 					<tbody>
 						{{#each tests}}
 							<tr>
-								<td on-click='runInNewWindow(test,version,ractiveUrl)'>{{name}}</td><td>{{count}}</td><td>{{formatTime(average)}}</td>
+								<td on-click='runInNewWindow(test,version,ractiveUrl)'>{{name}}</td><td>{{count}}</td><td /><td>{{formatTime(average)}}</td><td /><td /><td />
 							</tr>
 							{{#each .steps}}
 								<tr>
-									<td {{#if .error}}class='error'{{/if}}>&gt;&gt;&gt; {{.name}}{{#if .error}}<br />{{.error.message}}{{/if}}</td><td>{{.count}}</td><td>{{formatTime(.average)}}</td>
+									<td {{#if .error}}class='error'{{/if}}>&gt;&gt;&gt; {{.name}}{{#if .error}}<br />{{.error.message}}{{/if}}</td><td>{{.count}}</td><td>{{formatTime(.first)}}</td><td>{{formatTime(.average)}}</td><td>{{formatTime(.variation)}}</td><td>{{formatTime(.minimum)}}</td><td>{{formatTime(.maximum)}}</td>
 								</tr>
 							{{/each}}
 						{{/each}}

--- a/perf/tests/jsweb.js
+++ b/perf/tests/jsweb.js
@@ -138,7 +138,7 @@ var tests = [
 				name: 'hide rows',
 				test() {
 					/* global ractive */
-					ractive.set( 'show', false );
+					ractive.set( 'show', false, { keep: true } );
 				},
 				maxCount: 1
 			},
@@ -156,7 +156,7 @@ var tests = [
 				name: 'hide rows again',
 				test() {
 					/* global ractive */
-					ractive.set( 'show', false );
+					ractive.set( 'show', false, { keep: true } );
 				},
 				maxCount: 1
 			},
@@ -166,6 +166,25 @@ var tests = [
 				test() {
 					/* global ractive */
 					ractive.set( 'show', true );
+				},
+				maxCount: 1
+			},
+
+			{
+				name: 'set hide',
+				test() {
+					/* global ractive */
+					ractive.set( 'tmp', ractive.get( 'rows' ) );
+					ractive.set( 'rows', [] );
+				},
+				maxCount: 1
+			},
+
+			{
+				name: 'set show',
+				test() {
+					/* global ractive */
+					ractive.set( 'rows', ractive.get( 'tmp' ) );
 				},
 				maxCount: 1
 			},

--- a/perf/tests/jsweb.js
+++ b/perf/tests/jsweb.js
@@ -135,7 +135,7 @@ var tests = [
 			},
 
 			{
-				name: 'hide rows',
+				name: 'hide rows (keep)',
 				test() {
 					/* global ractive */
 					ractive.set( 'show', false, { keep: true } );
@@ -153,10 +153,46 @@ var tests = [
 			},
 
 			{
-				name: 'hide rows again',
+				name: 'hide rows again (keep)',
 				test() {
 					/* global ractive */
 					ractive.set( 'show', false, { keep: true } );
+				},
+				maxCount: 1
+			},
+
+			{
+				name: 'show rows again',
+				test() {
+					/* global ractive */
+					ractive.set( 'show', true );
+				},
+				maxCount: 1
+			},
+
+			{
+				name: 'hide rows (nokeep)',
+				test() {
+					/* global ractive */
+					ractive.set( 'show', false, { keep: false } );
+				},
+				maxCount: 1
+			},
+
+			{
+				name: 'show rows',
+				test() {
+					/* global ractive */
+					ractive.set( 'show', true );
+				},
+				maxCount: 1
+			},
+
+			{
+				name: 'hide rows again (nokeep)',
+				test() {
+					/* global ractive */
+					ractive.set( 'show', false, { keep: false } );
 				},
 				maxCount: 1
 			},

--- a/src/Ractive/prototype/add.js
+++ b/src/Ractive/prototype/add.js
@@ -1,5 +1,7 @@
 import add from './shared/add';
 
-export default function Ractive$add ( keypath, d ) {
-	return add( this, keypath, ( d === undefined ? 1 : +d ) );
+export default function Ractive$add ( keypath, d, options ) {
+	const num = d && typeof d !== 'object' ? +d : 1;
+	const opts = typeof d === 'object' ? d : options;
+	return add( this, keypath, num, opts );
 }

--- a/src/Ractive/prototype/set.js
+++ b/src/Ractive/prototype/set.js
@@ -2,7 +2,8 @@ import { build, set } from '../../shared/set';
 
 export default function Ractive$set ( keypath, value, options ) {
 	const ractive = this;
+	const opts = typeof keypath === 'object' ? value : options;
 
-	return set( ractive, build( ractive, keypath, value ), options );
+	return set( ractive, build( ractive, keypath, value ), opts );
 }
 

--- a/src/Ractive/prototype/set.js
+++ b/src/Ractive/prototype/set.js
@@ -3,8 +3,6 @@ import { build, set } from '../../shared/set';
 export default function Ractive$set ( keypath, value, options ) {
 	const ractive = this;
 
-	const opts = typeof keypath === 'object' ? value : options;
-
-	return set( ractive, build( ractive, keypath, value ), opts );
+	return set( ractive, build( ractive, keypath, value ), options );
 }
 

--- a/src/Ractive/prototype/subtract.js
+++ b/src/Ractive/prototype/subtract.js
@@ -1,5 +1,7 @@
 import add from './shared/add';
 
-export default function Ractive$subtract ( keypath, d ) {
-	return add( this, keypath, ( d === undefined ? -1 : -d ) );
+export default function Ractive$subtract ( keypath, d, options ) {
+	const num = d && typeof d !== 'object' ? -d : -1;
+	const opts = typeof d === 'object' ? d : options;
+	return add( this, keypath, num, opts );
 }

--- a/src/Ractive/prototype/toggle.js
+++ b/src/Ractive/prototype/toggle.js
@@ -1,10 +1,10 @@
 import { badArguments } from '../../config/errors';
 import { gather, set } from '../../shared/set';
 
-export default function Ractive$toggle ( keypath ) {
+export default function Ractive$toggle ( keypath, options ) {
 	if ( typeof keypath !== 'string' ) {
 		throw new TypeError( badArguments );
 	}
 
-	return set( this, gather( this, keypath ).map( m => [ m, !m.get() ] ) );
+	return set( this, gather( this, keypath ).map( m => [ m, !m.get() ] ), options );
 }

--- a/src/shared/set.js
+++ b/src/shared/set.js
@@ -3,8 +3,13 @@ import { splitKeypath } from './keypaths';
 import { isObject } from '../utils/is';
 import { warnIfDebug } from '../utils/log';
 
+export let keep = false;
+
 export function set ( ractive, pairs, options ) {
+	const k = keep;
 	const deep = options && options.deep;
+	if ( options && options.keep ) keep = options.keep;
+
 	const promise = runloop.start( ractive, true );
 
 	let i = pairs.length;
@@ -23,6 +28,8 @@ export function set ( ractive, pairs, options ) {
 	}
 
 	runloop.end();
+
+	keep = k;
 
 	return promise;
 }

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -81,7 +81,11 @@ export default class Fragment {
 
 	detach () {
 		const docFrag = createDocumentFragment();
-		this.items.forEach( item => docFrag.appendChild( item.detach() ) );
+		const items = this.items;
+		const len = items.length;
+		for ( let i = 0; i < len; i++ ) {
+			docFrag.appendChild( items[i].detach() );
+		}
 		return docFrag;
 	}
 

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -190,7 +190,10 @@ export default class Fragment {
 		if ( this.rendered ) throw new Error( 'Fragment is already rendered!' );
 		this.rendered = true;
 
-		this.items.forEach( item => item.render( target, occupants ) );
+		const len = this.items.length;
+		for ( let i = 0; i < len; i++ ) {
+			this.items[i].render( target, occupants );
+		}
 	}
 
 	resetTemplate ( template ) {

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -156,7 +156,11 @@ export default class RepeatedFragment {
 		// TODO use docFrag.cloneNode...
 
 		if ( this.iterations ) {
-			this.iterations.forEach( fragment => fragment.render( target, occupants ) );
+			const xs = this.iterations;
+			const len = xs.length;
+			for ( let i = 0; i < len; i++ ){
+				xs[i].render( target, occupants );
+			}
 		}
 
 		this.rendered = true;

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -178,45 +178,46 @@ export default class Element extends ContainerItem {
 	}
 
 	render ( target, occupants ) {
-		// TODO determine correct namespace
-		this.namespace = getNamespace( this );
-
-		let node;
+		let node = this.node;
 		let existing = false;
 
-		if ( occupants ) {
-			let n;
-			while ( ( n = occupants.shift() ) ) {
-				if ( n.nodeName.toUpperCase() === this.template.e.toUpperCase() && n.namespaceURI === this.namespace ) {
-					this.node = node = n;
-					existing = true;
-					break;
-				} else {
-					detachNode( n );
+		if ( !node ) {
+			this.namespace = getNamespace( this );
+
+			if ( !node && occupants ) {
+				let n;
+				while ( ( n = occupants.shift() ) ) {
+					if ( n.nodeName.toUpperCase() === this.template.e.toUpperCase() && n.namespaceURI === this.namespace ) {
+						this.node = node = n;
+						existing = true;
+						break;
+					} else {
+						detachNode( n );
+					}
 				}
 			}
-		}
 
-		if ( !node ) {
-			const name = this.template.e;
-			node = createElement( this.namespace === html ? name.toLowerCase() : name, this.namespace, this.getAttribute( 'is' ) );
-			this.node = node;
-		}
-
-		// tie the node to this vdom element
-		Object.defineProperty( node, '_ractive', {
-			value: {
-				proxy: this
+			if ( !node ) {
+				const name = this.template.e;
+				node = createElement( this.namespace === html ? name.toLowerCase() : name, this.namespace, this.getAttribute( 'is' ) );
+				this.node = node;
 			}
-		});
 
-		// Is this a top-level node of a component? If so, we may need to add
-		// a data-ractive-css attribute, for CSS encapsulation
-		if ( this.parentFragment.cssIds ) {
-			node.setAttribute( 'data-ractive-css', this.parentFragment.cssIds.map( x => `{${x}}` ).join( ' ' ) );
+			// tie the node to this vdom element
+			Object.defineProperty( node, '_ractive', {
+				value: {
+					proxy: this
+				}
+			});
+
+			// Is this a top-level node of a component? If so, we may need to add
+			// a data-ractive-css attribute, for CSS encapsulation
+			if ( this.parentFragment.cssIds ) {
+				node.setAttribute( 'data-ractive-css', this.parentFragment.cssIds.map( x => `{${x}}` ).join( ' ' ) );
+			}
+
+			if ( existing && this.foundNode ) this.foundNode( node );
 		}
-
-		if ( existing && this.foundNode ) this.foundNode( node );
 
 		// register intro before rendering content so children can find the intro
 		const intro = this.intro;

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -120,8 +120,8 @@ export default class Element extends ContainerItem {
 	}
 
 	detach () {
-		// if this element is no longer rendered, the transitions are complete and the attributes can be torn down
-		if ( !this.rendered ) this.destroyed();
+		// if this element is no longer viable, the transitions are complete and the attributes can be torn down
+		if ( this.destroy ) this.destroyed();
 
 		return detachNode( this.node );
 	}
@@ -355,6 +355,7 @@ export default class Element extends ContainerItem {
 			// since option elements can't have transitions anyway
 			this.detach();
 		} else if ( shouldDestroy ) {
+			this.destroy = true;
 			runloop.detachWhenReady( this );
 		}
 

--- a/src/view/items/Interpolator.js
+++ b/src/view/items/Interpolator.js
@@ -1,4 +1,4 @@
-import { doc } from '../../config/environment';
+import progressiveText from './shared/progressiveText';
 import { escapeHtml } from '../../utils/html';
 import { safeToStringValue } from '../../utils/dom';
 import Mustache from './shared/Mustache';
@@ -25,31 +25,10 @@ export default class Interpolator extends Mustache {
 
 	render ( target, occupants ) {
 		if ( inAttributes() ) return;
-		const value = this.getString();
 
 		this.rendered = true;
 
-		if ( occupants ) {
-			let n = occupants[0];
-			if ( n && n.nodeType === 3 ) {
-				occupants.shift();
-				if ( n.nodeValue !== value ) {
-					n.nodeValue = value;
-				}
-			} else {
-				n = this.node = doc.createTextNode( value );
-				if ( occupants[0] ) {
-					target.insertBefore( n, occupants[0] );
-				} else {
-					target.appendChild( n );
-				}
-			}
-
-			this.node = n;
-		} else {
-			this.node = doc.createTextNode( value );
-			target.appendChild( this.node );
-		}
+		progressiveText( this, target, occupants, this.getString() );
 	}
 
 	toString ( escape ) {

--- a/src/view/items/Text.js
+++ b/src/view/items/Text.js
@@ -1,4 +1,4 @@
-import { doc } from '../../config/environment';
+import progressiveText from './shared/progressiveText';
 import { TEXT } from '../../config/types';
 import { escapeHtml } from '../../utils/html';
 import Item from './shared/Item';
@@ -24,27 +24,7 @@ export default class Text extends Item {
 		if ( inAttributes() ) return;
 		this.rendered = true;
 
-		if ( occupants ) {
-			let n = occupants[0];
-			if ( n && n.nodeType === 3 ) {
-				occupants.shift();
-				if ( n.nodeValue !== this.template ) {
-					n.nodeValue = this.template;
-				}
-			} else {
-				n = this.node = doc.createTextNode( this.template );
-				if ( occupants[0] ) {
-					target.insertBefore( n, occupants[0] );
-				} else {
-					target.appendChild( n );
-				}
-			}
-
-			this.node = n;
-		} else {
-			this.node = doc.createTextNode( this.template );
-			target.appendChild( this.node );
-		}
+		progressiveText( this, target, occupants, this.template );
 	}
 
 	toString ( escape ) {

--- a/src/view/items/shared/progressiveText.js
+++ b/src/view/items/shared/progressiveText.js
@@ -1,0 +1,31 @@
+import { doc } from '../../../config/environment';
+
+export default function progressiveText ( item, target, occupants, text ) {
+	if ( occupants ) {
+		let n = occupants[0];
+		if ( n && n.nodeType === 3 ) {
+			const idx = n.nodeValue.indexOf( text );
+			occupants.shift();
+
+			if ( idx === 0 ) {
+				if ( n.nodeValue.length !== text.length ) {
+					occupants.unshift( n.splitText( text.length ) );
+				}
+			} else {
+				n.nodeValue = text;
+			}
+		} else {
+			n = item.node = doc.createTextNode( text );
+			if ( occupants[0] ) {
+				target.insertBefore( n, occupants[0] );
+			} else {
+				target.appendChild( n );
+			}
+		}
+
+		item.node = n;
+	} else {
+		if ( !item.node ) item.node = doc.createTextNode( text );
+		target.appendChild( item.node );
+	}
+}

--- a/src/view/items/triple/insertHtml.js
+++ b/src/view/items/triple/insertHtml.js
@@ -20,7 +20,7 @@ try {
 	};
 }
 
-export default function ( html, node, docFrag ) {
+export default function ( html, node ) {
 	const nodes = [];
 
 	// render 0 and false
@@ -68,7 +68,7 @@ export default function ( html, node, docFrag ) {
 	let child;
 	while ( child = container.firstChild ) {
 		nodes.push( child );
-		docFrag.appendChild( child );
+		container.removeChild( child );
 	}
 
 	// This is really annoying. Extracting <option> nodes from the

--- a/test/browser-tests/methods/set.js
+++ b/test/browser-tests/methods/set.js
@@ -24,4 +24,102 @@ export default function() {
 		r.set( '', { foo: [ 99 ] }, { deep: true } );
 		t.deepEqual( r.get( 'foo' ), [ 99, 42, 3 ] );
 	});
+
+	test( `keep set does not discard vdom or dom, where non-keep does`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: `{{#if show}}{{#each [1,2]}}<span>{{.}}</span>{{/each}}<cmp />{{/if}}`,
+			data: { show: true },
+			components: { cmp: Ractive.extend() }
+		});
+
+		const initFrag = r.fragment.items[0].fragment; // conditional fragment
+		const each = initFrag.items[0];
+		const cmp = r.findComponent( '*' );
+		const span1 = r.find( 'span' );
+
+		r.toggle( 'show', { keep: true } );
+		t.ok( initFrag === r.fragment.items[0].detached );
+		t.ok( each === r.fragment.items[0].detached.items[0] );
+		t.htmlEqual( fixture.innerHTML, '' );
+
+		r.toggle( 'show' );
+		t.ok( initFrag === r.fragment.items[0].fragment );
+		t.ok( each === r.fragment.items[0].fragment.items[0] );
+		t.htmlEqual( fixture.innerHTML, '<span>1</span><span>2</span>' );
+		t.ok( span1 === r.find( 'span' ) );
+		t.ok( cmp === r.findComponent( '*' ) );
+	});
+
+	test( `kept fragments aren't considered during find, findAll, and friends`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: `{{#if show}}<div /><cmp />{{/if}}`,
+			data: { show: true },
+			components: { cmp: Ractive.extend() }
+		});
+
+		const div = r.find( 'div' );
+		const cmp = r.findComponent( 'cmp' );
+
+		r.toggle( 'show', { keep: true } );
+		t.ok( cmp );
+		t.ok( r.find( 'div' ) === undefined );
+		t.ok( r.findAll( 'div' ).length === 0 );
+		t.ok( r.findComponent( 'cmp' ) === undefined );
+		t.ok( r.findAllComponents( 'div' ).length === 0 );
+
+		r.toggle( 'show' );
+		t.ok( div === r.find( 'div' ), 'div element is same' );
+		t.ok( cmp === r.findComponent( 'cmp' ), 'cmp instance is same' );
+	});
+
+	test( `kept fragments still intro and outro`, t => {
+		let count = 0;
+
+		const r = new Ractive({
+			target: fixture,
+			template: `{{#if show}}<div go-in-out />{{/if}}`,
+			data: { show: true },
+			transitions: {
+				go ( trans ) {
+					count++;
+					trans.complete();
+				}
+			}
+		});
+
+		t.equal( count, 1 );
+
+		r.toggle( 'show', { keep: true } );
+		t.equal( count, 2 );
+
+		r.toggle( 'show' );
+		t.equal( count, 3 );
+	});
+
+	test( `kept fragments with triples work correctly`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: `{{#if show}}{{{html}}}{{/if}}`,
+			data: {
+				show: true,
+				html: '<div></div>text'
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div></div>text' );
+
+		const div = r.find( 'div' );
+		const txt = fixture.childNodes[1];
+
+		r.toggle( 'show', { keep: true } );
+		t.htmlEqual( fixture.innerHTML, '' );
+
+		r.toggle( 'show' );
+		t.htmlEqual( fixture.innerHTML, '<div></div>text' );
+
+		t.ok( div === r.find( 'div' ) );
+		t.ok( fixture.childNodes[1] === txt );
+	});
 }

--- a/test/browser-tests/render/enhance.js
+++ b/test/browser-tests/render/enhance.js
@@ -457,4 +457,52 @@ export default function() {
 		t.strictEqual( r.find( 'svg' ), svg );
 		t.strictEqual( r.find( 'use' ), use );
 	});
+
+	test( `triples reuse existing content if it matches (#2403)`, t => {
+		fixture.innerHTML = '<div>foo bar</div><span><i>guts</i></span>&amp; why not?<!-- yep -->?sure';
+		const div = fixture.childNodes[0];
+		const text = div.childNodes[0];
+		const span = fixture.childNodes[1];
+		const text2 = fixture.childNodes[2];
+		const comment = span.childNodes[3];
+
+		new Ractive({
+			target: fixture,
+			template: '{{{html}}}?{{str}}',
+			data: {
+				html: '<div>foo bar</div><span><i>guts</i></span>&amp; why not?<!-- yep -->',
+				str: 'sure'
+			},
+			enhance: true
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div>foo bar</div><span><i>guts</i></span>&amp; why not?<!-- yep -->?sure' );
+
+		const _div = fixture.childNodes[0];
+		const _text = div.childNodes[0];
+		const _span = fixture.childNodes[1];
+		const _text2 = fixture.childNodes[2];
+		const _comment = span.childNodes[3];
+
+		t.ok( div === _div );
+		t.ok( text === _text );
+		t.ok( span === _span );
+		t.ok( text2 === _text2 );
+		t.ok( comment === _comment );
+	});
+
+	test( `triples that don't match existing content are still rendered correctly`, t => {
+		fixture.innerHTML = '<div>nope</div>sure';
+
+		new Ractive({
+			target: fixture,
+			template: '{{{html}}}',
+			data: {
+				html: '<div>yep</div>still yep'
+			},
+			enhance: true
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div>yep</div>still yep' );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:

When a rendered conditional section's condition goes false-y, the section is completely torn down and unrendered. For tiny chunks of template, that doesn't mean very much, but for larger things that means that the teardown is expensive and setting it back up when it goes truth-y again is very expensive. It also means that any components within that section are entirely destroyed and recreated in the same cycle, which can have unfortunate side-effects for components with private internal state.

This is my attempt to address those issues by adding a flag to the mutation methods `set`, `add`, `subtract`, and `toggle` that tells any sections that unrender during the course of updates propagating from the model mutation not to completely destroy their fragment but, instead, just unrender it and hang on to it for future re-rendering. The flag is passed in a new options object as the last parameter of those methods e.g. `ractive.toggle('foo', { keep: true })`. The default behavior is still to tear everything down.

### TODO

* [x] Tests

I haven't done any extensive testing yet, but this theoretically supports transitions properly. I also haven't specifically tested it with components, but I have verified that DOM is not completely torn down and recreated when `keep === true`.

## Fixes the following issues:
Just aggravation I've experienced since trying to write a tab component that used conditional sections before giving up and resorting to `display: none` instead, which is not at all transition friendly.

## Is breaking:
Nope.

## Reviewers:
Yep.