### PR TITLE
Meta BREAKING: Rename ractive.runtime.js to runtime.js

### DIFF
--- a/gobblefile.js
+++ b/gobblefile.js
@@ -70,9 +70,9 @@ var banner = sander.readFileSync( __dirname, 'src/banner.js' ).toString()
 if ( gobble.env() === 'production' ) {
 	lib = gobble([
 		buildLib( 'ractive.js'),
-		buildLib( 'ractive.runtime.js', /_parse\.js/ ),
+		buildLib( 'runtime.js', /_parse\.js/ ),
 		buildESLib( 'ractive.mjs' ),
-		buildESLib( 'ractive.runtime.mjs', /_parse\.js/ )
+		buildESLib( 'runtime.mjs', /_parse\.js/ )
 	]).transform( noConflict );
 } else {
 	lib = gobble([

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,7 +10,7 @@ echo "> running node.js-specific tests. working directory is $PWD"
 qunit-cli --quiet --code Ractive:./tmp/ractive.js ./tmp/test/node-tests/index.js
 
 # check ractive.runtime doesn't error (#1860)
-node tmp/ractive.runtime.js
+node tmp/runtime.js
 
 # run browser tests
 $MOD/phantomjs scripts/phantom-runner.js


### PR DESCRIPTION
## Description of the pull request:
This renames ractive.runtime.js to runtime.js so you can `require('ractive/runtime')` per #1709.

## Fixes the following issues:
#1709

## Is breaking:
Meta, yes. If you use the runtime version of ractive from a cdn, for 0.9 you'll need to drop the `ractive.` from the filename.