### PR TITLE
BREAKING: Normalize handling of directives

### DIFF
--- a/test/__support/js/samples/render.js
+++ b/test/__support/js/samples/render.js
@@ -1325,7 +1325,7 @@ const renderTests = [
 	},
 	{
 		name: 'class directives',
-		template: '<span class-foo-bar="{{foo}}" class-otherBaz="{{bat === 0}}"></span>',
+		template: '<span class-foo-bar="foo" class-otherBaz="bat === 0"></span>',
 		result: '<span></span>',
 		new_data: { foo: true, bat: 0 },
 		new_result: '<span class="foo-bar otherBaz"></span>'


### PR DESCRIPTION
## Description of the pull request:
This normalizes one of the last weird cases of attribute/directive handling - some expect mustaches and some don't. With this the division is clearer: attributes that need to be stringy, like style directives and plain attributes, use mustaches, as with other parts of the template that are stringy. Attributes that represent a value, like event, decorator, transition, and class directives, do not. For reference, event, decorator, and transition directives are looking for a comma operator substitute in the form of an implicit array, and the class directive is looking for a boolean.

This also introduces the bind directive, where `<cmp bind-foo />` is the same as `<cmp bind-foo="foo" />` is the same as `<cmp foo="{{foo}}" />`. The only real difference is that the `bind` directive cannot be thrown by whitespace. It will _always_ end up as a reference mapping, or in the case of `bind-value` on an input, a proper twoway binding, rather than an expression.

The bind directive also opens up a future optimization around twoway binding, where deep special casing happens around the fragment of certain attributes to see if an element should create a twoway binding.

## Fixes the following issues:
Last breaking change before 0.9.

## Is breaking:
Yep, because `class-foo="{{bar || baz}}"` is now `class-foo="bar || baz"`. The rest is not.