### PR TITLE
Add deep set/object merge as an option on set

### DIFF
--- a/src/Ractive/prototype/set.js
+++ b/src/Ractive/prototype/set.js
@@ -1,8 +1,10 @@
 import { build, set } from '../../shared/set';
 
-export default function Ractive$set ( keypath, value ) {
+export default function Ractive$set ( keypath, value, options ) {
 	const ractive = this;
 
-	return set( ractive, build( ractive, keypath, value ) );
+	const opts = typeof keypath === 'object' ? value : options;
+
+	return set( ractive, build( ractive, keypath, value ), opts );
 }
 

--- a/test/browser-tests/methods/set.js
+++ b/test/browser-tests/methods/set.js
@@ -1,0 +1,27 @@
+import { test } from 'qunit';
+import { initModule } from '../test-config';
+
+export default function() {
+	initModule( 'methods/set.js' );
+
+	test( `deep set merges data into the existing model tree`, t => {
+		const r = new Ractive({
+			data: { foo: { bar: 42, bip: 'yep' } }
+		});
+
+		r.set( 'foo', { bar: { bat: 42 }, baz: [ true ] }, { deep: true } );
+		t.deepEqual( r.get( 'foo' ), { bar: { bat: 42 }, bip: 'yep', baz: [ true ] } );
+	});
+
+	test( `deep setting with numeric keys will update array indices`, t => {
+		const r = new Ractive({
+			data: { foo: [ 1, 2, 3 ] }
+		});
+
+		r.set( '', { foo: { 1: 42 } }, { deep: true } );
+		t.deepEqual( r.get( 'foo' ), [ 1, 42, 3 ] );
+
+		r.set( '', { foo: [ 99 ] }, { deep: true } );
+		t.deepEqual( r.get( 'foo' ), [ 99, 42, 3 ] );
+	});
+}


### PR DESCRIPTION
## Description of the pull request:
This adds an option `{ deep: true }` on `set` that, instead of replacing the existing data, merges the new data into it. So with `{ foo: { bar: 1, bat: 2 } }`, calling `ractive.set('foo', { baz: 99 }, { deep: true })` will result in the data being `{ foo: { bar: 1, bat: 2, baz: 99 } }`.

Handily, this also works with arrays using both arrays and objects with numeric keys e.g. with `{ foo: [ 1, 2, 3 ] }`, `ractive.set('foo', { 1: 42 }, { deep: true })` and `ractive.set('foo', [99], { deep: true })` will both do what you'd expect. The keypath can also be root e.g. `''`.

## Fixes the following issues:
#550 #1907

## Is breaking:
Nope.

## Reviewers:
Yep.