### PR TITLE
Add an option to force an update to bypass equality dirty checking - #1671

### DIFF
--- a/src/Ractive/prototype/update.js
+++ b/src/Ractive/prototype/update.js
@@ -4,7 +4,7 @@ import { splitKeypath } from '../../shared/keypaths';
 
 const updateHook = new Hook( 'update' );
 
-export function update ( ractive, model ) {
+export function update ( ractive, model, options ) {
 	// if the parent is wrapped, the adaptor will need to be updated before
 	// updating on this keypath
 	if ( model.parent && model.parent.wrapper ) {
@@ -13,7 +13,7 @@ export function update ( ractive, model ) {
 
 	const promise = runloop.start( ractive, true );
 
-	model.mark();
+	model.mark( options && options.force );
 
 	// notify upstream of changes
 	model.notifyUpstream();
@@ -25,8 +25,8 @@ export function update ( ractive, model ) {
 	return promise;
 }
 
-export default function Ractive$update ( keypath ) {
+export default function Ractive$update ( keypath, options ) {
 	if ( keypath ) keypath = splitKeypath( keypath );
 
-	return update( this, keypath ? this.viewmodel.joinAll( keypath ) : this.viewmodel );
+	return update( this, keypath ? this.viewmodel.joinAll( keypath ) : this.viewmodel, options );
 }

--- a/src/model/LinkModel.js
+++ b/src/model/LinkModel.js
@@ -108,8 +108,8 @@ export default class LinkModel extends ModelBase {
 		return this.childByKey[ key ];
 	}
 
-	mark () {
-		this.target.mark();
+	mark ( force ) {
+		this.target.mark( force );
 	}
 
 	marked () {

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -193,12 +193,12 @@ export default class Model extends ModelBase {
 		return this.childByKey[ key ];
 	}
 
-	mark () {
+	mark ( force ) {
 		if ( this._link ) return this._link.mark();
 
 		const value = this.retrieve();
 
-		if ( !isEqual( value, this.value ) ) {
+		if ( force || !isEqual( value, this.value ) ) {
 			const old = this.value;
 			this.value = value;
 			if ( this.boundValue ) this.boundValue = null;

--- a/src/shared/Context.js
+++ b/src/shared/Context.js
@@ -160,8 +160,8 @@ export default class Context {
 		return modelUnshift( findModel( this, keypath ).model, add );
 	}
 
-	update ( keypath ) {
-		return protoUpdate( this.ractive, findModel( this, keypath ).model );
+	update ( keypath, options ) {
+		return protoUpdate( this.ractive, findModel( this, keypath ).model, options );
 	}
 
 	updateModel ( keypath, cascade ) {

--- a/test/browser-tests/methods/update.js
+++ b/test/browser-tests/methods/update.js
@@ -36,4 +36,23 @@ export default function() {
 		r.findComponent().update();
 		t.htmlEqual( fixture.innerHTML, 'still yep' );
 	});
+
+	test( `an update can be forced on a keypath by passing force: true (#1671)`, t => {
+		let msg = 'one';
+		const r = new Ractive({
+			target: fixture,
+			template: '{{fn()}} {{#with foo}}{{fn()}}{{/with}}',
+			data: {
+				fn () { return msg; },
+				foo: {}
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'one one' );
+
+		msg = 'two';
+		r.update( 'fn', { force: true } );
+
+		t.htmlEqual( fixture.innerHTML, 'two two' );
+	});
 }

--- a/test/browser-tests/node-info.js
+++ b/test/browser-tests/node-info.js
@@ -613,4 +613,24 @@ export default function() {
 
 		t.ok( Ractive.getNodeInfo( fixture ).ractive === r2 );
 	});
+
+	test( `force update works from a context object`, t => {
+		let msg = 'one';
+		const r = new Ractive({
+			target: fixture,
+			template: `{{#with foo.bar}}{{#with baz}}<div>{{fn()}}</div>{{/with}}{{/with}}`,
+			data: {
+				foo: { bar: {
+					fn () { return msg; },
+					baz: {}
+				} }
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div>one</div>' );
+
+		msg = 'two';
+		r.getNodeInfo( 'div' ).update( '../fn', { force: true } );
+		t.htmlEqual( fixture.innerHTML, '<div>two</div>' );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
Dirty checking in models uses a little bit of extra logic that only forces a reevaluation of a value if the old and new are both objects. Anything else defers to an identity check, which for functions means that unless you actually swap out the function, it won't been seen as dirty. You wouldn't want to _always_ force it to be dirty because that could get computationally expensive pretty fast, so the next best thing is an option `ractive.update('some.path', { force: true })`.

This also works with relative paths and context objects.

## Fixes the following issues:
#1671

## Is breaking:
Nope.