### PR TITLE
More enhance support (triples, splitText, and anchors)

### DIFF
--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -184,10 +184,18 @@ export default class Component extends Item {
 
 	render ( target, occupants ) {
 		if ( this.isAnchor ) {
+			this.rendered = true;
 			this.target = target;
+
 			if ( !checking.length ) {
 				checking.push( this.ractive );
-				runloop.scheduleTask( checkAnchors, true );
+				if ( occupants ) {
+					this.occupants = occupants;
+					checkAnchors();
+					this.occupants = null;
+				} else {
+					runloop.scheduleTask( checkAnchors, true );
+				}
 			}
 		} else {
 			render( this.instance, target, null, occupants );
@@ -195,8 +203,9 @@ export default class Component extends Item {
 			this.attributes.forEach( callRender );
 			this.eventHandlers.forEach( callRender );
 			updateLiveQueries( this );
+
+			this.rendered = true;
 		}
-		this.rendered = true;
 	}
 
 	shuffled () {
@@ -305,7 +314,7 @@ function renderItem ( anchor, meta ) {
 	anchor.eventHandlers.forEach( callRender );
 
 	const target = anchor.parentFragment.findParentNode();
-	render( meta.instance, target, target.contains( nextNode ) ? nextNode : null );
+	render( meta.instance, target, target.contains( nextNode ) ? nextNode : null, anchor.occupants );
 
 	if ( meta.lastBound !== anchor ) {
 		meta.lastBound = anchor;

--- a/src/view/items/Interpolator.js
+++ b/src/view/items/Interpolator.js
@@ -1,4 +1,4 @@
-import { doc } from '../../config/environment';
+import progressiveText from './shared/progressiveText';
 import { escapeHtml } from '../../utils/html';
 import { safeToStringValue } from '../../utils/dom';
 import Mustache from './shared/Mustache';
@@ -29,27 +29,7 @@ export default class Interpolator extends Mustache {
 
 		this.rendered = true;
 
-		if ( occupants ) {
-			let n = occupants[0];
-			if ( n && n.nodeType === 3 ) {
-				occupants.shift();
-				if ( n.nodeValue !== value ) {
-					n.nodeValue = value;
-				}
-			} else {
-				n = this.node = doc.createTextNode( value );
-				if ( occupants[0] ) {
-					target.insertBefore( n, occupants[0] );
-				} else {
-					target.appendChild( n );
-				}
-			}
-
-			this.node = n;
-		} else {
-			this.node = doc.createTextNode( value );
-			target.appendChild( this.node );
-		}
+		progressiveText( this, target, occupants, value );
 	}
 
 	toString ( escape ) {

--- a/src/view/items/Text.js
+++ b/src/view/items/Text.js
@@ -1,4 +1,4 @@
-import { doc } from '../../config/environment';
+import progressiveText from './shared/progressiveText';
 import { TEXT } from '../../config/types';
 import { escapeHtml } from '../../utils/html';
 import Item from './shared/Item';
@@ -24,27 +24,7 @@ export default class Text extends Item {
 		if ( inAttributes() ) return;
 		this.rendered = true;
 
-		if ( occupants ) {
-			let n = occupants[0];
-			if ( n && n.nodeType === 3 ) {
-				occupants.shift();
-				if ( n.nodeValue !== this.template ) {
-					n.nodeValue = this.template;
-				}
-			} else {
-				n = this.node = doc.createTextNode( this.template );
-				if ( occupants[0] ) {
-					target.insertBefore( n, occupants[0] );
-				} else {
-					target.appendChild( n );
-				}
-			}
-
-			this.node = n;
-		} else {
-			this.node = doc.createTextNode( this.template );
-			target.appendChild( this.node );
-		}
+		progressiveText( this, target, occupants, this.template );
 	}
 
 	toString ( escape ) {

--- a/src/view/items/Triple.js
+++ b/src/view/items/Triple.js
@@ -61,12 +61,62 @@ export default class Triple extends Mustache {
 	}
 
 	firstNode () {
-		return this.nodes[0];
+		return this.rendered && this.nodes[0];
 	}
 
-	render ( target ) {
-		const html = this.model ? this.model.get() : '';
-		this.nodes = insertHtml( html, this.parentFragment.findParentNode(), target );
+	render ( target, occupants ) {
+		const parentNode = this.parentFragment.findParentNode();
+
+		if ( !this.nodes ) {
+			const html = this.model ? this.model.get() : '';
+			this.nodes = insertHtml( html, this.parentFragment.findParentNode(), target );
+		}
+
+		let nodes = this.nodes;
+		let anchor = this.parentFragment.findNextNode( this );
+
+		// progressive enhancement
+		if ( occupants ) {
+			let i = -1;
+			let next;
+
+			// start with the first node that should be rendered
+			while ( occupants.length && ( next = this.nodes[ i + 1 ] ) ) {
+				let n;
+				// look through the occupants until a matching node is found
+				while ( n = occupants.shift() ) {
+					const t = n.nodeType;
+
+					if ( t === next.nodeType && ( ( t === 1 && n.outerHTML === next.outerHTML ) || ( ( t === 3 || t === 8 ) && n.nodeValue === next.nodeValue ) ) ) {
+						this.nodes.splice( ++i, 1, n ); // replace the generated node with the existing one
+						break;
+					} else {
+						target.removeChild( n ); // remove the non-matching existing node
+					}
+				}
+			}
+
+			if ( i >= 0 ) {
+				// update the list of remaining nodes to attach, excluding any that were replaced by existing nodes
+				nodes = this.nodes.slice( i );
+			}
+
+			// update the anchor to be the next occupant
+			if ( occupants.length ) anchor = occupants[0];
+		}
+
+		// attach any remainging nodes to the parent
+		if ( nodes.length ) {
+			const frag = createDocumentFragment();
+			nodes.forEach( n => frag.appendChild( n ) );
+
+			if ( anchor ) {
+				anchor.parentNode.insertBefore( frag, anchor );
+			} else {
+				parentNode.appendChild( frag );
+			}
+		}
+
 		this.rendered = true;
 	}
 
@@ -77,6 +127,7 @@ export default class Triple extends Mustache {
 	unrender () {
 		if ( this.nodes ) this.nodes.forEach( node => detachNode( node ) );
 		this.rendered = false;
+		this.nodes = null;
 	}
 
 	update () {
@@ -84,13 +135,7 @@ export default class Triple extends Mustache {
 			this.dirty = false;
 
 			this.unrender();
-			const docFrag = createDocumentFragment();
-			this.render( docFrag );
-
-			const parentNode = this.parentFragment.findParentNode();
-			const anchor = this.parentFragment.findNextNode( this );
-
-			parentNode.insertBefore( docFrag, anchor );
+			this.render();
 		} else {
 			// make sure to reset the dirty flag even if not rendered
 			this.dirty = false;

--- a/src/view/items/shared/progressiveText.js
+++ b/src/view/items/shared/progressiveText.js
@@ -1,0 +1,31 @@
+import { doc } from '../../../config/environment';
+
+export default function progressiveText ( item, target, occupants, text ) {
+	if ( occupants ) {
+		let n = occupants[0];
+		if ( n && n.nodeType === 3 ) {
+			const idx = n.nodeValue.indexOf( text );
+			occupants.shift();
+
+			if ( idx === 0 ) {
+				if ( n.nodeValue.length !== text.length ) {
+					occupants.unshift( n.splitText( text.length ) );
+				}
+			} else {
+				n.nodeValue = text;
+			}
+		} else {
+			n = item.node = doc.createTextNode( text );
+			if ( occupants[0] ) {
+				target.insertBefore( n, occupants[0] );
+			} else {
+				target.appendChild( n );
+			}
+		}
+
+		item.node = n;
+	} else {
+		if ( !item.node ) item.node = doc.createTextNode( text );
+		target.appendChild( item.node );
+	}
+}

--- a/src/view/items/triple/insertHtml.js
+++ b/src/view/items/triple/insertHtml.js
@@ -20,7 +20,7 @@ try {
 	};
 }
 
-export default function ( html, node, docFrag ) {
+export default function ( html, node ) {
 	const nodes = [];
 
 	// render 0 and false
@@ -68,7 +68,7 @@ export default function ( html, node, docFrag ) {
 	let child;
 	while ( child = container.firstChild ) {
 		nodes.push( child );
-		docFrag.appendChild( child );
+		container.removeChild( child );
 	}
 
 	// This is really annoying. Extracting <option> nodes from the

--- a/test/browser-tests/render/enhance.js
+++ b/test/browser-tests/render/enhance.js
@@ -457,4 +457,16 @@ export default function() {
 		t.strictEqual( r.find( 'svg' ), svg );
 		t.strictEqual( r.find( 'use' ), use );
 	});
+
+	test( `enhancing sibling text nodes and interpolators`, t => {
+		fixture.innerHTML = 'foo bar baz';
+		new Ractive({
+			target: fixture,
+			template: 'foo {{bar}} baz',
+			enhance: true,
+			data: { bar: 'bar' }
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'foo bar baz' );
+	});
 }

--- a/test/browser-tests/render/enhance.js
+++ b/test/browser-tests/render/enhance.js
@@ -469,4 +469,52 @@ export default function() {
 
 		t.htmlEqual( fixture.innerHTML, 'foo bar baz' );
 	});
+
+	test( `triples reuse existing content if it matches (#2403)`, t => {
+		fixture.innerHTML = '<div>foo bar</div><span><i>guts</i></span>&amp; why not?<!-- yep -->?sure';
+		const div = fixture.childNodes[0];
+		const text = div.childNodes[0];
+		const span = fixture.childNodes[1];
+		const text2 = fixture.childNodes[2];
+		const comment = span.childNodes[3];
+
+		new Ractive({
+			target: fixture,
+			template: '{{{html}}}?{{str}}',
+			data: {
+				html: '<div>foo bar</div><span><i>guts</i></span>&amp; why not?<!-- yep -->',
+				str: 'sure'
+			},
+			enhance: true
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div>foo bar</div><span><i>guts</i></span>&amp; why not?<!-- yep -->?sure' );
+
+		const _div = fixture.childNodes[0];
+		const _text = div.childNodes[0];
+		const _span = fixture.childNodes[1];
+		const _text2 = fixture.childNodes[2];
+		const _comment = span.childNodes[3];
+
+		t.ok( div === _div );
+		t.ok( text === _text );
+		t.ok( span === _span );
+		t.ok( text2 === _text2 );
+		t.ok( comment === _comment );
+	});
+
+	test( `triples that don't match existing content are still rendered correctly`, t => {
+		fixture.innerHTML = '<div>nope</div>sure';
+
+		new Ractive({
+			target: fixture,
+			template: '{{{html}}}',
+			data: {
+				html: '<div>yep</div>still yep'
+			},
+			enhance: true
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div>yep</div>still yep' );
+	});
 }

--- a/test/browser-tests/render/enhance.js
+++ b/test/browser-tests/render/enhance.js
@@ -517,4 +517,26 @@ export default function() {
 
 		t.htmlEqual( fixture.innerHTML, '<div>yep</div>still yep' );
 	});
+
+	test( `enhancement works with anchors`, t => {
+		fixture.innerHTML = '<div>foo</div>';
+		const div = fixture.childNodes[0];
+		const text = div.childNodes[0];
+
+		const foo = new Ractive({
+			template: '<div>{{bar}}</div>',
+			data: { bar: 'foo' }
+		});
+
+		const host = new Ractive({
+			template: '<#foo />',
+			enhance: true
+		});
+
+		host.attachChild( foo, { target: 'foo' } );
+		host.render( fixture );
+
+		t.ok( host.find( 'div' ) === div );
+		t.ok( host.find( 'div' ).childNodes[0] === text );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
This adds progressive enhancement support for triples by checking the supplied occupants against the nodes generated by converting the html to DOM, mostly with `Element.outerHTML`.

This also adjusts the enhancement of text node items (text and interpolator) so that they use `TextNode.splitText`, which does what it says on the tin, rather than truncating the node and appending a new one manually. _Theoretically_, that would eliminate any flash that _may_ occur by taking the truncate-and-add-a-sibling approach.

This also adds progressive enhancement support for attached children in anchors. It's a bit weird getting an anchor set up to be occupied before the initial render, but it's also pretty important for apps that need enhancement and want to use layouts. Basically, you have to create all of your relevant instances without target elements and with the enhance flag on the root instance, attach and children with appropriate targets, and then render the root instance into its target element.

With all of those addressed, I'd say we have full coverage on progressive enhancement for 0.9.

## Fixes the following issues:
#2403 #2664

## Is breaking:
Nope.