### PR TITLE
Option to keep vdom around during change propagation - take 2

### DIFF
--- a/src/Ractive/prototype/add.js
+++ b/src/Ractive/prototype/add.js
@@ -1,5 +1,7 @@
 import add from './shared/add';
 
-export default function Ractive$add ( keypath, d ) {
-	return add( this, keypath, ( d === undefined ? 1 : +d ) );
+export default function Ractive$add ( keypath, d, options ) {
+	const num = typeof d === 'number' ? d : 1;
+	const opts = typeof d === 'object' ? d : options;
+	return add( this, keypath, num, opts );
 }

--- a/src/Ractive/prototype/subtract.js
+++ b/src/Ractive/prototype/subtract.js
@@ -1,5 +1,7 @@
 import add from './shared/add';
 
-export default function Ractive$subtract ( keypath, d ) {
-	return add( this, keypath, ( d === undefined ? -1 : -d ) );
+export default function Ractive$subtract ( keypath, d, options ) {
+	const num = typeof d === 'number' ? -d : -1;
+	const opts = typeof d === 'object' ? d : options;
+	return add( this, keypath, num, opts );
 }

--- a/src/Ractive/prototype/toggle.js
+++ b/src/Ractive/prototype/toggle.js
@@ -1,10 +1,10 @@
 import { badArguments } from '../../config/errors';
 import { gather, set } from '../../shared/set';
 
-export default function Ractive$toggle ( keypath ) {
+export default function Ractive$toggle ( keypath, options ) {
 	if ( typeof keypath !== 'string' ) {
 		throw new TypeError( badArguments );
 	}
 
-	return set( this, gather( this, keypath ).map( m => [ m, !m.get() ] ) );
+	return set( this, gather( this, keypath ).map( m => [ m, !m.get() ] ), options );
 }

--- a/src/shared/Context.js
+++ b/src/shared/Context.js
@@ -31,15 +31,15 @@ export default class Context {
 	}
 
 	// the usual mutation suspects
-	add ( keypath, value ) {
-		if ( value === undefined ) value = 1;
-		if ( !isNumeric( value ) ) throw new Error( 'Bad arguments' );
-		return sharedSet( this.ractive, build( this, keypath, value ).map( pair => {
+	add ( keypath, d, options ) {
+		const num = typeof d === 'number' ? +d : 1;
+		const opts = typeof d === 'object' ? d : options;
+		return sharedSet( this.ractive, build( this, keypath, num ).map( pair => {
 			const [ model, val ] = pair;
 			const value = model.get();
 			if ( !isNumeric( val ) || !isNumeric( value ) ) throw new Error( 'Cannot add non-numeric value' );
 			return [ model, value + val ];
-		}) );
+		}), opts );
 	}
 
 	animate ( keypath, value, options ) {
@@ -132,20 +132,20 @@ export default class Context {
 		return modelSort( findModel( this, keypath ).model, [] );
 	}
 
-	subtract ( keypath, value ) {
-		if ( value === undefined ) value = 1;
-		if ( !isNumeric( value ) ) throw new Error( 'Bad arguments' );
-		return sharedSet( this.ractive, build( this, keypath, value ).map( pair => {
+	subtract ( keypath, d, options ) {
+		const num = typeof d === 'number' ? d : 1;
+		const opts = typeof d === 'object' ? d : options;
+		return sharedSet( this.ractive, build( this, keypath, num ).map( pair => {
 			const [ model, val ] = pair;
 			const value = model.get();
 			if ( !isNumeric( val ) || !isNumeric( value ) ) throw new Error( 'Cannot add non-numeric value' );
 			return [ model, value - val ];
-		}) );
+		}), opts );
 	}
 
-	toggle ( keypath ) {
+	toggle ( keypath, options ) {
 		const { model } = findModel( this, keypath );
-		return sharedSet( this.ractive, [ [ model, !model.get() ] ] );
+		return sharedSet( this.ractive, [ [ model, !model.get() ] ], options );
 	}
 
 	unlink ( dest ) {

--- a/src/shared/set.js
+++ b/src/shared/set.js
@@ -3,10 +3,15 @@ import { splitKeypath } from './keypaths';
 import { isObject } from '../utils/is';
 import { warnIfDebug } from '../utils/log';
 
+export let keep = false;
+
 export function set ( ractive, pairs, options ) {
+	const k = keep;
+
 	const deep = options && options.deep;
 	const shuffle = options && options.shuffle;
 	const promise = runloop.start( ractive, true );
+	if ( options && 'keep' in options ) keep = options.keep;
 
 	let i = pairs.length;
 	while ( i-- ) {
@@ -36,6 +41,8 @@ export function set ( ractive, pairs, options ) {
 	}
 
 	runloop.end();
+
+	keep = k;
 
 	return promise;
 }

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -83,7 +83,11 @@ export default class Fragment {
 
 	detach () {
 		const docFrag = createDocumentFragment();
-		this.items.forEach( item => docFrag.appendChild( item.detach() ) );
+		const xs = this.items;
+		const len = xs.length;
+		for ( let i = 0; i < len; i++ ) {
+			docFrag.appendChild( xs[i].detach() );
+		}
 		return docFrag;
 	}
 
@@ -188,7 +192,11 @@ export default class Fragment {
 		if ( this.rendered ) throw new Error( 'Fragment is already rendered!' );
 		this.rendered = true;
 
-		this.items.forEach( item => item.render( target, occupants ) );
+		const xs = this.items;
+		const len = xs.length;
+		for ( let i = 0; i < len; i++ ) {
+			xs[i].render( target, occupants );
+		}
 	}
 
 	resetTemplate ( template ) {

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -155,8 +155,12 @@ export default class RepeatedFragment {
 	render ( target, occupants ) {
 		// TODO use docFrag.cloneNode...
 
-		if ( this.iterations ) {
-			this.iterations.forEach( fragment => fragment.render( target, occupants ) );
+		const xs = this.iterations;
+		if ( xs ) {
+			const len = xs.length;
+			for ( let i = 0; i < len; i++ ) {
+				xs[i].render( target, occupants );
+			}
 		}
 
 		this.rendered = true;

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -4,6 +4,8 @@ import { isObject } from '../../utils/is';
 import Fragment from '../Fragment';
 import RepeatedFragment from '../RepeatedFragment';
 import { MustacheContainer } from './shared/Mustache';
+import { keep } from '../../shared/set';
+import runloop from '../../global/runloop';
 
 function isEmpty ( value ) {
 	return !value ||
@@ -46,6 +48,11 @@ export default class Section extends MustacheContainer {
 				template: this.template.f
 			}).bind();
 		}
+	}
+
+	detach () {
+		const frag = this.fragment || this.detached;
+		return frag ? frag.detach() : super.detach();
 	}
 
 	isTruthy () {
@@ -115,7 +122,16 @@ export default class Section extends MustacheContainer {
 		                            ( siblingFalsey && ( this.sectionType === SECTION_UNLESS ? !this.isTruthy() : this.isTruthy() ) ); // if, unless, and if-with depend on siblings and the condition
 
 		if ( fragmentShouldExist ) {
+			if ( !this.fragment ) this.fragment = this.detached;
+
 			if ( this.fragment ) {
+				// check for detached fragment
+				if ( this.detached ) {
+					attach( this, this.fragment );
+					this.detached = false;
+					this.rendered = true;
+				}
+
 				this.fragment.update();
 			} else {
 				if ( this.sectionType === SECTION_EACH ) {
@@ -135,7 +151,13 @@ export default class Section extends MustacheContainer {
 			}
 		} else {
 			if ( this.fragment && this.rendered ) {
-				this.fragment.unbind().unrender( true );
+				if ( keep !== true ) {
+					this.fragment.unbind().unrender( true );
+				} else {
+					this.unrender( false );
+					this.detached = this.fragment;
+					runloop.scheduleTask( () => this.detach() );
+				}
 			}
 
 			this.fragment = null;
@@ -143,19 +165,7 @@ export default class Section extends MustacheContainer {
 
 		if ( newFragment ) {
 			if ( this.rendered ) {
-				const parentNode = this.parentFragment.findParentNode();
-				const anchor = this.parentFragment.findNextNode( this );
-
-				if ( anchor ) {
-					const docFrag = createDocumentFragment();
-					newFragment.render( docFrag );
-
-					// we use anchor.parentNode, not parentNode, because the sibling
-					// may be temporarily detached as a result of a shuffle
-					anchor.parentNode.insertBefore( docFrag, anchor );
-				} else {
-					newFragment.render( parentNode );
-				}
+				attach( this, newFragment );
 			}
 
 			this.fragment = newFragment;
@@ -165,5 +175,18 @@ export default class Section extends MustacheContainer {
 			this.nextSibling.dirty = true;
 			this.nextSibling.update();
 		}
+	}
+}
+
+function attach ( section, fragment ) {
+	const anchor = section.parentFragment.findNextNode( section );
+
+	if ( anchor ) {
+		const docFrag = createDocumentFragment();
+		fragment.render( docFrag );
+
+		anchor.parentNode.insertBefore( docFrag, anchor );
+	} else {
+		fragment.render( section.parentFragment.findParentNode() );
 	}
 }

--- a/src/view/items/Triple.js
+++ b/src/view/items/Triple.js
@@ -12,7 +12,7 @@ export default class Triple extends Mustache {
 
 	detach () {
 		const docFrag = createDocumentFragment();
-		this.nodes.forEach( node => docFrag.appendChild( node ) );
+		if ( this.nodes ) this.nodes.forEach( node => docFrag.appendChild( node ) );
 		return docFrag;
 	}
 

--- a/test/browser-tests/methods/set.js
+++ b/test/browser-tests/methods/set.js
@@ -24,4 +24,94 @@ export default function() {
 		r.set( '', { foo: [ 99 ] }, { deep: true } );
 		t.deepEqual( r.get( 'foo' ), [ 99, 42, 3 ] );
 	});
+
+
+	test( `keep set does not discard vdom or dom, where non-keep does`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: `{{#if show}}{{#each [1,2]}}<span>{{.}}</span>{{/each}}<cmp />{{/if}}`,
+			data: { show: true },
+			components: { cmp: Ractive.extend() }
+		});
+
+		const initFrag = r.fragment.items[0].fragment; // conditional fragment
+		const each = initFrag.items[0];
+		const cmp = r.findComponent( '*' );
+
+		r.toggle( 'show', { keep: true } );
+		t.ok( initFrag === r.fragment.items[0].detached );
+		t.ok( each === r.fragment.items[0].detached.items[0] );
+		t.htmlEqual( fixture.innerHTML, '' );
+
+		r.toggle( 'show' );
+		t.ok( initFrag === r.fragment.items[0].fragment );
+		t.ok( each === r.fragment.items[0].fragment.items[0] );
+		t.htmlEqual( fixture.innerHTML, '<span>1</span><span>2</span>' );
+		t.ok( cmp === r.findComponent( '*' ) );
+	});
+
+	test( `kept fragments aren't considered during find, findAll, and friends`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: `{{#if show}}<div /><cmp />{{/if}}`,
+			data: { show: true },
+			components: { cmp: Ractive.extend() }
+		});
+
+		const cmp = r.findComponent( 'cmp' );
+
+		r.toggle( 'show', { keep: true } );
+		t.ok( cmp );
+		t.ok( r.find( 'div' ) === undefined );
+		t.ok( r.findAll( 'div' ).length === 0 );
+		t.ok( r.findComponent( 'cmp' ) === undefined );
+		t.ok( r.findAllComponents( 'cmp' ).length === 0 );
+
+		r.toggle( 'show' );
+		t.ok( r.findAll( 'div' ).length, 'div element reappeared' );
+		t.ok( cmp === r.findComponent( 'cmp' ), 'cmp instance is same' );
+	});
+
+	test( `kept fragments still intro and outro`, t => {
+		let count = 0;
+
+		const r = new Ractive({
+			target: fixture,
+			template: `{{#if show}}<div go-in-out />{{/if}}`,
+			data: { show: true },
+			transitions: {
+				go ( trans ) {
+					count++;
+					trans.complete();
+				}
+			}
+		});
+
+		t.equal( count, 1 );
+
+		r.toggle( 'show', { keep: true } );
+		t.equal( count, 2 );
+
+		r.toggle( 'show' );
+		t.equal( count, 3 );
+	});
+
+	test( `kept fragments with triples work correctly`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: `{{#if show}}{{{html}}}{{/if}}`,
+			data: {
+				show: true,
+				html: '<div></div>text'
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, '<div></div>text' );
+
+		r.toggle( 'show', { keep: true } );
+		t.htmlEqual( fixture.innerHTML, '' );
+
+		r.toggle( 'show' );
+		t.htmlEqual( fixture.innerHTML, '<div></div>text' );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
This introduces the `{ keep: true }` option from #2855, but without the extra fluff and a bit more limited scope. There are some lurking issues with reusing the DOM associated with a fragment, but this is a good starting point for not destroying the world when you know that you will need to re-render the affected fragments again soon.

I have an idea about how to use this to add built-in filter/sort to iterative sections, but that will require solving the element reuse issue that I'm shooting for getting into 0.10.

## Is breaking:
Nope.