### PR TITLE
Allow use of existing constructors (classes) in extend - RFC

### DIFF
--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -3,7 +3,7 @@ import easing from './Ractive/static/easing';
 import interpolators from './Ractive/static/interpolators';
 import { magic, svg, win } from './config/environment';
 import proto from './Ractive/prototype';
-import extend from './extend/_extend';
+import { extend, initClass } from './extend/_extend';
 import parse from './parse/_parse';
 import getNodeInfo from './Ractive/static/getNodeInfo';
 import construct from './Ractive/construct';
@@ -48,6 +48,7 @@ Object.defineProperties( Ractive, {
 
 	// static methods:
 	extend:         { value: extend },
+	initClass:      { value: initClass },
 	escapeKey:      { value: escapeKey },
 	getNodeInfo:    { value: getNodeInfo },
 	joinKeys:       { value: joinKeys },

--- a/src/extend/_extend.js
+++ b/src/extend/_extend.js
@@ -8,9 +8,7 @@ import unwrapExtended from './unwrapExtended';
 
 const callsSuper = /super\s\(|\.call\s*\(\s*this/;
 
-export default extend;
-
-function extend ( ...options ) {
+export function extend ( ...options ) {
 	if( !options.length ) {
 		return extendOne( this );
 	} else {
@@ -18,7 +16,11 @@ function extend ( ...options ) {
 	}
 }
 
-function extendOne ( Parent, options = {} ) {
+export function initClass ( Class, options = {} ) {
+	return extendOne( this, options, Class );
+}
+
+function extendOne ( Parent, options = {}, Target ) {
 	// if we're extending with another Ractive instance...
 	//
 	//   var Human = Ractive.extend(...), Spider = Ractive.extend(...);
@@ -29,12 +31,10 @@ function extendOne ( Parent, options = {} ) {
 		options = unwrapExtended( options );
 	}
 
-	let Child, proto;
+	let proto;
+	let Child = typeof Target === 'function' && Target;
 
-	if ( typeof options.class === 'function' ) {
-		Child = options.class;
-		delete options.class;
-
+	if ( Child ) {
 		if ( !( Child.prototype instanceof Parent ) ) {
 			throw new Error( `Only classes that inherit the appropriate prototype may be used with extend` );
 		}
@@ -64,6 +64,7 @@ function extendOne ( Parent, options = {} ) {
 
 		// extendable
 		extend: { value: extend, writable: true, configurable: true },
+		extendClass: { value: initClass, writable: true, configurable: true },
 
 		// Parent - for IE8, can't use Object.getPrototypeOf
 		_Parent: { value: Parent }

--- a/test/browser-tests/init/extend.js
+++ b/test/browser-tests/init/extend.js
@@ -248,8 +248,7 @@ export default function() {
 			}
 		}
 
-		Ractive.extend({
-			class: Foo,
+		Ractive.initClass( Foo, {
 			template: 'hello, {{name}}'
 		});
 
@@ -267,7 +266,7 @@ export default function() {
 		class Foo {}
 
 		t.throws( () => {
-			Ractive.extend({ class: Foo });
+			Ractive.initClass( Foo );
 		}, /inherit the appropriate prototype/ );
 	});
 
@@ -277,7 +276,7 @@ export default function() {
 		class Foo extends Ractive {}
 
 		t.throws( () => {
-			Ractive.extend({ class: Foo });
+			Ractive.initClass( Foo );
 		}, /call super/ );
 	});
 }

--- a/test/browser-tests/init/extend.js
+++ b/test/browser-tests/init/extend.js
@@ -236,4 +236,48 @@ export default function() {
 		r.toggle( 'foo' );
 		r.toggle( 'bar' );
 	});
+
+	test( `an existing constructor can be specified using the class option`, t => {
+		class Foo extends Ractive {
+			constructor ( opts ) {
+				super( opts );
+			}
+
+			go () {
+				this.set( 'name', 'classy' );
+			}
+		}
+
+		Ractive.extend({
+			class: Foo,
+			template: 'hello, {{name}}'
+		});
+
+		const f = new Foo({
+			target: fixture
+		});
+
+		f.go();
+		t.htmlEqual( fixture.innerHTML, 'hello, classy' );
+	});
+
+	test( `existing constructors supplied to extend should inherit from Ractive`, t => {
+		t.expect( 1 );
+
+		class Foo {}
+
+		t.throws( () => {
+			Ractive.extend({ class: Foo });
+		}, /inherit the appropriate prototype/ );
+	});
+
+	test( `existing constructors supploed to extend should call super`, t => {
+		t.expect( 1 );
+
+		class Foo extends Ractive {}
+
+		t.throws( () => {
+			Ractive.extend({ class: Foo });
+		}, /call super/ );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
This adds support for calling Ractive.extend with an existing constructor, meaning that you can use an ES6 class or the appropriate function construct usually created by js-sugar languages to create a new component/view. The only two constraints are

1. the constructor has a Ractive as a prototypal ancestor
2. the constructor calls super

Both of these are checked during `extend`, though the super call is a bit of a loose check. If the checks don't pass, `extend` will throw an error.

```js
// Ractive could also be another extension
class Foo extends Ractive {
  constructor(opts) {
    super(opts);
    this.foo = doSomethingMeaningfulOnEveryConstruction();
  }
  
  go() {
    this.set( 'gone', 'probably' );
  }
}

// you still have to call extend, which handles
// setting up all of the fun things like parsing
// templates, munging attributes, and rigging
// on and observe listeners
Ractive.extend({
  class: Foo,
  attributes: { ... },
  on: { ... },
  template: '...'
});

// again, Ractive could be other extensions

const f = new Foo({
  target: '#some-el'
});

f.go(); // probably gone
```

### Why?

I was wondering how we could go with the ES6 (and maybe typescript, coffeescript, livescript, etc) grain a little more readily, and it occurred to me that there's no hard requirement for Ractive to create the constructor. It just needs to decorate it if everything lines up right.

That and it really irritates me that _every_ component is just `Child`. With this you can control the constructor name 😄 

## Fixes the following issues:
#1885 and maybe a few other closed issues

## Is breaking:
Not really, unless you use `class` as an attribute in `extend`

## Reviewers:
Yep.