### PR TITLE
Better CSS at-rules handling (fixes #2854)

### DIFF
--- a/src/utils/cleanCss.js
+++ b/src/utils/cleanCss.js
@@ -5,10 +5,14 @@ const value = /\0(\d+)/g;
 // Removes comments and strings from the given CSS to make it easier to parse.
 // Callback receives the cleaned CSS and a function which can be used to put
 // the removed strings back in place after parsing is done.
-export default function ( css, callback ) {
+export default function ( css, callback, additionalReplaceRules = [] ) {
 	const values = [];
 	const reconstruct = css => css.replace( value, ( match, n ) => values[ n ] );
 	css = css.replace( escape, match => `\0${values.push( match ) - 1}`).replace( remove, '' );
+
+	additionalReplaceRules.forEach( ( pattern ) => {
+		css = css.replace( pattern, match => `\0${values.push( match ) - 1}` );
+	});
 
 	return callback( css, reconstruct );
 }

--- a/test/browser-tests/render/css.js
+++ b/test/browser-tests/render/css.js
@@ -369,4 +369,16 @@ export default function() {
 		t.equal( cmp.toHTML(), '<div data-ractive-css="{my-nifty-cmp}"></div>' );
 		t.ok( ~cmp.toCSS().indexOf( 'my-nifty-cmp' ) );
 	});
+
+	test( `using 'from' and 'to' in keyframe declarations works (#2854)`, t => {
+		const cmp = new (Ractive.extend({
+			el: fixture,
+			template: '<p class="blue">foo</p><p class="red">bar</p>',
+			css: '.blue { color: blue } @keyframes someAnimation { from { transform: scale3d(1.5,1.5,1) rotate(0deg); } } .red { color: red }'
+		}));
+
+		t.equal( getHexColor( cmp.find( '.blue' ) ), hexCodes.blue );
+		t.equal( getHexColor( cmp.find( '.red' ) ), hexCodes.red );
+		t.ok( ~cmp.toCSS().indexOf( 'someAnimation { from { transform: scale3d(1.5,1.5,1) rotate(0deg); } }' ) );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
Excludes contents of `@keyframes someAnimation {...}` blocks from the transformation process.

## Fixes the following issues:
#2854

## Is breaking:
No.