### PR TITLE
Post-parsing transforms, view-local data, and maybe `@state` with nested computations - RFC

### DIFF
--- a/gobblefile.js
+++ b/gobblefile.js
@@ -155,7 +155,7 @@ function skipModule(excludedModules) {
 			// Gobble has a predictable directory structure of gobble/transform/number
 			// so we slice at 3 to slice relative to project root.
 			const moduleRelativePath = path.relative(__dirname, modulePath).split(path.sep).slice(3).join(path.sep);
-			return excludedModules.indexOf(moduleRelativePath) > -1 ? 'export default null;' : src;
+			return excludedModules.indexOf(moduleRelativePath) > -1 ? 'export default null; export const shared = {};' : src;
 		}
 	};
 }

--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -38,6 +38,7 @@ Ractive.defaults = Ractive.prototype;
 
 // share defaults with the parser
 shared.defaults = Ractive.defaults;
+shared.Ractive = Ractive;
 
 // static properties
 Object.defineProperties( Ractive, {

--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -11,6 +11,7 @@ import initialise from './Ractive/initialise';
 import { getCSS } from './global/css';
 import { escapeKey, unescapeKey } from './shared/keypaths';
 import { joinKeys, splitKeypath } from './Ractive/static/keypaths';
+import shared from './Ractive/shared';
 
 export default function Ractive ( options ) {
 	if ( !( this instanceof Ractive ) ) return new Ractive( options );
@@ -34,6 +35,9 @@ Ractive.prototype.constructor = Ractive;
 
 // alias prototype as `defaults`
 Ractive.defaults = Ractive.prototype;
+
+// share defaults with the parser
+shared.defaults = Ractive.defaults;
 
 // static properties
 Object.defineProperties( Ractive, {

--- a/src/Ractive/prototype/fire.js
+++ b/src/Ractive/prototype/fire.js
@@ -4,7 +4,10 @@ import Context from '../../shared/Context';
 export default function Ractive$fire ( eventName, ...args ) {
 	// watch for reproxy
 	if ( args[0] instanceof Context ) {
-		return fireEvent( this, eventName, Context.forRactive( this, args.shift() ), args );
+		const proto = args.shift();
+		const ctx = Object.create( proto );
+		Object.assign( ctx, proto );
+		return fireEvent( this, eventName, ctx, args );
 	} else {
 		return fireEvent( this, eventName, Context.forRactive( this ), args );
 	}

--- a/src/Ractive/shared.js
+++ b/src/Ractive/shared.js
@@ -1,0 +1,1 @@
+export default {};

--- a/src/parse/_parse.js
+++ b/src/parse/_parse.js
@@ -14,6 +14,7 @@ import readPartialDefinitionSection from './converters/readPartialDefinitionSect
 import readTemplate from './converters/readTemplate';
 import cleanup from './utils/cleanup';
 import insertExpressions from './utils/insertExpressions';
+import shared from '../Ractive/shared';
 
 // See https://github.com/ractivejs/template-spec for information
 // about the Ractive template specification
@@ -29,11 +30,11 @@ const defaultInterpolate = [ 'script', 'style', 'template' ];
 
 const StandardParser = Parser.extend({
 	init ( str, options ) {
-		const tripleDelimiters = options.tripleDelimiters || [ '{{{', '}}}' ];
-		const staticDelimiters = options.staticDelimiters || [ '[[', ']]' ];
-		const staticTripleDelimiters = options.staticTripleDelimiters || [ '[[[', ']]]' ];
+		const tripleDelimiters = options.tripleDelimiters || shared.defaults.tripleDelimiters;
+		const staticDelimiters = options.staticDelimiters || shared.defaults.staticDelimiters;
+		const staticTripleDelimiters = options.staticTripleDelimiters || shared.defaults.staticTripleDelimiters;
 
-		this.standardDelimiters = options.delimiters || [ '{{', '}}' ];
+		this.standardDelimiters = options.delimiters || shared.defaults.delimiters;
 
 		this.tags = [
 			{ isStatic: false, isTriple: false, open: this.standardDelimiters[0], close: this.standardDelimiters[1], readers: STANDARD_READERS },
@@ -42,14 +43,14 @@ const StandardParser = Parser.extend({
 			{ isStatic: true,  isTriple: true,  open: staticTripleDelimiters[0],  close: staticTripleDelimiters[1],  readers: TRIPLE_READERS }
 		];
 
-		this.contextLines = options.contextLines || 0;
+		this.contextLines = options.contextLines || shared.defaults.contextLines;
 
 		this.sortMustacheTags();
 
 		this.sectionDepth = 0;
 		this.elementStack = [];
 
-		this.interpolate = Object.create( options.interpolate || {} );
+		this.interpolate = Object.create( options.interpolate || shared.defaults.interpolate || {} );
 		this.interpolate.textarea = true;
 		defaultInterpolate.forEach( t => this.interpolate[ t ] = !options.interpolate || options.interpolate[ t ] !== false );
 

--- a/src/parse/converters/expressions/primary/readReference.js
+++ b/src/parse/converters/expressions/primary/readReference.js
@@ -9,7 +9,7 @@ const globals = /^(?:Array|console|Date|RegExp|decodeURIComponent|decodeURI|enco
 const keywords = /^(?:break|case|catch|continue|debugger|default|delete|do|else|finally|for|function|if|in|instanceof|new|return|switch|throw|try|typeof|var|void|while|with)$/;
 
 const prefixPattern = /^(?:\@\.|\@|~\/|(?:\^\^\/(?:\^\^\/)*(?:\.\.\/)*)|(?:\.\.\/)+|\.\/(?:\.\.\/)*|\.)/;
-const specials = /^(key|index|keypath|rootpath|this|global|shared|context|event|node)/;
+const specials = /^(key|index|keypath|rootpath|this|global|shared|context|event|node|data)/;
 
 export default function readReference ( parser ) {
 	let prefix, name, global, reference, lastDotIndex;

--- a/src/parse/converters/expressions/primary/readReference.js
+++ b/src/parse/converters/expressions/primary/readReference.js
@@ -9,7 +9,7 @@ const globals = /^(?:Array|console|Date|RegExp|decodeURIComponent|decodeURI|enco
 const keywords = /^(?:break|case|catch|continue|debugger|default|delete|do|else|finally|for|function|if|in|instanceof|new|return|switch|throw|try|typeof|var|void|while|with)$/;
 
 const prefixPattern = /^(?:\@\.|\@|~\/|(?:\^\^\/(?:\^\^\/)*(?:\.\.\/)*)|(?:\.\.\/)+|\.\/(?:\.\.\/)*|\.)/;
-const specials = /^(key|index|keypath|rootpath|this|global|shared|context|event|node|data)/;
+const specials = /^(key|index|keypath|rootpath|this|global|shared|context|event|node|local)/;
 
 export default function readReference ( parser ) {
 	let prefix, name, global, reference, lastDotIndex;

--- a/src/parse/utils/refineExpression.js
+++ b/src/parse/utils/refineExpression.js
@@ -10,7 +10,8 @@ export default function refineExpression ( expression, mustache ) {
 		}
 
 		if ( expression.t === REFERENCE ) {
-			if ( !~expression.n.indexOf( '@context' ) ) {
+			const n = expression.n;
+			if ( !~n.indexOf( '@context' ) ) {
 				mustache.r = expression.n;
 			} else {
 				mustache.x = flattenExpression( expression );

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -153,8 +153,10 @@ export default class Element extends ContainerItem {
 	}
 
 	getContext ( ...assigns ) {
+		if ( this.fragment ) return this.fragment.getContext( ...assigns );
+
 		if ( !this.ctx ) this.ctx = new Context( this.parentFragment, this );
-		assigns.unshift( this.ctx );
+		assigns.unshift( Object.create( this.ctx ) );
 		return Object.assign.apply( null, assigns );
 	}
 

--- a/src/view/resolvers/resolveReference.js
+++ b/src/view/resolvers/resolveReference.js
@@ -99,7 +99,7 @@ export default function resolveReference ( fragment, ref ) {
 		}
 
 		// @context-local data
-		else if ( base === '@data' ) {
+		else if ( base === '@local' ) {
 			return fragment.getContext()._data.joinAll( keys );
 		}
 

--- a/src/view/resolvers/resolveReference.js
+++ b/src/view/resolvers/resolveReference.js
@@ -98,6 +98,11 @@ export default function resolveReference ( fragment, ref ) {
 			return new ContextModel( fragment.getContext() );
 		}
 
+		// @context-local data
+		else if ( base === '@data' ) {
+			return fragment.getContext()._data.joinAll( keys );
+		}
+
 		// nope
 		else {
 			throw new Error( `Invalid special reference '${base}'` );

--- a/tests/browser/misc.js
+++ b/tests/browser/misc.js
@@ -1785,4 +1785,12 @@ export default function() {
 
 		t.equal( r.toHTML(), '<b>&amp; &lt;</b>' );
 	});
+
+	test( `global defaults apply to parsing even with no instance`, t => {
+		const delimiters = Ractive.defaults.delimiters;
+		Ractive.defaults.delimiters = [ '<%', '%>' ];
+		const parsed = Ractive.parse( '<% foo %>' );
+		t.deepEqual( parsed, { v: 4, t: [{ t: 2, r: 'foo' }] } );
+		Ractive.defaults.delimiters = delimiters;
+	});
 }

--- a/tests/browser/misc.js
+++ b/tests/browser/misc.js
@@ -1785,12 +1785,4 @@ export default function() {
 
 		t.equal( r.toHTML(), '<b>&amp; &lt;</b>' );
 	});
-
-	test( `global defaults apply to parsing even with no instance`, t => {
-		const delimiters = Ractive.defaults.delimiters;
-		Ractive.defaults.delimiters = [ '<%', '%>' ];
-		const parsed = Ractive.parse( '<% foo %>' );
-		t.deepEqual( parsed, { v: 4, t: [{ t: 2, r: 'foo' }] } );
-		Ractive.defaults.delimiters = delimiters;
-	});
 }

--- a/tests/browser/parser.js
+++ b/tests/browser/parser.js
@@ -1,0 +1,65 @@
+import { test } from 'qunit';
+import { initModule } from '../helpers/test-config';
+
+export default function () {
+	initModule( 'parser' );
+
+	test( `global defaults apply to parsing even with no instance`, t => {
+		const delimiters = Ractive.defaults.delimiters;
+		Ractive.defaults.delimiters = [ '<%', '%>' ];
+		const parsed = Ractive.parse( '<% foo %>' );
+		t.deepEqual( parsed, { v: 4, t: [{ t: 2, r: 'foo' }] } );
+		Ractive.defaults.delimiters = delimiters;
+	});
+
+	test( `parser transforms can drop elements`, t => {
+		const parsed = Ractive.parse( `<foo /><div />`, {
+			transforms: [
+				n => n.e === 'foo' ? { remove: true } : undefined
+			]
+		});
+
+		t.deepEqual( parsed, { v: 4, t: [{ t: 7, e: 'div' }] } );
+	});
+
+	test( `parser transforms can modify an element in place`, t => {
+		const parsed = Ractive.parse( `<div />`, {
+			transforms: [
+				n => n.e === 'div' ? ( n.m || ( n.m = [] ) ).push({ t: 13, f: 'bar', n: 'class' }) && n : undefined
+			]
+		});
+
+		t.deepEqual( parsed, { v: 4, t: [{ t: 7, e: 'div', m: [{ t: 13, f: 'bar', n: 'class' }] }] } );
+	});
+
+	test( `parser transforms can replace an element`, t => {
+		const parsed = Ractive.parse( `<bar />`, {
+			transforms: [
+				function ( n ) { return n.e === 'bar' ? { replace: this.parse( `<div id="replaced">yep</div>` ).t[0] } : undefined; }
+			]
+		});
+
+		t.deepEqual( parsed, { v: 4, t: [{ t: 7, e: 'div', m: [{ t: 13, f: 'replaced', n: 'id' }], f: [ 'yep' ] }] } );
+	});
+
+	test( `parser transforms can replace an element with multiple elements`, t => {
+		const parsed = Ractive.parse( `<bar />`, {
+			transforms: [
+				function ( n ) { return n.e === 'bar' ? { replace: this.parse( `<div id="replaced">yep</div><span>sure</span>` ).t } : undefined; }
+			]
+		});
+
+		t.deepEqual( parsed, { v: 4, t: [{ t: 7, e: 'div', m: [{ t: 13, f: 'replaced', n: 'id' }], f: [ 'yep' ] }, { t: 7, e: 'span', f: [ 'sure' ] }] } );
+	});
+
+	test( `parser transforms can replace an element with multiple elements, which can also be replaced`, t => {
+		const parsed = Ractive.parse( `<bar />`, {
+			transforms: [
+				function ( n ) { return n.e === 'bar' ? { replace: this.parse( `<div id="replaced">yep</div><baz>sure</baz>` ).t } : undefined; },
+				function ( n ) { if ( n.e === 'baz' ) n.e = 'span'; }
+			]
+		});
+
+		t.deepEqual( parsed, { v: 4, t: [{ t: 7, e: 'div', m: [{ t: 13, f: 'replaced', n: 'id' }], f: [ 'yep' ] }, { t: 7, e: 'span', f: [ 'sure' ] }] } );
+	});
+}

--- a/tests/browser/references.js
+++ b/tests/browser/references.js
@@ -421,14 +421,14 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>yep</div>' );
 	});
 
-	test( `@data resolves to a template-local model`, t => {
+	test( `@local resolves to a template-local model`, t => {
 		const r = new Ractive({
 			target: fixture,
-			template: `<div>{{@data.foo}}</div>`
+			template: `<div>{{@local.foo}}</div>`
 		});
 
 		const ctx = r.getNodeInfo( 'div' );
-		ctx.set( '@data.foo', 42 );
+		ctx.set( '@local.foo', 42 );
 		t.htmlEqual( fixture.innerHTML, '<div>42</div>' );
 	});
 }

--- a/tests/browser/references.js
+++ b/tests/browser/references.js
@@ -420,4 +420,15 @@ export default function() {
 
 		t.htmlEqual( fixture.innerHTML, '<div>yep</div>' );
 	});
+
+	test( `@data resolves to a template-local model`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: `<div>{{@data.foo}}</div>`
+		});
+
+		const ctx = r.getNodeInfo( 'div' );
+		ctx.set( '@data.foo', 42 );
+		t.htmlEqual( fixture.innerHTML, '<div>42</div>' );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
In looking at how to implement something like materializecss in pure ractive, it feels excessive to create a component for every button and card you add to the view. That lead back to the lightweight components PR, but even that seems like too much for simple things that could easily be a partial with a few parameters.

That brought me around to "what if we could just turn what looks like a regular component into a sort of macro that replaced itself with other template". So that's what this is:

1. `Ractive.parse` now considers `Ractive.defaults` rather than using hard-coded values if no options are passed, meaning that `Ractive.defaults.delimiters = ['<%', '%>']` will actually work with `Ractive.parse('...')` now. It also means that `Ractive.defaults.parserTransforms` would actually mean something.
2. The parser now accepts a `transforms` array or the global/instance `parserTransforms` which is an array of functions to be called with each element in the parsed template. Each function may remove, modify, or replace each element template with which it is called. It is called with `Ractive` as the context, so `parse` is available locally without having to pull in Ractive as a dependency.
3. To facilitate having small bits of local state, this introduces `@data`, which is a root model that is created as needed on the current `@context`, with the idea being that the transform sets up something like `<div>{{#with @data as state}}...{{/with}}</div>` as the replacement template. Then any `state` references within the template won't interfere with normal data, but will instead live only for the lifetime of the outer `div` element in the replacement.
4. `@data` refs are also available to `@context` objects, so you can interact with template-local context from outside of the template.

This is sort of the reciprocal to the `@state` PR, which would be the same thing, but hanging off of the internal model object rather than the view. I considered introducing `@state` here too, but there are a few questions surrounding that and probably a little bit of confusion around the difference between `@state` and `@data`. One of the questions is should `foo.bar.@state.foo.bar` be the same as `foo.bar.foo.@state.bar` or should it be its own independent tree? There's also some question as to what should happen with state on linked models.

At any rate, `@data` is not really meant to be used for general purposes, nor are transforms for that matter. Transforms require a fairly intimate knowledge of the compiled template format, but I don't expect many people to want to write their own widget libraries beyond the level of components. If you _do_ need to achieve something like a partial with paramaters, including passed-in inline partials, this would allow it, though in a component-like form rather than `{{> partial}}` form. Attributes, child elements, inline partials, and other content are all fairly easy to access, move around, and massage.

### Why?

One of the major goals for 0.9/0.10 is to have a nice component suite like materialize or vuetify available to use alongside a ractive-based router/app framework that uses anchors to swap views in and out. Part of any of the better component suites are small things like buttons and cards that may be rendered _a lot_ in various places, so low overhead is important. Most of those _could mostly_ be handled with css alone, but they would be a lot more ergonomic and complete as component-like constructs.

### Questions

1. Is there a better name for `@data`.
2. Right now the return of the transform determines what happens with the node being transformed. I think it's probably a bit limited with `false` removing the node and an object replacing the node. I think maybe it should be an object that specifies what to do instead, like maybe `{ remove: true }` for remove, `{ replace: { ... } }` or `{ replace: [ ... ] }` to replace it with one or more nodes, and `undefined` for nothing?
3. Should figuring out what exactly to do with `@state` go ahead and happen? It would give stable out-of-data storage, meaning it wouldn't interfere with normal data, it wouldn't disappear with an unrender/re-render, and it has been requested a fair amount. It would also give a nice entry point for nested computeds, which remains one of the oldest requested features.

## Is breaking:
Nope.

## Reviewers:
Yep.