### PR TITLE
Allow css option in extend to come from an element - #2511

### DIFF
--- a/src/Ractive/config/custom/css/css.js
+++ b/src/Ractive/config/custom/css/css.js
@@ -2,21 +2,32 @@ import { addCSS } from '../../../../global/css';
 import transformCss from './transform';
 import { uuid } from '../../../../utils/id';
 import { warnIfDebug } from '../../../../utils/log';
+import { getElement } from '../../../../utils/dom';
 
+const hasCurly = /\{/;
 export default {
 	name: 'css',
 
 	// Called when creating a new component definition
 	extend: ( Parent, proto, options ) => {
 		if ( !options.css ) return;
+		let css = typeof options.css === 'string' && !hasCurly.test( options.css ) ?
+			( getElement( options.css ) || options.css ) :
+			options.css;
 
 		const id = options.cssId || uuid();
-		const styles = options.noCssTransform ? options.css : transformCss( options.css, id );
+
+		if ( typeof css === 'object' ) {
+			css = 'textContent' in css ? css.textContent : css.innerHTML;
+		}
+
+		if ( !css ) return;
+
+		const styles = options.noCssTransform ? css : transformCss( css, id );
 
 		proto.cssId = id;
 
 		addCSS( { id, styles } );
-
 	},
 
 	// Called when creating a new component instance

--- a/test/browser-tests/render/css.js
+++ b/test/browser-tests/render/css.js
@@ -381,4 +381,29 @@ export default function() {
 		t.equal( getHexColor( cmp.find( '.red' ) ), hexCodes.red );
 		t.ok( ~cmp.toCSS().indexOf( 'someAnimation { from { transform: scale3d(1.5,1.5,1) rotate(0deg); } }' ) );
 	});
+
+	test( `css can be loaded from an element, and id, or a selector too (#2511)`, t => {
+		const script = document.createElement( 'script' );
+		script.setAttribute( 'type', 'text/css' );
+		script.setAttribute( 'id', 'foo-css' );
+		const prop = 'textContent' in script ? 'textContent' : 'innerHTML';
+		script[prop] = '.blue { color: blue; }';
+		document.head.appendChild( script );
+
+		const cmp1 = Ractive.extend({
+			css: script
+		});
+		const cmp2 = Ractive.extend({
+			css: 'foo-css'
+		});
+		const cmp3 = Ractive.extend({
+			css: '#foo-css'
+		});
+
+		document.head.removeChild( script );
+
+		t.ok( cmp1.prototype.cssId );
+		t.ok( cmp2.prototype.cssId );
+		t.ok( cmp3.prototype.cssId );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
This adds a check for curly braces in the CSS option of a component extend, and if there are none, it will look for an element from which to pull text content or inner html. It will also work with an element reference.

## Fixes the following issues:
#2511 

## Is breaking:
Nope.
