### PR TITLE
BREAKING: Switch isolated flag to default to true - #2803

### DIFF
--- a/src/Ractive/config/defaults.js
+++ b/src/Ractive/config/defaults.js
@@ -28,7 +28,7 @@ export default {
 	magic:                  false,
 	modifyArrays:           false,
 	adapt:                  [],
-	isolated:               false,
+	isolated:               true,
 	twoway:                 true,
 	lazy:                   false,
 

--- a/test/browser-tests/components/data-and-mappings.js
+++ b/test/browser-tests/components/data-and-mappings.js
@@ -99,10 +99,12 @@ export default function() {
 			},
 			components: {
 				Outer: Ractive.extend({
-					template: '{{#with item}}<Inner foo="{{foo}}"/>{{/with}}'
+					template: '{{#with item}}<Inner foo="{{foo}}"/>{{/with}}',
+					isolated: false
 				}),
 				Inner: Ractive.extend({
-					template: '<p>foo: {{foo}}</p>'
+					template: '<p>foo: {{foo}}</p>',
+					isolated: false
 				})
 			}
 		});
@@ -209,7 +211,8 @@ export default function() {
 
 	test( 'Components can access outer data context, in the same way JavaScript functions can access outer lexical scope', t => {
 		const Widget = Ractive.extend({
-			template: '<p>{{foo || "missing"}}</p>'
+			template: '<p>{{foo || "missing"}}</p>',
+			isolated: false
 		});
 
 		const ractive = new Ractive({
@@ -236,12 +239,14 @@ export default function() {
 
 	test( 'Nested components can access outer-most data context', t => {
 		const GrandWidget = Ractive.extend({
-			template: 'hello {{world}}'
+			template: 'hello {{world}}',
+			isolated: false
 		});
 
 		const Widget = Ractive.extend({
 			template: '<GrandWidget/>',
-			components: { GrandWidget }
+			components: { GrandWidget },
+			isolated: false
 		});
 
 		const ractive = new Ractive({
@@ -258,10 +263,12 @@ export default function() {
 
 	test( 'Nested components registered at global Ractive can access outer-most data context', t => {
 		Ractive.components.Widget = Ractive.extend({
-			template: '<GrandWidget/>'
+			template: '<GrandWidget/>',
+			isolated: false
 		});
 		Ractive.components.GrandWidget = Ractive.extend({
-			template: 'hello {{world}}'
+			template: 'hello {{world}}',
+			isolated: false
 		});
 
 		const ractive = new Ractive({
@@ -420,7 +427,8 @@ export default function() {
 
 	test( 'Uninitialised implicit dependencies of evaluators that use inherited functions are handled', t => {
 		const Widget = Ractive.extend({
-			template: '{{status()}}'
+			template: '{{status()}}',
+			isolated: false
 		});
 
 		const ractive = new Ractive({
@@ -498,7 +506,8 @@ export default function() {
 			data: { items: [ 'a', 'b', 'c' ] },
 			components: {
 				Widget: Ractive.extend({
-					template: '<p>{{i}}: {{letter}}</p>'
+					template: '<p>{{i}}: {{letter}}</p>',
+					isolated: false
 				})
 			}
 		});
@@ -729,7 +738,8 @@ export default function() {
 			data: { person: {} },
 			components: {
 				Widget: Ractive.extend({
-					template: '<input value="{{person.first}}"/><input value="{{person.last}}"/>'
+					template: '<input value="{{person.first}}"/><input value="{{person.last}}"/>',
+					isolated: false
 				})
 			}
 		});
@@ -750,7 +760,8 @@ export default function() {
 			template: '{{#context}}<Widget/>{{/}}',
 			components: {
 				Widget: Ractive.extend({
-					template: 'works? {{works}}'
+					template: 'works? {{works}}',
+					isolated: false
 				})
 			},
 			data: {
@@ -824,7 +835,8 @@ export default function() {
 			oninit () {
 				this.observe( 'message', message => this.set( 'proxy', message ) );
 				t.equal( this.get( 'answer' ), 42 );
-			}
+			},
+			isolated: false
 		});
 
 		const ractive = new Ractive({
@@ -909,7 +921,8 @@ export default function() {
 
 					t.complete();
 				}
-			}
+			},
+			isolated: false
 		});
 
 		const ractive = new Ractive({
@@ -1117,7 +1130,8 @@ export default function() {
 
 	test( 'components should update their mappings on rebind to prevent weirdness with shuffling (#2147)', t => {
 		const Item = Ractive.extend({
-			template: '{{value}}'
+			template: '{{value}}',
+			isolated: false
 		});
 
 		const ractive = new Ractive({
@@ -1257,7 +1271,8 @@ export default function() {
 
 	test( 'complex mappings continue to update with their dependencies', t => {
 		const cmp = Ractive.extend({
-			template: '{{foo}}'
+			template: '{{foo}}',
+			isolated: false
 		});
 		const r = new Ractive({
 			el: fixture,
@@ -1326,9 +1341,9 @@ export default function() {
 	test( `shuffling a link to a link to a list doesn't blow the stack (#2699)`, t => {
 		t.expect( 0 );
 
-		const cmp1 = Ractive.extend({ template: '<cmp2 list="{{list}}" />' });
-		const cmp2 = Ractive.extend({ template: '<cmp3 list="{{list}}" />' });
-		const cmp3 = Ractive.extend();
+		const cmp1 = Ractive.extend({ template: '<cmp2 list="{{list}}" />', isolated: false });
+		const cmp2 = Ractive.extend({ template: '<cmp3 list="{{list}}" />', isolated: false });
+		const cmp3 = Ractive.extend({ isolated: false });
 		const r = new Ractive({
 			el: fixture,
 			template: '<cmp1 list="{{items}}" />',
@@ -1342,9 +1357,9 @@ export default function() {
 	test( `shuffling a link to a link to a list updates correctly`, t => {
 		t.expect( 2 );
 
-		const cmp1 = Ractive.extend({ template: '<cmp2 list="{{list}}" />' });
-		const cmp2 = Ractive.extend({ template: '{{#each list}}{{.}}{{/each}}<cmp3 list="{{list}}" />' });
-		const cmp3 = Ractive.extend();
+		const cmp1 = Ractive.extend({ template: '<cmp2 list="{{list}}" />', isolated: false });
+		const cmp2 = Ractive.extend({ template: '{{#each list}}{{.}}{{/each}}<cmp3 list="{{list}}" />', isolated: false });
+		const cmp3 = Ractive.extend({ isolated: false });
 		const r = new Ractive({
 			el: fixture,
 			template: '<cmp1 list="{{items}}" />',

--- a/test/browser-tests/components/misc.js
+++ b/test/browser-tests/components/misc.js
@@ -211,7 +211,8 @@ export default function() {
 		});
 
 		const Bar = Ractive.extend({
-			template: '<Foo/>'
+			template: '<Foo/>',
+			isolated: false
 		});
 
 		new Ractive({
@@ -287,7 +288,8 @@ export default function() {
 
 	test( 'Regression test for #871', t => {
 		const Widget = Ractive.extend({
-			template: '<p>inside component: {{i}}-{{text}}</p>'
+			template: '<p>inside component: {{i}}-{{text}}</p>',
+			isolated: false
 		});
 
 		const ractive = new Ractive({
@@ -436,7 +438,8 @@ export default function() {
 			data: { foo: true },
 			components: {
 				Widget: Ractive.extend({
-					template: '<Bar/>'
+					template: '<Bar/>',
+					isolated: false
 				}),
 				Foo () {
 					thisForFoo = this;
@@ -449,8 +452,8 @@ export default function() {
 			}
 		});
 
-		t.equal( thisForFoo, ractive );
-		t.equal( thisForBar, ractive );
+		t.ok( thisForFoo === ractive );
+		t.ok( thisForBar === ractive );
 	});
 
 	test( 'oninit() only fires once on a component (#943 #927), oncomplete fires each render', t => {
@@ -557,7 +560,8 @@ export default function() {
 		const inDom = {};
 
 		const Widget = Ractive.extend({
-			template: '<div as-check=""widget"">{{yield}}</div>'
+			template: '<div as-check=""widget"">{{yield}}</div>',
+			isolated: false
 		});
 
 		new Ractive({
@@ -678,9 +682,9 @@ export default function() {
 			el: fixture,
 			template: '<Foo message="{{message}}"/>',
 			components: {
-				Foo: Ractive.extend({ template: '<Bar message="{{message}}"/>' }),
-				Bar: Ractive.extend({ template: '<Baz message="{{message}}"/>' }),
-				Baz: Ractive.extend({ template: '{{message}}' })
+				Foo: Ractive.extend({ template: '<Bar message="{{message}}"/>', isolated: false }),
+				Bar: Ractive.extend({ template: '<Baz message="{{message}}"/>', isolated: false }),
+				Baz: Ractive.extend({ template: '{{message}}', isolated: false })
 			}
 		});
 
@@ -693,9 +697,9 @@ export default function() {
 			el: fixture,
 			template: '<Foo message="{{message}}"/>',
 			components: {
-				Foo: Ractive.extend({ template: '<Bar/>' }),
-				Bar: Ractive.extend({ template: '<Baz/>' }),
-				Baz: Ractive.extend({ template: '{{message}}' })
+				Foo: Ractive.extend({ template: '<Bar/>', isolated: false }),
+				Bar: Ractive.extend({ template: '<Baz/>', isolated: false }),
+				Baz: Ractive.extend({ template: '{{message}}', isolated: false })
 			}
 		});
 
@@ -915,10 +919,12 @@ export default function() {
 
 	test( 'component @rootpaths should skip root contexts (#2026)', t => {
 		const end = Ractive.extend({
-			template: '{{@rootpath}}'
+			template: '{{@rootpath}}',
+			isolated: false
 		});
 		const middle = Ractive.extend({
-			template: '{{#if middle}}{{#with middle}}<middle middle="{{.next}}" />{{/with}}{{else}}<end />{{/if}}'
+			template: '{{#if middle}}{{#with middle}}<middle middle="{{.next}}" />{{/with}}{{else}}<end />{{/if}}',
+			isolated: false
 		});
 		new Ractive({
 			el: fixture,
@@ -934,10 +940,12 @@ export default function() {
 
 	test( '@rootpath should be accurate in events fired from within components (#2026)', t => {
 		const end = Ractive.extend({
-			template: '<button on-click="go">click me</button>'
+			template: '<button on-click="go">click me</button>',
+			isolated: false
 		});
 		const middle = Ractive.extend({
-			template: '{{#if middle}}{{#with middle}}<middle middle="{{.next}}" />{{/with}}{{else}}<end />{{/if}}'
+			template: '{{#if middle}}{{#with middle}}<middle middle="{{.next}}" />{{/with}}{{else}}<end />{{/if}}',
+			isolated: false
 		});
 		const r = new Ractive({
 			el: fixture,

--- a/test/browser-tests/components/yield.js
+++ b/test/browser-tests/components/yield.js
@@ -96,7 +96,8 @@ export default function() {
 
 	test( 'A component {{yield}} can be rerendered in conditional section block', t => {
 		const Widget = Ractive.extend({
-			template: '<p>{{#foo}}{{yield}}{{/}}</p>'
+			template: '<p>{{#foo}}{{yield}}{{/}}</p>',
+			isolated: false
 		});
 
 		const ractive = new Ractive({
@@ -117,7 +118,8 @@ export default function() {
 			template: `
 				{{#each items:i}}
 					{{this}}{{#if i===1}}:{{yield}}:{{/if}}
-				{{/each}}`
+				{{/each}}`,
+			isolated: false
 		});
 
 		const ractive = new Ractive({

--- a/test/browser-tests/computations.js
+++ b/test/browser-tests/computations.js
@@ -370,7 +370,8 @@ export default function() {
 				BAR () {
 					return this.get( 'bar' ).toUpperCase();
 				}
-			}
+			},
+			isolated: false
 		});
 
 		new Ractive({

--- a/test/browser-tests/events/bubbling.js
+++ b/test/browser-tests/events/bubbling.js
@@ -9,11 +9,13 @@ export default function() {
 
 	beforeEach( () => {
 		Component = Ractive.extend({
-			template: '<span id="test" on-click="someEvent">click me</span>'
+			template: '<span id="test" on-click="someEvent">click me</span>',
+			isolated: false
 		});
 
 		Middle = Ractive.extend({
-			template: '<Component/>'
+			template: '<Component/>',
+			isolated: false
 		});
 
 		Subclass = Ractive.extend({

--- a/test/browser-tests/events/dom-proxy-events.js
+++ b/test/browser-tests/events/dom-proxy-events.js
@@ -153,10 +153,12 @@ export default function() {
 		t.expect( 4 );
 
 		const cmp = Ractive.extend({
-			template: '{{#with baz}}<span id="test" on-click="someEvent">click me</span>{{/with}}<cmp2 oof="{{baz}}" />'
+			template: '{{#with baz}}<span id="test" on-click="someEvent">click me</span>{{/with}}<cmp2 oof="{{baz}}" />',
+			isolated: false
 		});
 		const cmp2 = Ractive.extend({
-			template: '{{#with oof}}<span id="test2" on-click="someEvent">click me</span>{{/with}}'
+			template: '{{#with oof}}<span id="test2" on-click="someEvent">click me</span>{{/with}}',
+			isolated: false
 		});
 		const ractive = new Ractive({
 			el: fixture,
@@ -184,10 +186,12 @@ export default function() {
 		t.expect( 4 );
 
 		const cmp = Ractive.extend({
-			template: '{{#with baz}}<span id="test" on-click="someEvent">click me</span>{{/with}}<cmp2 oof="{{baz}}" />'
+			template: '{{#with baz}}<span id="test" on-click="someEvent">click me</span>{{/with}}<cmp2 oof="{{baz}}" />',
+			isolated: false
 		});
 		const cmp2 = Ractive.extend({
-			template: '{{#with oof}}<span id="test2" on-click="someEvent">click me</span>{{/with}}'
+			template: '{{#with oof}}<span id="test2" on-click="someEvent">click me</span>{{/with}}',
+			isolated: false
 		});
 		const ractive = new Ractive({
 			el: fixture,

--- a/test/browser-tests/events/misc.js
+++ b/test/browser-tests/events/misc.js
@@ -19,14 +19,16 @@ export default function() {
 				</div>`,
 			onteardown () {
 				torndown.push( this );
-			}
+			},
+			isolated: false
 		});
 
 		const Grandchild = Ractive.extend({
 			template: '{{title}}',
 			onteardown () {
 				torndown.push( this );
-			}
+			},
+			isolated: false
 		});
 
 		const ractive = new Ractive({

--- a/test/browser-tests/init/config.js
+++ b/test/browser-tests/init/config.js
@@ -37,7 +37,7 @@ export default function() {
 		const adaptor1 = {};
 		const adaptor2 = {};
 		const parent = new Ractive( { adaptors: { foo: adaptor1 } } );
-		const ractive = new Ractive( { adaptors: { bar: adaptor2 } } );
+		const ractive = new Ractive( { adaptors: { bar: adaptor2 }, isolated: false } );
 
 		ractive.parent = parent;
 

--- a/test/browser-tests/init/hooks/order.js
+++ b/test/browser-tests/init/hooks/order.js
@@ -229,7 +229,8 @@ export default function() {
 			ondestruct () {
 				t.ok( finished );
 				t.ok( !fixture.querySelector( '*' ) );
-			}
+			},
+			isolated: false
 		});
 
 		const r = new Ractive({

--- a/test/browser-tests/methods/observe.js
+++ b/test/browser-tests/methods/observe.js
@@ -1104,7 +1104,8 @@ export default function() {
 						t.equal( n, 0 );
 					}
 				});
-			}
+			},
+			isolated: false
 		});
 
 		const r = new Ractive({

--- a/test/browser-tests/methods/readLink.js
+++ b/test/browser-tests/methods/readLink.js
@@ -43,9 +43,10 @@ export default function() {
 
 	test( `readLink is canonical by default`, t => {
 		const cmp1 = Ractive.extend({
-			template: '<cmp2 fizz="{{bop}}" />'
+			template: '<cmp2 fizz="{{bop}}" />',
+			isolated: false
 		});
-		const cmp2 = Ractive.extend();
+		const cmp2 = Ractive.extend({ isolated: false });
 		const r = new Ractive({
 			on: { init() { this.set( 'foo.bar.baz.bat', true ); } },
 			target: fixture,
@@ -60,9 +61,10 @@ export default function() {
 
 	test( `readLink can optionally be uncanonical`, t => {
 		const cmp1 = Ractive.extend({
-			template: '<cmp2 fizz="{{bop}}" />'
+			template: '<cmp2 fizz="{{bop}}" />',
+			isolated: false
 		});
-		const cmp2 = Ractive.extend();
+		const cmp2 = Ractive.extend({ isolated: false });
 		const r = new Ractive({
 			on: { init() { this.set( 'foo.bar.baz.bat', true ); } },
 			target: fixture,

--- a/test/browser-tests/methods/toCSS.js
+++ b/test/browser-tests/methods/toCSS.js
@@ -13,7 +13,8 @@ export default function() {
 				.green {
 					color: green
 				}
-			`
+			`,
+			isolated: false
 		} );
 
 	}

--- a/test/browser-tests/misc.js
+++ b/test/browser-tests/misc.js
@@ -1359,7 +1359,8 @@ export default function() {
 			template: '<div><foo /></div>{{#bars:i}}<b>b</b><foo />{{/}}{{#baz}}{{#bat}}<p>hello</p>{{/}}{{/}}',
 			components: {
 				foo: Ractive.extend({
-					template: '<span>foo</span>'
+					template: '<span>foo</span>',
+					isolated: false
 				})
 			},
 			data: {

--- a/test/browser-tests/partials.js
+++ b/test/browser-tests/partials.js
@@ -87,7 +87,8 @@ export default function() {
 			data: { foo: true },
 			components: {
 				widget: Ractive.extend({
-					template: '{{>bar}}'
+					template: '{{>bar}}',
+					isolated: false
 				})
 			},
 			partials: {
@@ -189,7 +190,8 @@ export default function() {
 
 	test( 'partials functions can be found on view heirarchy', t => {
 		const Widget = Ractive.extend({
-			template: '{{>foo}}'
+			template: '{{>foo}}',
+			isolated: false
 		});
 
 		const ractive = new Ractive({
@@ -452,7 +454,8 @@ export default function() {
 					template: '{{>foo}} {{>bar}}',
 					partials: {
 						bar: 'cbar'
-					}
+					},
+					isolated: false
 				})
 			}
 		});
@@ -605,7 +608,8 @@ export default function() {
 				</Widget>`,
 			components: {
 				Widget: Ractive.extend({
-					template: '{{>foo}}'
+					template: '{{>foo}}',
+					isolated: false
 				})
 			}
 		});

--- a/test/browser-tests/plugins/adaptors/basic.js
+++ b/test/browser-tests/plugins/adaptors/basic.js
@@ -221,7 +221,8 @@ export default function() {
 
 	test( 'Components inherit modifyArrays option from environment (#1297)', t => {
 		const Widget = Ractive.extend({
-			template: '{{#each items}}{{this}}{{/each}}'
+			template: '{{#each items}}{{this}}{{/each}}',
+			isolated: false
 		});
 
 		// YOUR CODE GOES HERE
@@ -373,7 +374,8 @@ export default function() {
 		Ractive.adaptors.foo = fooAdaptor;
 
 		Ractive.components.Widget = Ractive.extend({
-			template: '<p>{{wrappedThing}}{{otherThing}}</p>'
+			template: '<p>{{wrappedThing}}{{otherThing}}</p>',
+			isolated: false
 		});
 
 		const r = new Ractive({

--- a/test/browser-tests/plugins/decorators.js
+++ b/test/browser-tests/plugins/decorators.js
@@ -513,7 +513,8 @@ export default function() {
 	test( 'decorators in nested components are torn down (#2608)', t => {
 		let count = 0;
 		const cmp = Ractive.extend({
-			template: '<div as-foo />'
+			template: '<div as-foo />',
+			isolated: false
 		});
 		const r = new Ractive({
 			el: fixture,

--- a/test/browser-tests/references.js
+++ b/test/browser-tests/references.js
@@ -276,7 +276,8 @@ export default function() {
 
 		const cmp = Ractive.extend({
 			template: '{{foo}}',
-			warnAboutAmbiguity: true
+			warnAboutAmbiguity: true,
+			isolated: false
 		});
 		new Ractive({
 			target: fixture,

--- a/test/browser-tests/render/components.js
+++ b/test/browser-tests/render/components.js
@@ -110,10 +110,11 @@ export default function() {
 			template: '<cmp/>',
 			components: {
 				cmp () { return this.get('cmp') || 'cmp2'; }
-			}
+			},
+			isolated: false
 		});
-		const cmp2 = Ractive.extend({ template: 'first' });
-		const cmp3 = Ractive.extend({ template: 'second' });
+		const cmp2 = Ractive.extend({ template: 'first', isolated: false });
+		const cmp3 = Ractive.extend({ template: 'second', isolated: false });
 		const r = new Ractive({
 			el: fixture,
 			template: 'the <cmp1/> place',

--- a/test/browser-tests/twoway.js
+++ b/test/browser-tests/twoway.js
@@ -1118,7 +1118,8 @@ export default function() {
 				<label class='switcher'>
 					<input type='checkbox' value='{{id}}' name='{{name}}'>
 					{{yield}}
-				</label>`
+				</label>`,
+			isolated: false
 		});
 
 		const ractive = new Ractive({

--- a/test/node-tests/components.js
+++ b/test/node-tests/components.js
@@ -2,7 +2,8 @@ QUnit.module( 'Components' );
 
 QUnit.test( 'should render in a non-DOM environment', function ( assert ) {
 	var Widget = Ractive.extend({
-		template: '<p>foo-{{bar}}</p>'
+		template: '<p>foo-{{bar}}</p>',
+		isolated: false
 	});
 
 	var ractive = new Ractive({


### PR DESCRIPTION
## Description of the pull request:
This switches the default for the `isolated` flag from `false` to `true`. If you rely on non-isolated components heavily, you can just make `Ractive.defaults.isolated = false;` part of your init, but if you don't, you can enjoy not having to worry about whether or not data changes will result in an implicit mapping to move what you thought was component-private state out of the component. You also don't have to worry about component users adding whacky adaptors to their root instance and breaking things. The global registries still apply, though.

The more tests I fixed for this change, the more I was convinced that isolated by default is a better setting. I also spent a few weeks fighting an isolation but when I first started using Ractive at around 0.4.0, where my components would start randomly sharing data.

## Fixes the following issues:
#2803

## Is breaking:
Quite.

## Reviewers:
Sure, but I'mma go ahead and merge, since the discussions already happened in #2803.

<!--
Hello!



Thank you for taking your time submitting this pull request. To make it easy for everyone to review, we'll just need a few key pieces of information:

Description of the pull request:
Describe as much as you can what this pull request is all about. Highlight key points as well as parts that need additional eyes for review.

Fixes the following issues:
Include the issues that are addressed by this pull request.

Is breaking:
Indicate if this pull request includes breaking changes.

Reviewers:
Should you want a specific someone to review this code, tag their name.



Once again, thank you for your time and patience.

Ractive Community

-->