### PR TITLE
Test changes to make backporting fixes easier

### DIFF
--- a/gobblefile.js
+++ b/gobblefile.js
@@ -128,7 +128,7 @@ function buildNodeTests() {
 			format: 'cjs',
 			entry: 'tests.js',
 			dest: 'node.js',
-			external: ['qunitjs', 'cheerio']
+			external: ['cheerio']
 		}).moveTo('tests');
 }
 

--- a/tests/browser/aliases.js
+++ b/tests/browser/aliases.js
@@ -1,11 +1,12 @@
 import { initModule } from '../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'aliases' );
 
 	/* global navigator */
 
-	QUnit.test( 'simple template aliases', t => {
+	test( 'simple template aliases', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{#with foo.bar.baz as bar, bippy.boppy as boop}}{{bar}} {{boop}}{{/with}}',
@@ -18,7 +19,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep works' );
 	});
 
-	QUnit.test( 'aliased computations', t => {
+	test( 'aliased computations', t => {
 		new Ractive({
 			el: fixture,
 			template: `{{#with 3 * 2 + 10 as num}}{{num}}{{/with}}`
@@ -27,7 +28,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '16' );
 	});
 
-	QUnit.test( '@index refs can be aliased', t => {
+	test( '@index refs can be aliased', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#each items}}{{#with @index as idx}}{{idx}}{{/with}}{{/each}}',
@@ -39,7 +40,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '0123' );
 	});
 
-	QUnit.test( '@key refs can be aliased', t => {
+	test( '@key refs can be aliased', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#each items}}{{#with @key as idx}}{{idx}}{{/with}}{{/each}}',
@@ -51,7 +52,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foobarbazbat' );
 	});
 
-	QUnit.test( '@keypath refs can be aliased', t => {
+	test( '@keypath refs can be aliased', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#each items}}{{#with @keypath as idx}}{{idx}}{{/with}}{{/each}}',
@@ -63,7 +64,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'items.0items.1items.2items.3' );
 	});
 
-	QUnit.test( 'aliased complex computations are cached', t => {
+	test( 'aliased complex computations are cached', t => {
 		let normal = 0;
 		let aliased = 0;
 
@@ -84,7 +85,7 @@ export default function() {
 		t.equal( aliased, 1 );
 	});
 
-	QUnit.test( 'unresolved aliases should resolve if a suitable model appears', t => {
+	test( 'unresolved aliases should resolve if a suitable model appears', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#with foo.bar as baz}}{{baz}}{{/with}}'
@@ -95,7 +96,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( 'multiple nested aliases', t => {
+	test( 'multiple nested aliases', t => {
 		new Ractive({
 			el: fixture,
 			template:`
@@ -119,7 +120,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'items.0 items.0.foo.bar.0 1items.1 items.1.foo.bar.0 2items.2 items.2.foo.bar.0 3' );
 	});
 
-	QUnit.test( 'basic aliased array iteration', t => {
+	test( 'basic aliased array iteration', t => {
 		new Ractive({
 			el: fixture,
 			template: `{{#each items as item:i}}|{{i+1}}-{{item}}{{/each}}`,
@@ -129,7 +130,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '|1-a|2-b|3-c' );
 	});
 
-	QUnit.test( 'basic aliased object iteration', t => {
+	test( 'basic aliased object iteration', t => {
 		new Ractive({
 			el: fixture,
 			template: `{{#each items as item:k,i}}|{{k}}-{{i+1}}-{{item}}{{/each}}`,
@@ -139,7 +140,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '|k1-1-a|k2-2-b|k3-3-c' );
 	});
 
-	QUnit.test( 'aliased array iteration shuffle', t => {
+	test( 'aliased array iteration shuffle', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items as item:i}}|{{i+1}}-{{item}}{{/each}}`,
@@ -153,7 +154,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '|1-a|2-d|3-b|4-c' );
 	});
 
-	QUnit.test( `aliases survive shuffling`, t => {
+	test( `aliases survive shuffling`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: '{{#each items as item}}{{#with item.foo as foo}}{{foo}}{{/with}}{{/each}}',
@@ -170,7 +171,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '21' );
 	});
 
-	QUnit.test( `explicit aliases survive rebinding`, t => {
+	test( `explicit aliases survive rebinding`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `{{#with foo.0.bar as baz}}{{#if flip}}{{baz}}{{else}}{{baz}}{{/if}}{{/with}}`,
@@ -188,7 +189,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( `partial aliases survive rebinding`, t => {
+	test( `partial aliases survive rebinding`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `{{>p foo.0.bar as baz}}`,
@@ -209,7 +210,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( `nested iteration aliases survive rebinding`, t => {
+	test( `nested iteration aliases survive rebinding`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `{{#each list as outer}}{{#each outer.sub as inner}}{{#if flip}}{{outer.a}}{{inner.a}}{{else}}{{outer.a}}{{inner.a}}{{/if}}{{/each}}{{/each}}`,

--- a/tests/browser/attributes.js
+++ b/tests/browser/attributes.js
@@ -1,10 +1,11 @@
 import { initModule } from '../helpers/test-config';
 import { fire } from 'simulant';
+import { test } from 'qunit';
 
 export default function () {
 	initModule( 'attributes.js' );
 
-	QUnit.test( `class attributes only update the classes in their content`, t => {
+	test( `class attributes only update the classes in their content`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span class="{{classes}}" />`,
@@ -18,7 +19,7 @@ export default function () {
 		t.equal( span.className, 'foo yep baz' );
 	});
 
-	QUnit.test( `style attributes only update the styles in their content`, t => {
+	test( `style attributes only update the styles in their content`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span style="{{styles}}" />`,
@@ -34,7 +35,7 @@ export default function () {
 		t.equal( span.style.height, '87.5%' );
 	});
 
-	QUnit.test( `style attributes update hyphenated properties correctly (#2796)`, t => {
+	test( `style attributes update hyphenated properties correctly (#2796)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span style="background-color: green;" />`
@@ -44,7 +45,7 @@ export default function () {
 		t.equal( span.style.backgroundColor, 'green' );
 	});
 
-	QUnit.test( `style attributes currectly detect the removal of a hyphenated property`, t => {
+	test( `style attributes currectly detect the removal of a hyphenated property`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span style="{{#if foo}}background-color: green;{{/if}}" />`,
@@ -57,7 +58,7 @@ export default function () {
 		t.equal( span.style.backgroundColor, '' );
 	});
 
-	QUnit.test( `inline styles can be set with important priority`, t => {
+	test( `inline styles can be set with important priority`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span style-background-color="{{color}}" />`,
@@ -75,7 +76,7 @@ export default function () {
 		t.equal( span.style.getPropertyPriority( 'background-color' ), '' );
 	});
 
-	QUnit.test( `style attributes don't try to use a boolean value (#2522)`, t => {
+	test( `style attributes don't try to use a boolean value (#2522)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span style="{{#if foo}}{{else}}color: red{{/if}}" />`,
@@ -88,7 +89,7 @@ export default function () {
 		t.equal( span.style.color, '' );
 	});
 
-	QUnit.test( `style attributes can correctly set an inline priority (#2794)`, t => {
+	test( `style attributes can correctly set an inline priority (#2794)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span style="color: red !important" /><span style="color: green" />`,
@@ -102,7 +103,7 @@ export default function () {
 		t.equal( span2.style.color, 'green' );
 	});
 
-	QUnit.test( `style attributes can be inline directives`, t => {
+	test( `style attributes can be inline directives`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span style-color="{{color}}" />`,
@@ -115,7 +116,7 @@ export default function () {
 		t.equal( span.style.color, 'green' );
 	});
 
-	QUnit.test( `class attributes can be inline directives`, t => {
+	test( `class attributes can be inline directives`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span class-foo-bar="foo" class-fooBar="bar" />`
@@ -133,7 +134,7 @@ export default function () {
 		t.equal( span.className, '' );
 	});
 
-	QUnit.test( `class attributes don't try to remove missing attributes (#2510)`, t => {
+	test( `class attributes don't try to remove missing attributes (#2510)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span class="bar{{#if foo}} foo{{/if}}" />`,
@@ -149,7 +150,7 @@ export default function () {
 		t.equal( span.className, 'bar baz foo' );
 	});
 
-	QUnit.test( `class attributes don't override class directives at render (#2565)`, t => {
+	test( `class attributes don't override class directives at render (#2565)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span class-foo="true" class="bar" />`
@@ -158,7 +159,7 @@ export default function () {
 		t.equal( r.find( 'span' ).className, 'bar foo' );
 	});
 
-	QUnit.test( `class directives and class attributes both contribute to toHTML (#2537)`, t => {
+	test( `class directives and class attributes both contribute to toHTML (#2537)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span class-bip="true" class-nope="false" class="foo bar" class-bop="true" /><span class-foo="true" class-bar-baz="true" />`
@@ -167,7 +168,7 @@ export default function () {
 		t.equal( r.toHTML(), `<span class="foo bar bip bop"></span><span class="foo bar-baz"></span>` );
 	});
 
-	QUnit.test( `style directives and style attributes both contribute to toHTML (#2537)`, t => {
+	test( `style directives and style attributes both contribute to toHTML (#2537)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span style-text-decoration="underline" style="color: green" style-fontSize="12pt" /><span style-text-decoration="underline" style-fontSize="12pt" />`
@@ -176,7 +177,7 @@ export default function () {
 		t.equal( r.toHTML(), `<span style="text-decoration: underline; color: green; font-size: 12pt;"></span><span style="text-decoration: underline; font-size: 12pt;"></span>` );
 	});
 
-	QUnit.test( `nested sections in an element tag don't create phantom empty attribute nodes (#2783)`, t => {
+	test( `nested sections in an element tag don't create phantom empty attribute nodes (#2783)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<div\n{{#if foo}}\n{{#if bar}}\ndata-foo="yep"\n{{/if}}\n{{/if}}></div>`,
@@ -188,7 +189,7 @@ export default function () {
 		t.ok( r.find( 'div' ).getAttribute( 'data-foo' ) === 'yep' );
 	});
 
-	QUnit.test( `class directives may be boolean`, t => {
+	test( `class directives may be boolean`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `<div class-foo class-bar />`
@@ -198,7 +199,7 @@ export default function () {
 		t.ok( div.getAttribute( 'class' ) === 'foo bar' );
 	});
 
-	QUnit.test( `bind directives create the appropriate attribute binding`, t => {
+	test( `bind directives create the appropriate attribute binding`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `<div bind-data-foo="bar" /><input bind-value="foo" />`,
@@ -222,7 +223,7 @@ export default function () {
 		t.equal( div.getAttribute( 'data-foo' ), 'sure' );
 	});
 
-	QUnit.test( `bind directives as boolean use their name as the reference`, t => {
+	test( `bind directives as boolean use their name as the reference`, t => {
 		const cmp = Ractive.extend({
 			template: '<span>{{foo}}</span>'
 		});

--- a/tests/browser/components/attributes.js
+++ b/tests/browser/components/attributes.js
@@ -1,9 +1,10 @@
 import { onWarn, initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'components/attributes.js' );
 
-	QUnit.test( `by default all attributes are mapped`, t => {
+	test( `by default all attributes are mapped`, t => {
 		const cmp = Ractive.extend({
 			template: '{{foo}} {{bar}}'
 		});
@@ -23,7 +24,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '1 2' );
 	});
 
-	QUnit.test( `attributes as an array of strings are all optional`, t => {
+	test( `attributes as an array of strings are all optional`, t => {
 		const cmp = Ractive.extend({
 			attributes: [ 'foo', 'bar' ]
 		});
@@ -31,7 +32,7 @@ export default function() {
 		t.deepEqual( cmp.attributes, { optional: [ 'foo', 'bar' ], required: [] } );
 	});
 
-	QUnit.test( `attributes may contain optional, required, neither, or both`, t => {
+	test( `attributes may contain optional, required, neither, or both`, t => {
 		const optional = Ractive.extend({
 			attributes: { optional: [ 'foo' ] }
 		});
@@ -51,7 +52,7 @@ export default function() {
 		t.deepEqual( neither.attributes, { optional: [], required: [] } );
 	});
 
-	QUnit.test( `only named attributes are mapped into component`, t => {
+	test( `only named attributes are mapped into component`, t => {
 		const cmp = Ractive.extend({
 			attributes: [ 'foo', 'bar' ],
 			template: '{{foo}} {{bar}} {{baz}}',
@@ -69,7 +70,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo bar' );
 	});
 
-	QUnit.test( `leaving off a required attribute issues a warning`, t => {
+	test( `leaving off a required attribute issues a warning`, t => {
 		t.expect( 2 );
 		onWarn( msg => t.ok( /.*cmp.*requires attribute.*foo.*/.test( msg ) ) );
 		const cmp = Ractive.extend({
@@ -87,7 +88,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( `extra attributes are collected into a partial and attached to the instance`, t => {
+	test( `extra attributes are collected into a partial and attached to the instance`, t => {
 		const cmp = Ractive.extend({
 			attributes: [ 'item', 'color' ],
 			template: `<div {{yield extra-attributes}} style-color="{{color}}">{{item}}</div>`,
@@ -107,7 +108,7 @@ export default function() {
 		t.ok( inst.get( 'data-foo' ) === undefined );
 	});
 
-	QUnit.test( `extra attributes may be mapped if requested and the partial will refer to the mapping`, t => {
+	test( `extra attributes may be mapped if requested and the partial will refer to the mapping`, t => {
 		const cmp = Ractive.extend({
 			attributes: {
 				optional: [ 'item' ],
@@ -133,7 +134,7 @@ export default function() {
 		t.equal( r.get( 'foo' ), 'still yep' );
 	});
 
-	QUnit.test( `multiple component renders with attributes all start with the initial template`, t => {
+	test( `multiple component renders with attributes all start with the initial template`, t => {
 		const cmp = Ractive.extend({
 			attributes: [],
 			template: '<div {{yield extra-attributes}} />'

--- a/tests/browser/components/data-and-mappings.js
+++ b/tests/browser/components/data-and-mappings.js
@@ -1,10 +1,11 @@
 import Model from '../../helpers/Model';
 import { initModule, onWarn } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'components/data-and-mappings.js' );
 
-	QUnit.test( 'Static data is propagated from parent to child', t => {
+	test( 'Static data is propagated from parent to child', t => {
 		const Widget = Ractive.extend({
 			template: '<p>{{foo}}</p>'
 		});
@@ -21,7 +22,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>blah</p>' );
 	});
 
-	QUnit.test( 'Static object data is propagated from parent to child', t => {
+	test( 'Static object data is propagated from parent to child', t => {
 		const Widget = Ractive.extend({
 			template: '<p>{{foo.bar}}</p>'
 		});
@@ -41,7 +42,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>bah</p>' );
 	});
 
-	QUnit.test( 'Dynamic data is propagated from parent to child, and (two-way) bindings are created', t => {
+	test( 'Dynamic data is propagated from parent to child, and (two-way) bindings are created', t => {
 		const Widget = Ractive.extend({
 			template: '<p>{{foo}}</p>'
 		});
@@ -69,7 +70,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>shmup</p>' );
 	});
 
-	QUnit.test( 'Missing data on the parent is added when set', t => {
+	test( 'Missing data on the parent is added when set', t => {
 		const Widget = Ractive.extend({
 			template: '<p>{{foo}}</p>'
 		});
@@ -87,7 +88,7 @@ export default function() {
 
 	});
 
-	QUnit.test( 'Data is synced as soon as an unresolved mapping is resolved', t => {
+	test( 'Data is synced as soon as an unresolved mapping is resolved', t => {
 		onWarn( () => {} ); // suppress
 
 		const ractive = new Ractive({
@@ -117,7 +118,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>foo: false</p>' );
 	});
 
-	QUnit.test( 'Data on the child is propagated to the parent, if it is not missing', t => {
+	test( 'Data on the child is propagated to the parent, if it is not missing', t => {
 		const Widget = Ractive.extend({
 			template: '<p>{{foo}}{{bar}}</p>',
 			data: {
@@ -136,7 +137,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>yes</p>' );
 	});
 
-	QUnit.test( 'Parent data overrides child data during child model creation', t => {
+	test( 'Parent data overrides child data during child model creation', t => {
 		const Widget = Ractive.extend({
 			template: '<p>{{foo}}{{bar}}</p>',
 			data: {
@@ -165,7 +166,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>unodos</p>' );
 	});
 
-	QUnit.test( 'Regression test for #317', t => {
+	test( 'Regression test for #317', t => {
 		const Widget = Ractive.extend({
 			template: '<ul>{{#items:i}}<li>{{i}}: {{.}}</li>{{/items}}</ul>'
 		});
@@ -208,7 +209,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<ul><li>0: h</li><li>1: d</li></ul><p>h d</p>' );
 	});
 
-	QUnit.test( 'Components can access outer data context, in the same way JavaScript functions can access outer lexical scope', t => {
+	test( 'Components can access outer data context, in the same way JavaScript functions can access outer lexical scope', t => {
 		const Widget = Ractive.extend({
 			template: '<p>{{foo || "missing"}}</p>',
 			isolated: false
@@ -236,7 +237,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'Nested components can access outer-most data context', t => {
+	test( 'Nested components can access outer-most data context', t => {
 		const GrandWidget = Ractive.extend({
 			template: 'hello {{world}}',
 			isolated: false
@@ -260,7 +261,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'hello venus' );
 	});
 
-	QUnit.test( 'Nested components registered at global Ractive can access outer-most data context', t => {
+	test( 'Nested components registered at global Ractive can access outer-most data context', t => {
 		Ractive.components.Widget = Ractive.extend({
 			template: '<GrandWidget/>',
 			isolated: false
@@ -284,7 +285,7 @@ export default function() {
 		delete Ractive.components.GrandWidget;
 	});
 
-	QUnit.test( 'mixed use of same component parameters across different instances', t => {
+	test( 'mixed use of same component parameters across different instances', t => {
 		const Widget = Ractive.extend({
 			template: '{{foo}}'
 		});
@@ -311,7 +312,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'one one' );
 	});
 
-	QUnit.test( 'Component data passed but non-existent on parent data', t => {
+	test( 'Component data passed but non-existent on parent data', t => {
 		const Widget = Ractive.extend({
 			template: '{{exists}}{{missing}}'
 		});
@@ -326,7 +327,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'exists' );
 	});
 
-	QUnit.test( 'Some component data not included in invocation parameters', t => {
+	test( 'Some component data not included in invocation parameters', t => {
 		const Widget = Ractive.extend({
 			template: '{{exists}}{{missing}}'
 		});
@@ -341,7 +342,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'exists' );
 	});
 
-	QUnit.test( 'Some component data not included, with implicit sibling', t => {
+	test( 'Some component data not included, with implicit sibling', t => {
 		const Widget = Ractive.extend({
 			template: '{{exists}}{{also}}{{missing}}'
 		});
@@ -360,7 +361,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'existsalso' );
 	});
 
-	QUnit.test( 'Isolated components do not interact with ancestor viewmodels', t => {
+	test( 'Isolated components do not interact with ancestor viewmodels', t => {
 		const Widget = Ractive.extend({
 			template: '{{foo}}.{{bar}}',
 			isolated: true
@@ -379,7 +380,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'you should see me.' );
 	});
 
-	QUnit.test( 'isolated components do not interact with ancestor viewmodels via API (#2335)', t => {
+	test( 'isolated components do not interact with ancestor viewmodels via API (#2335)', t => {
 		const cmp = Ractive.extend({
 			template: '{{foo}}',
 			oninit() {
@@ -398,7 +399,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( 'Children do not nuke parent data when inheriting from ancestors', t => {
+	test( 'Children do not nuke parent data when inheriting from ancestors', t => {
 		const Widget = Ractive.extend({
 			template: '<p>value: {{thing.value}}</p>'
 		});
@@ -424,7 +425,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'things' ), { one: { value: 1 }, two: { value: 2 }, three: { value: 3 } } );
 	});
 
-	QUnit.test( 'Uninitialised implicit dependencies of evaluators that use inherited functions are handled', t => {
+	test( 'Uninitialised implicit dependencies of evaluators that use inherited functions are handled', t => {
 		const Widget = Ractive.extend({
 			template: '{{status()}}',
 			isolated: false
@@ -450,7 +451,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'bar-bar' );
 	});
 
-	QUnit.test( 'foo.bar should stay in sync between <one foo="{{foo}}"/> and <two foo="{{foo}}"/>', t => {
+	test( 'foo.bar should stay in sync between <one foo="{{foo}}"/> and <two foo="{{foo}}"/>', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<One foo="{{foo}}"/><Two foo="{{foo}}"/>',
@@ -471,7 +472,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'qux.foo.bar should stay in sync between <one foo="{{foo}}"/> and <two foo="{{foo}}"/>', t => {
+	test( 'qux.foo.bar should stay in sync between <one foo="{{foo}}"/> and <two foo="{{foo}}"/>', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			data: { qux: { foo: {} } },
@@ -495,7 +496,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>qux</p><p>qux</p>' );
 	});
 
-	QUnit.test( 'Index references propagate down to non-isolated components', t => {
+	test( 'Index references propagate down to non-isolated components', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -517,7 +518,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>0: a</p><p>1: c</p>' );
 	});
 
-	QUnit.test( 'Index references passed via @index propagate down to non-isolated components', t => {
+	test( 'Index references passed via @index propagate down to non-isolated components', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -538,7 +539,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>0: a</p><p>1: c</p>' );
 	});
 
-	QUnit.test( 'Reference based fragment parameters update components', t => {
+	test( 'Reference based fragment parameters update components', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<Widget answer="{{foo}} and {{bar}}"/>',
@@ -556,7 +557,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'rice and more rice' );
 	});
 
-	QUnit.test( 'Data will propagate up through multiple component boundaries (#520)', t => {
+	test( 'Data will propagate up through multiple component boundaries (#520)', t => {
 		const Inner = Ractive.extend({
 			template: '{{input.value}}',
 			update ( val ) {
@@ -587,7 +588,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '2' );
 	});
 
-	QUnit.test( 'Component in template has data function called on initialize', t => {
+	test( 'Component in template has data function called on initialize', t => {
 		const data = { foo: 'bar' } ;
 
 		const Widget = Ractive.extend({
@@ -626,7 +627,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'barbam' );
 	});*/
 
-	QUnit.test( 'Component in template with dynamic template function', t => {
+	test( 'Component in template with dynamic template function', t => {
 		const Widget = Ractive.extend({
 			template () {
 				return this.get( 'useFoo' ) ? '{{foo}}' : '{{fizz}}';
@@ -643,7 +644,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'Inline component attributes are passed through correctly', t => {
+	test( 'Inline component attributes are passed through correctly', t => {
 		const Widget = Ractive.extend({
 			template: '<p>{{foo.bar}}</p><p>{{typeof answer}}: {{answer}}</p><p>I got {{string}} but type coercion ain\'t one</p><p>{{dynamic.yes}}</p>'
 		});
@@ -661,7 +662,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>10</p><p>number: 42</p><p>I got 99 problems but type coercion ain\'t one</p><p>maybe</p>' );
 	});
 
-	QUnit.test( 'Inline component attributes update the value of bindings pointing to them even if they are old values (#681)', t => {
+	test( 'Inline component attributes update the value of bindings pointing to them even if they are old values (#681)', t => {
 		const Widget = Ractive.extend({
 			template: '{{childdata}}'
 		});
@@ -682,7 +683,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'old - old' );
 	});
 
-	QUnit.test( 'Insane variable shadowing bug doesn\'t appear (#710)', t => {
+	test( 'Insane variable shadowing bug doesn\'t appear (#710)', t => {
 		const List = Ractive.extend({
 			template: `
 				{{#each items:i}}
@@ -711,7 +712,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>0:</p><p>1:0</p><p>2:0</p>' );
 	});
 
-	QUnit.test( 'Component bindings propagate the underlying value in the case of adaptors (#945)', t => {
+	test( 'Component bindings propagate the underlying value in the case of adaptors (#945)', t => {
 		const Widget = Ractive.extend({
 			adapt: [ Model.adaptor ],
 			template: '{{#model}}Title: {{title}}{{/model}}'
@@ -730,7 +731,7 @@ export default function() {
 		t.ok( ractive.get( 'model' ) instanceof Model );
 	});
 
-	QUnit.test( 'Implicit bindings are created at the highest level possible (#960)', t => {
+	test( 'Implicit bindings are created at the highest level possible (#960)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<Widget/>',
@@ -753,7 +754,7 @@ export default function() {
 		t.equal( ractive.get( 'person' ), widget.get( 'person' ) );
 	});
 
-	QUnit.test( 'Implicit bindings involving context (#975)', t => {
+	test( 'Implicit bindings involving context (#975)', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{#context}}<Widget/>{{/}}',
@@ -773,7 +774,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'works? yes' );
 	});
 
-	QUnit.test( 'Reference expressions default to two-way binding (#996)', t => {
+	test( 'Reference expressions default to two-way binding (#996)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -812,7 +813,7 @@ export default function() {
 		t.deepEqual( JSON.parse( output.innerHTML ), [{ name: 'Brian', age: 54 }, { name: 'Angela', age: 30 }] );
 	});
 
-	QUnit.test( 'Data that does not exist in a parent context binds to the current instance on set (#1205)', t => {
+	test( 'Data that does not exist in a parent context binds to the current instance on set (#1205)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<Widget/><Widget/>',
@@ -828,7 +829,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>title:foo</p><p>title:</p>' );
 	});
 
-	QUnit.test( 'Inter-component bindings can be created via this.get() and this.observe(), not just through templates', t => {
+	test( 'Inter-component bindings can be created via this.get() and this.observe(), not just through templates', t => {
 		const Widget = Ractive.extend({
 			template: '<p>message: {{proxy}}</p>',
 			oninit () {
@@ -853,7 +854,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>message: goodbye</p>' );
 	});
 
-	QUnit.test( 'Sibling components do not unnessarily update on refinement update of data. (#1293)', t => {
+	test( 'Sibling components do not unnessarily update on refinement update of data. (#1293)', t => {
 		let noCall = false;
 		let errored = false;
 
@@ -904,7 +905,7 @@ export default function() {
 		t.ok( !errored );
 	});
 
-	QUnit.test( 'Component bindings respect smart updates (#1209)', t => {
+	test( 'Component bindings respect smart updates (#1209)', t => {
 		const intros = {};
 		const outros = {};
 
@@ -940,7 +941,7 @@ export default function() {
 		t.deepEqual( outros, { a: 1, b: 1 });
 	});
 
-	QUnit.test( 'Multiple related values propagate across component boundaries (#1373)', t => {
+	test( 'Multiple related values propagate across component boundaries (#1373)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<Tweedle dee="{{dee}}" dum="{{dum}}"/>',
@@ -963,7 +964,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'forget quarrel' );
 	});
 
-	QUnit.test( 'Components unbind their resolvers while they are unbinding (#1428)', t => {
+	test( 'Components unbind their resolvers while they are unbinding (#1428)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -990,7 +991,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'john jacob jingleheimerschmidt' );
 	});
 
-	QUnit.test( 'Components may bind to the parent root (#1442)', t => {
+	test( 'Components may bind to the parent root (#1442)', t => {
 		new Ractive({
 			el: fixture,
 			template: '<Foo data="{{.}}" />',
@@ -1005,7 +1006,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo!' );
 	});
 
-	QUnit.test( 'Mappings with reference expressions that change bind correctly', t => {
+	test( 'Mappings with reference expressions that change bind correctly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<Widget foo="{{a[p]}}"/>',
@@ -1025,7 +1026,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'c' );
 	});
 
-	QUnit.test( 'Mappings with upstream reference expressions that change bind correctly', t => {
+	test( 'Mappings with upstream reference expressions that change bind correctly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#a[p]}}<Widget foo="{{bar}}"/>{{/a}}',
@@ -1092,7 +1093,7 @@ export default function() {
 		t.ok( 'bat' in cmp );
 	});*/
 
-	QUnit.test( 'Multiple levels of mappings work', t => {
+	test( 'Multiple levels of mappings work', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{a}}-{{b}}-{{c}}:<C1 d="{{a}}" e="{{b}}" f="{{c}}"/>',
@@ -1117,7 +1118,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo-bar-qux:foo-bar-qux:foo-bar-qux' );
 	});
 
-	QUnit.test( 'Bindings, mappings, and upstream computations should not cause infinite mark recursion (#1526)', t => {
+	test( 'Bindings, mappings, and upstream computations should not cause infinite mark recursion (#1526)', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{JSON.stringify(.)}}<widget foo="{{bar}}" /><input value="{{bar}}" />',
@@ -1127,7 +1128,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '{"bar":""}<input />' );
 	});
 
-	QUnit.test( 'components should update their mappings on rebind to prevent weirdness with shuffling (#2147)', t => {
+	test( 'components should update their mappings on rebind to prevent weirdness with shuffling (#2147)', t => {
 		const Item = Ractive.extend({
 			template: '{{value}}',
 			isolated: false
@@ -1164,7 +1165,7 @@ export default function() {
 		t.htmlEqual( ractive.find( '#s3' ).innerHTML, '12' );
 	});
 
-	QUnit.test( 'updates to children of mappings update correctly in the parent (#2469)', t => {
+	test( 'updates to children of mappings update correctly in the parent (#2469)', t => {
 		const cmp = Ractive.extend({
 			template: '{{#each foo.baz}}{{@key}}{{/each}}'
 		});
@@ -1188,7 +1189,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'b-' );
 	});
 
-	QUnit.test( 'Interpolators based on computed mappings update correctly #2261)', t => {
+	test( 'Interpolators based on computed mappings update correctly #2261)', t => {
 		const Component = Ractive.extend({
 			template: `{{active ? "active" : "inactive"}}`
 		});
@@ -1209,7 +1210,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'inactive active' );
 	});
 
-	QUnit.test( 'conditional mapping updates correctly', t => {
+	test( 'conditional mapping updates correctly', t => {
 		const cmp = Ractive.extend({
 			template: '{{foo}}'
 		});
@@ -1228,7 +1229,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'conditional mappings unmap correctly', t => {
+	test( 'conditional mappings unmap correctly', t => {
 		const cmp = Ractive.extend({
 			template: '{{foo}}'
 		});
@@ -1248,7 +1249,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'root references inside a component should resolve to the component', t => {
+	test( 'root references inside a component should resolve to the component', t => {
 		const cmp = Ractive.extend({
 			template: '{{#with foo.bar}}{{~/test}}{{/with}}',
 			data() {
@@ -1268,7 +1269,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( 'complex mappings continue to update with their dependencies', t => {
+	test( 'complex mappings continue to update with their dependencies', t => {
 		const cmp = Ractive.extend({
 			template: '{{foo}}',
 			isolated: false
@@ -1289,7 +1290,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo? yes' );
 	});
 
-	QUnit.test( `complex mappings work with a single section (#2444)`, t => {
+	test( `complex mappings work with a single section (#2444)`, t => {
 		const cmp = Ractive.extend({
 			template: '{{foo}}'
 		});
@@ -1304,7 +1305,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'hey is yep' );
 	});
 
-	QUnit.test( 'complex mapped reference expressions update correctly', t => {
+	test( 'complex mapped reference expressions update correctly', t => {
 		const cmp = Ractive.extend({
 			template: '<input value="{{foo[wat][yep + \'z\']}}" />',
 			data: {
@@ -1337,7 +1338,7 @@ export default function() {
 		t.equal( info.getBinding(), 'yep' );
 	});
 
-	QUnit.test( `shuffling a link to a link to a list doesn't blow the stack (#2699)`, t => {
+	test( `shuffling a link to a link to a list doesn't blow the stack (#2699)`, t => {
 		t.expect( 0 );
 
 		const cmp1 = Ractive.extend({ template: '<cmp2 list="{{list}}" />', isolated: false });
@@ -1353,7 +1354,7 @@ export default function() {
 		r.findComponent( 'cmp3' ).push( 'list', 1 );
 	});
 
-	QUnit.test( `shuffling a link to a link to a list updates correctly`, t => {
+	test( `shuffling a link to a link to a list updates correctly`, t => {
 		t.expect( 2 );
 
 		const cmp1 = Ractive.extend({ template: '<cmp2 list="{{list}}" />', isolated: false });
@@ -1372,7 +1373,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '21' );
 	});
 
-	QUnit.test( `computed properties can be mapped`, t => {
+	test( `computed properties can be mapped`, t => {
 		const cmp = Ractive.extend({ template: '{{foo.0}} {{foo.length}}' });
 		const r = new Ractive({
 			el: fixture,
@@ -1395,7 +1396,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '4 4' );
 	});
 
-	QUnit.test( `parent data can be referenced via special model to avoid computations with get`, t => {
+	test( `parent data can be referenced via special model to avoid computations with get`, t => {
 		const cmp = Ractive.extend({ template: '{{@.parent.data.foo}}' });
 		const r = new Ractive({
 			target: fixture,
@@ -1409,7 +1410,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'baz' );
 	});
 
-	QUnit.test( `mapped functions are bound to the right root context (#2552)`, t => {
+	test( `mapped functions are bound to the right root context (#2552)`, t => {
 		const cmp = Ractive.extend({
 			template: '{{foo()}}',
 			data: {
@@ -1429,7 +1430,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'baz' );
 	});
 
-	QUnit.test( `component attributes can contain stringified jsonish values`, t => {
+	test( `component attributes can contain stringified jsonish values`, t => {
 		const cmp = Ractive.extend();
 		const r = new Ractive({
 			target: fixture,
@@ -1440,7 +1441,7 @@ export default function() {
 		t.equal( JSON.stringify( r.findComponent().get( 'json' ) ), JSON.stringify( { foo: [1,2,3], bar: { baz: true }, bat: 'yep' } ) );
 	});
 
-	QUnit.test( `mappings don't try to initial a parent computed property that is readonly (#2888)`, t => {
+	test( `mappings don't try to initial a parent computed property that is readonly (#2888)`, t => {
 		const cmp = Ractive.extend({
 			data: { foo: 1 },
 			template: `{{'' + foo}}`

--- a/tests/browser/components/misc.js
+++ b/tests/browser/components/misc.js
@@ -1,12 +1,13 @@
 import { initModule, hasUsableConsole, onWarn } from '../../helpers/test-config';
 import { fire } from 'simulant';
+import { test } from 'qunit';
 
 // TODO tidy up, move some of these tests into separate files
 
 export default function() {
 	initModule( 'components/misc.js' );
 
-	QUnit.test( 'Component oncomplete() methods are called', t => {
+	test( 'Component oncomplete() methods are called', t => {
 		t.expect( 2 );
 
 		const done = t.async();
@@ -34,7 +35,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Instances with multiple components still fire oncomplete() handlers (#486 regression)', t => {
+	test( 'Instances with multiple components still fire oncomplete() handlers (#486 regression)', t => {
 		t.expect( 3 );
 
 		const done = t.async();
@@ -63,7 +64,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Correct value exists for node info keypath when a component is torn down and re-rendered (#470)', t => {
+	test( 'Correct value exists for node info keypath when a component is torn down and re-rendered (#470)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#foo}}<Widget visible="{{visible}}"/>{{/foo}}',
@@ -83,7 +84,7 @@ export default function() {
 		t.equal( Ractive.getNodeInfo( ractive.find( 'p' ) ).resolve(), '' );
 	});
 
-	QUnit.test( 'Nested components fire the oninit() event correctly (#511)', t => {
+	test( 'Nested components fire the oninit() event correctly (#511)', t => {
 		let outerInitCount = 0;
 		let innerInitCount = 0;
 
@@ -116,7 +117,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'Component removed from DOM on tear-down with teardown override that calls _super', t => {
+	test( 'Component removed from DOM on tear-down with teardown override that calls _super', t => {
 		const Widget = Ractive.extend({
 			template: 'foo',
 			onteardown () {
@@ -137,7 +138,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( 'Component names cannot include underscores (#483)', t => {
+	test( 'Component names cannot include underscores (#483)', t => {
 		t.expect( 1 );
 
 		const Component = Ractive.extend({ template: '{{foo}}' });
@@ -156,7 +157,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'Components can have names that happen to be Array.prototype or Object.prototype methods', t => {
+	test( 'Components can have names that happen to be Array.prototype or Object.prototype methods', t => {
 		new Ractive({
 			el: fixture,
 			template: '<map/>',
@@ -170,7 +171,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div class="map"></div>' );
 	});
 
-	QUnit.test( 'Set operations inside an inline component\'s onrender method update the DOM synchronously', t => {
+	test( 'Set operations inside an inline component\'s onrender method update the DOM synchronously', t => {
 		t.expect( 8 );
 
 		let previousHeight = -1;
@@ -204,7 +205,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Component constructors found in view hierarchy', t => {
+	test( 'Component constructors found in view hierarchy', t => {
 		const Foo = Ractive.extend({
 			template: 'foo'
 		});
@@ -223,7 +224,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'foo' );
 	});
 
-	QUnit.test( 'Components not found in view hierarchy when isolated is true', t => {
+	test( 'Components not found in view hierarchy when isolated is true', t => {
 		const Foo = Ractive.extend({
 			template: 'foo'
 		});
@@ -242,7 +243,7 @@ export default function() {
 		t.equal( fixture.innerHTML, '<foo></foo>' );
 	});
 
-	QUnit.test( 'Evaluator used in component more than once (#844)', t => {
+	test( 'Evaluator used in component more than once (#844)', t => {
 		const Widget = Ractive.extend({
 			template: '{{getLabels(foo)}}{{getLabels(boo)}}',
 			data: {
@@ -261,7 +262,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'fooboo' );
 	});
 
-	QUnit.test( 'Removing inline components causes teardown events to fire (#853)', t => {
+	test( 'Removing inline components causes teardown events to fire (#853)', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -285,7 +286,7 @@ export default function() {
 		ractive.toggle( 'foo' );
 	});
 
-	QUnit.test( 'Regression test for #871', t => {
+	test( 'Regression test for #871', t => {
 		const Widget = Ractive.extend({
 			template: '<p>inside component: {{i}}-{{text}}</p>',
 			isolated: false
@@ -312,7 +313,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>outside component: 0-A</p><p>inside component: 0-A</p><p>outside component: 1-C</p><p>inside component: 1-C</p>' );
 	});
 
-	QUnit.test( 'Specify component by function', t => {
+	test( 'Specify component by function', t => {
 		const Widget1 = Ractive.extend({ template: 'widget1' });
 		const Widget2 = Ractive.extend({ template: 'widget2' });
 
@@ -339,7 +340,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'widget2widget2' );
 	});
 
-	QUnit.test( 'Specify component by function as string', t => {
+	test( 'Specify component by function as string', t => {
 		const Widget = Ractive.extend({ template: 'foo' });
 
 		new Ractive({
@@ -357,7 +358,7 @@ export default function() {
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'no return of component warns in debug', t => {
+		test( 'no return of component warns in debug', t => {
 			t.expect( 1 );
 
 			onWarn( msg => {
@@ -375,7 +376,7 @@ export default function() {
 			});
 		});
 
-		QUnit.test( 'Inline components disregard `el` option (#1072) (and print a warning in debug mode)', t => {
+		test( 'Inline components disregard `el` option (#1072) (and print a warning in debug mode)', t => {
 			t.expect( 1 );
 
 			onWarn( () => {
@@ -398,7 +399,7 @@ export default function() {
 			ractive.set( 'show', false );
 		});
 
-		QUnit.test( 'Using non-primitives in data passed to Ractive.extend() triggers a warning', t => {
+		test( 'Using non-primitives in data passed to Ractive.extend() triggers a warning', t => {
 			t.expect( 1 );
 
 			onWarn( msg => {
@@ -425,7 +426,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( '`this` in function refers to ractive instance', t => {
+	test( '`this` in function refers to ractive instance', t => {
 		const Component = Ractive.extend({});
 
 		let thisForFoo;
@@ -455,7 +456,7 @@ export default function() {
 		t.ok( thisForBar === ractive );
 	});
 
-	QUnit.test( 'oninit() only fires once on a component (#943 #927), oncomplete fires each render', t => {
+	test( 'oninit() only fires once on a component (#943 #927), oncomplete fires each render', t => {
 		t.expect( 5 );
 
 		const done = t.async();
@@ -493,7 +494,7 @@ export default function() {
 		component.reset({ foo: true });
 	});
 
-	QUnit.test( 'Double teardown is handled gracefully (#1218)', t => {
+	test( 'Double teardown is handled gracefully (#1218)', t => {
 		t.expect( 0 );
 
 		onWarn( () => {} ); // suppress
@@ -518,7 +519,7 @@ export default function() {
 		ractive.findComponent( 'Widget' ).teardown();
 	});
 
-	QUnit.test( 'component.teardown() causes component to be removed from the DOM (#1223)', t => {
+	test( 'component.teardown() causes component to be removed from the DOM (#1223)', t => {
 		onWarn( () => {} ); // suppress
 
 		const Widget = Ractive.extend({
@@ -535,7 +536,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( 'Component CSS is added to the page before components (#1046)', t => {
+	test( 'Component CSS is added to the page before components (#1046)', t => {
 		const Box = Ractive.extend({
 			template: '<div class="box"></div>',
 			css: '.box { width: 100px; height: 100px; }',
@@ -555,7 +556,7 @@ export default function() {
 		ractive.set( 'showBox', true );
 	});
 
-	QUnit.test( 'Decorators and transitions are only initialised post-render, when components are inside elements (#1346)', t => {
+	test( 'Decorators and transitions are only initialised post-render, when components are inside elements (#1346)', t => {
 		const inDom = {};
 
 		const Widget = Ractive.extend({
@@ -580,7 +581,7 @@ export default function() {
 
 	// TODO: revist how we should handle this before finishing keypath-ftw
 	/*
-QUnit.test( 'Mapping to a computed property is an error', t => {
+test( 'Mapping to a computed property is an error', t => {
 		t.throws( function () {
 			var ractive = new Ractive({
 				template: '<widget foo="{{bar}}"/>',
@@ -601,7 +602,7 @@ QUnit.test( 'Mapping to a computed property is an error', t => {
 	*/
 	// TODO: fix this, failing since keypath-ftw. maybe revisit if this is really correct
 	/*
-QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t => {
+test( 'Implicit mappings are created by restricted references (#1465)', t => {
 		new Ractive({
 			el: fixture,
 			template: '<p>a: {{foo}}</p><b/><c/>',
@@ -625,7 +626,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 	});
 	*/
 
-	QUnit.test( 'Multiple components two-way binding', t => {
+	test( 'Multiple components two-way binding', t => {
 		const ListFoo = Ractive.extend({
 			template: `{{d.foo}}`
 		});
@@ -674,7 +675,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.htmlEqual( fixture.innerHTML, '11233' );
 	});
 
-	QUnit.test( 'Explicit mappings with uninitialised data', t => {
+	test( 'Explicit mappings with uninitialised data', t => {
 		onWarn( () => {} ); // suppress
 
 		const ractive = new Ractive({
@@ -691,7 +692,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.htmlEqual( fixture.innerHTML, 'hello' );
 	});
 
-	QUnit.test( 'Implicit mappings with uninitialised data', t => {
+	test( 'Implicit mappings with uninitialised data', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<Foo message="{{message}}"/>',
@@ -706,7 +707,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.htmlEqual( fixture.innerHTML, 'hello' );
 	});
 
-	QUnit.test( 'Two-way bindings on an unresolved key can force resolution', t => {
+	test( 'Two-way bindings on an unresolved key can force resolution', t => {
 		onWarn( () => {} ); // suppress
 
 		const ractive = new Ractive({
@@ -722,7 +723,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.equal( ractive.find( 'input' ).value, 'hello' );
 	});
 
-	QUnit.test( 'Component mappings used in computations resolve correctly with the mapping (#1645)', t => {
+	test( 'Component mappings used in computations resolve correctly with the mapping (#1645)', t => {
 		onWarn( () => {} ); // suppress
 
 		const ractive = new Ractive({
@@ -740,7 +741,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.htmlEqual( fixture.innerHTML, ractive.toHTML() );
 	});
 
-	QUnit.test( 'Component attributes with no = are boolean true', t => {
+	test( 'Component attributes with no = are boolean true', t => {
 		new Ractive({
 			el: fixture,
 			template: '<Widget foo/>',
@@ -750,7 +751,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( 'Component attributes with an empty string come back with an empty string', t => {
+	test( 'Component attributes with an empty string come back with an empty string', t => {
 		new Ractive({
 			el: fixture,
 			template: `<Widget foo='' />`,
@@ -760,7 +761,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( 'Unresolved keypath can be safely torn down', t => {
+	test( 'Unresolved keypath can be safely torn down', t => {
 		t.expect( 0 );
 
 		onWarn( () => {} ); // suppress
@@ -780,7 +781,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		ractive.set('show', false);
 	});
 
-	QUnit.test( 'Mappings resolve correctly where references are shadowed (#2108)', assert => {
+	test( 'Mappings resolve correctly where references are shadowed (#2108)', assert => {
 		const names = [ 'alice', 'amy', 'andrew', 'bob', 'beatrice', 'brenda', 'charles', 'colin', 'camilla' ];
 
 		const Group = Ractive.extend({
@@ -811,7 +812,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 	});
 
 
-	QUnit.test( 'this.parent exists in component.onconstruct() (#2091)', t => {
+	test( 'this.parent exists in component.onconstruct() (#2091)', t => {
 		const Widget = Ractive.extend({
 			template: '<div>component</div>',
 			onconstruct () {
@@ -826,7 +827,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		});
 	});
 
-	QUnit.test( 'Inline components have a `container` property', t => {
+	test( 'Inline components have a `container` property', t => {
 		const ractive = new Ractive({
 			template: '<Outer><Inner/></Outer>',
 			components: {
@@ -839,7 +840,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.strictEqual( ractive.container, null );
 	});
 
-	QUnit.test( 'component w/ empty select/option value does not throw (#2139)', t => {
+	test( 'component w/ empty select/option value does not throw (#2139)', t => {
 		t.expect( 0 );
 
 		const Component = Ractive.extend({
@@ -864,7 +865,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		ractive.set('persons', [{}]);
 	});
 
-	QUnit.test( 'component @keypath references should shuffle correctly', t => {
+	test( 'component @keypath references should shuffle correctly', t => {
 		const cmp = Ractive.extend({
 			template: `{{#with foo.bar}}{{.}} {{@keypath}} {{@rootpath}} {{#each ../list}}{{@keypath}}|{{/each}}{{/with}}`
 		});
@@ -893,7 +894,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.htmlEqual( fixture.innerHTML, '2 foo.bar items.0.baz.bar foo.list.0|foo.list.1|1 foo.bar items.1.baz.bar foo.list.0|foo.list.1|' );
 	});
 
-	QUnit.test( 'component dom has correct keypaths in node info', t => {
+	test( 'component dom has correct keypaths in node info', t => {
 		const cmp = Ractive.extend({
 			template: '{{#with foo.bar}}<inner />{{/with}}'
 		});
@@ -916,7 +917,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.equal( inner.resolve( '.', r ), 'baz.bat.bar' );
 	});
 
-	QUnit.test( 'component @rootpaths should skip root contexts (#2026)', t => {
+	test( 'component @rootpaths should skip root contexts (#2026)', t => {
 		const end = Ractive.extend({
 			template: '{{@rootpath}}',
 			isolated: false
@@ -937,7 +938,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.htmlEqual( fixture.innerHTML, 'root.next.next.next.next root.next.next.next.next' );
 	});
 
-	QUnit.test( '@rootpath should be accurate in events fired from within components (#2026)', t => {
+	test( '@rootpath should be accurate in events fired from within components (#2026)', t => {
 		const end = Ractive.extend({
 			template: '<button on-click="go">click me</button>',
 			isolated: false
@@ -962,7 +963,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		fire( r.find( 'button' ), 'click' );
 	});
 
-	QUnit.test( '@rootpath should be accurate in a yielder', t => {
+	test( '@rootpath should be accurate in a yielder', t => {
 		const end = Ractive.extend({
 			template: '{{#with other.path}}{{yield}}{{/with}}',
 			data: { other: { path: { yep: true } } }
@@ -979,7 +980,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.htmlEqual( fixture.innerHTML, 'root.next.next.next.next true' );
 	});
 
-	QUnit.test( 'nested components play nice with the transition manager - #2578', t => {
+	test( 'nested components play nice with the transition manager - #2578', t => {
 		const done = t.async();
 		let count = 0;
 		let count1 = 0;
@@ -1019,7 +1020,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		}, 200 );
 	});
 
-	QUnit.test( `setting a falsey value in a component registry blocks the loading of the component (#1800)`, t => {
+	test( `setting a falsey value in a component registry blocks the loading of the component (#1800)`, t => {
 		const cmp = Ractive.extend({
 			template: '<cmp>stuff</cmp>',
 			components: { cmp: false }
@@ -1033,7 +1034,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		t.htmlEqual( fixture.innerHTML, '<cmp>stuff</cmp>' );
 	});
 
-	QUnit.test( `overriding a Ractive prototype method in extend issues a warning in debug mode (#2358)`, t => {
+	test( `overriding a Ractive prototype method in extend issues a warning in debug mode (#2358)`, t => {
 		t.expect( 1 );
 
 		onWarn( msg => t.ok( /overriding.*render.*dangerous/i.test( msg ) ) );
@@ -1047,7 +1048,7 @@ QUnit.test( 'Implicit mappings are created by restricted references (#1465)', t 
 		});
 	});
 
-	QUnit.test( `returning false from a component event doesn't try to cancel something that doesn't exist (#2731)`, t => {
+	test( `returning false from a component event doesn't try to cancel something that doesn't exist (#2731)`, t => {
 		t.expect( 1 );
 
 		onWarn( msg => {

--- a/tests/browser/components/yield.js
+++ b/tests/browser/components/yield.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { hasUsableConsole, onWarn, initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'components/yield.js' );
 
-	QUnit.test( 'Basic yield', t => {
+	test( 'Basic yield', t => {
 		const Widget = Ractive.extend({
 			template: '<p>{{yield}}</p>'
 		});
@@ -18,7 +19,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>yeah!</p>' );
 	});
 
-	QUnit.test( 'References are resolved in parent context', t => {
+	test( 'References are resolved in parent context', t => {
 		const Widget = Ractive.extend({
 			template: '<p>{{yield}}</p>',
 			isolated: true
@@ -34,7 +35,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>yeah!</p>' );
 	});
 
-	QUnit.test( 'References are resolved in parent context through multiple layers', t => {
+	test( 'References are resolved in parent context through multiple layers', t => {
 		const WidgetInner = Ractive.extend({
 			template: '<p>{{yield}}</p>',
 			isolated: true
@@ -60,7 +61,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p><strong>yeah!</strong></p>' );
 	});
 
-	QUnit.test( 'Events fire in parent context', t => {
+	test( 'Events fire in parent context', t => {
 		t.expect( 1 );
 
 		const WidgetInner = Ractive.extend({
@@ -92,7 +93,7 @@ export default function() {
 		fire( ractive.find( 'button' ), 'click' );
 	});
 
-	QUnit.test( 'A component {{yield}} can be rerendered in conditional section block', t => {
+	test( 'A component {{yield}} can be rerendered in conditional section block', t => {
 		const Widget = Ractive.extend({
 			template: '<p>{{#foo}}{{yield}}{{/}}</p>',
 			isolated: false
@@ -111,7 +112,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>yield</p>' );
 	});
 
-	QUnit.test( 'A component {{yield}} can be rerendered in list section block', t => {
+	test( 'A component {{yield}} can be rerendered in list section block', t => {
 		const Widget = Ractive.extend({
 			template: `
 				{{#each items:i}}
@@ -134,7 +135,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'ca:YIELDED:' );
 	});
 
-	QUnit.test( 'A component {{yield}} should be parented by the fragment holding the yield and not the fragment holding the component', t => {
+	test( 'A component {{yield}} should be parented by the fragment holding the yield and not the fragment holding the component', t => {
 		const Widget = Ractive.extend({
 			template: '<div>{{yield}}</div>',
 			data: {
@@ -155,7 +156,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>foo! foo!</div>' );
 	});
 
-	QUnit.test( 'Named yield with a hyphenated name (#1681)', t => {
+	test( 'Named yield with a hyphenated name (#1681)', t => {
 		const template = `
 			<Widget>
 				{{#partial foo-bar}}
@@ -176,7 +177,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>this is foo-bar</p>' );
 	});
 
-	QUnit.test( 'yield can yield an expression', t => {
+	test( 'yield can yield an expression', t => {
 		const cmp = Ractive.extend({
 			template: '{{yield { template: "<p>yep</p>" } }}'
 		});
@@ -189,7 +190,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>yep</p>' );
 	});
 
-	QUnit.test( 'Named yield with Ractive.extend() works as with new Ractive() (#1680)', t => {
+	test( 'Named yield with Ractive.extend() works as with new Ractive() (#1680)', t => {
 		const Widget = Ractive.extend({
 			template: '{{yield foo}}'
 		});
@@ -221,7 +222,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>this is foo</p>' );
 	});
 
-	QUnit.test( 'yielded fragments that are updated from an observer should actually update (#2225)', t => {
+	test( 'yielded fragments that are updated from an observer should actually update (#2225)', t => {
 		const cmp = Ractive.extend({
 			template: '{{yield}}',
 			onrender() {
@@ -243,7 +244,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '-2 yep' );
 	});
 
-	QUnit.test( 'Components inherited from more than one generation off work with named yields', t => {
+	test( 'Components inherited from more than one generation off work with named yields', t => {
 		const widget = Ractive.extend({
 			template: '{{yield foo}}'
 		});
@@ -270,7 +271,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>this is foo</p>' );
 	});
 
-	QUnit.test( 'yielders should properly update with their container instance (#2235)', t => {
+	test( 'yielders should properly update with their container instance (#2235)', t => {
 		const Foo = Ractive.extend({
 			template: '{{yield}}'
 		});
@@ -289,7 +290,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'yielders should search the container for their anchor (#2235)', t => {
+	test( 'yielders should search the container for their anchor (#2235)', t => {
 		const Foo = Ractive.extend({
 			template: '<div>{{yield}}</div>'
 		});
@@ -309,7 +310,7 @@ export default function() {
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'Yield with missing partial (#1681)', t => {
+		test( 'Yield with missing partial (#1681)', t => {
 			onWarn( msg => {
 				t.ok( /Could not find template for partial 'missing'/.test( msg ) );
 			});
@@ -325,7 +326,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'a plain content yielder may provide context via aliases', t => {
+	test( 'a plain content yielder may provide context via aliases', t => {
 		const cmp = Ractive.extend({
 			template: `<ul>{{#each items}}<li>{{yield with . as item}}</li>{{/each}}</ul>`
 		});
@@ -342,7 +343,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<ul><li>hello 1</li><li>hello 2</li><li>hello 3</li></ul>' );
 	});
 
-	QUnit.test( 'a specific content yielder may provide context via aliases', t => {
+	test( 'a specific content yielder may provide context via aliases', t => {
 		const cmp = Ractive.extend({
 			template: `<ul>{{#each items}}<li>{{yield foo with . as item}}</li>{{/each}}</ul>`
 		});
@@ -359,7 +360,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<ul><li>hello 1</li><li>hello 2</li><li>hello 3</li></ul>' );
 	});
 
-	QUnit.test( 'partial expression is evaluated outside of the partial context', t => {
+	test( 'partial expression is evaluated outside of the partial context', t => {
 		new Ractive({
 			el: fixture,
 			template: `{{>foo { foo: 'nope' } }}`,
@@ -375,7 +376,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( 'yield resolves its expression in the correct context', t => {
+	test( 'yield resolves its expression in the correct context', t => {
 		const cmp = Ractive.extend({
 			template: '{{yield foo.bar}}',
 			data: {

--- a/tests/browser/computations.js
+++ b/tests/browser/computations.js
@@ -1,10 +1,11 @@
 import { hasUsableConsole, onWarn } from '../helpers/test-config';
 import { initModule } from '../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'computations.js' );
 
-	QUnit.test( 'Computed value declared as a function', t => {
+	test( 'Computed value declared as a function', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<p>area: {{area}}</p>',
@@ -28,7 +29,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>area: 225</p>' );
 	});
 
-	QUnit.test( 'Dependency of computed property', t => {
+	test( 'Dependency of computed property', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{answer}}',
@@ -53,7 +54,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '40' );
 	});
 
-	QUnit.test( 'Computed value declared as a string', t => {
+	test( 'Computed value declared as a string', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<p>area: {{area}}</p>',
@@ -75,7 +76,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>area: 225</p>' );
 	});
 
-	QUnit.test( 'Computed value with a set() method', t => {
+	test( 'Computed value with a set() method', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<p>First name: {{first}}</p><p>Last name: {{last}}</p><p>Full name: {{full}}</p>',
@@ -110,7 +111,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>First name: John</p><p>Last name: Belushi</p><p>Full name: John Belushi</p>' );
 	});
 
-	QUnit.test( 'Components can have default computed properties', t => {
+	test( 'Components can have default computed properties', t => {
 		const Box = Ractive.extend({
 			template: '<div style="width: {{width}}px; height: {{height}}px;">{{area}}px squared</div>',
 			computed: {
@@ -135,7 +136,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML.replace( /\s+/g, '' ), `<div style="width: 200px; height: 100px;">20000px squared</div>`.replace( /\s+/g, '' ) );
 	});
 
-	QUnit.test( 'Instances can augment default computed properties of components', t => {
+	test( 'Instances can augment default computed properties of components', t => {
 		const Box = Ractive.extend({
 			template: '<div style="width: {{width}}px; height: {{height}}px;">{{area}}px squared</div>',
 			computed: {
@@ -159,7 +160,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML.replace( /\s+/g, '' ), `<div style="width: 200px; height: 100px;">20000px squared</div>`.replace( /\s+/g, '' ) );
 	});
 
-	QUnit.test( 'Computed values can depend on other computed values', t => {
+	test( 'Computed values can depend on other computed values', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{number}} - {{squared}} - {{cubed}}',
@@ -176,7 +177,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '6 - 36 - 216' );
 	});
 
-	QUnit.test( 'Computed values with mix of computed and non-computed dependencies updates when non-computed dependencies change (#2228)', t => {
+	test( 'Computed values with mix of computed and non-computed dependencies updates when non-computed dependencies change (#2228)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{number}}',
@@ -201,7 +202,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '42' );
 	});
 
-	QUnit.test( 'Computations that cause errors are considered undefined', t => {
+	test( 'Computations that cause errors are considered undefined', t => {
 		onWarn( () => {} ); // suppress
 
 		const ractive = new Ractive({
@@ -218,7 +219,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'WORKS' );
 	});
 
-	QUnit.test( 'Computations can be updated with ractive.update() (#651)', t => {
+	test( 'Computations can be updated with ractive.update() (#651)', t => {
 		let bar = undefined;
 
 		const ractive = new Ractive({
@@ -236,7 +237,7 @@ export default function() {
 		t.equal( ractive.get( 'foo' ), 1 );
 	});
 
-	QUnit.test( 'Regression test for #836', t => {
+	test( 'Regression test for #836', t => {
 		const Widget = Ractive.extend({
 			template: '{{# foo <= bar }}yes{{/}}',
 			computed: { foo: '[]' },
@@ -254,7 +255,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yes' );
 	});
 
-	QUnit.test( 'Setters are called on init with supplied data (#837)', t => {
+	test( 'Setters are called on init with supplied data (#837)', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{firstname}}',
@@ -280,7 +281,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'Colonel' );
 	});
 
-	QUnit.test( 'Set operations are not short-circuited when the set value is identical to the current get value (#837)', t => {
+	test( 'Set operations are not short-circuited when the set value is identical to the current get value (#837)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{bar}}',
@@ -304,7 +305,7 @@ export default function() {
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'Computations on unresolved refs don\'t error on initial component bindings', t => {
+		test( 'Computations on unresolved refs don\'t error on initial component bindings', t => {
 			t.expect( 0 );
 
 			onWarn( () => t.ok( false ) );
@@ -322,7 +323,7 @@ export default function() {
 			});
 		});
 
-		QUnit.test( 'Computed value that calls itself (#1359)', t => {
+		test( 'Computed value that calls itself (#1359)', t => {
 			let messages = 0;
 
 			onWarn( msg => {
@@ -361,7 +362,7 @@ export default function() {
 	}
 
 
-	QUnit.test( 'Unresolved computations resolve when parent component data exists', t => {
+	test( 'Unresolved computations resolve when parent component data exists', t => {
 		const Component = Ractive.extend({
 			template: '{{FOO}} {{BAR}}',
 			computed: {
@@ -387,7 +388,7 @@ export default function() {
 
 	});
 
-	QUnit.test( 'Computed properties referencing bound parent data', t => {
+	test( 'Computed properties referencing bound parent data', t => {
 		const List = Ractive.extend({
 			template: `{{limits.sum}}`,
 			computed: {
@@ -418,7 +419,7 @@ export default function() {
 		t.equal( fixture.innerHTML, '963' );
 	});
 
-	QUnit.test( 'Computed properties referencing bound parent data w/ conditional', t => {
+	test( 'Computed properties referencing bound parent data w/ conditional', t => {
 		const List = Ractive.extend({
 			template: `
 				{{#if limits.sum}}
@@ -454,7 +455,7 @@ export default function() {
 		t.equal( fixture.innerHTML, '963' );
 	});
 
-	QUnit.test( 'Computed properties referencing deep objects', t => {
+	test( 'Computed properties referencing deep objects', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{one.two.tre}}',
@@ -477,7 +478,7 @@ export default function() {
 		t.equal( fixture.innerHTML, '99' );
 	});
 
-	QUnit.test( 'Computations are not order dependent', t => {
+	test( 'Computations are not order dependent', t => {
 
 		const Component = Ractive.extend({
 			template: '{{foo}}',
@@ -502,7 +503,7 @@ export default function() {
 
 	});
 
-	QUnit.test( 'Parent extend instance computations are resolved before child computations', t => {
+	test( 'Parent extend instance computations are resolved before child computations', t => {
 		const Base = Ractive.extend({
 			computed: {
 				base: () => 1
@@ -525,7 +526,7 @@ export default function() {
 		t.equal( fixture.innerHTML, '2' );
 	});
 
-	QUnit.test( 'Computed values are only computed as necessary', t => {
+	test( 'Computed values are only computed as necessary', t => {
 		const count = { foo: 0, bar: 0, baz: 0, qux: 0 };
 
 		const ractive = new Ractive({
@@ -567,7 +568,7 @@ export default function() {
 		t.deepEqual( count, { foo: 3, bar: 3, baz: 3, qux: 1 });
 	});
 
-	QUnit.test( 'What happens if you access a computed property in data config?', t => {
+	test( 'What happens if you access a computed property in data config?', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{total}}',
@@ -582,7 +583,7 @@ export default function() {
 		t.equal( fixture.innerHTML, '5' );
 	});
 
-	QUnit.test( 'Computations matching _[0-9]+ that are not references should not be mangled incorrectly for caching', t => {
+	test( 'Computations matching _[0-9]+ that are not references should not be mangled incorrectly for caching', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{ foo["_1bar"] }} {{ foo["_2bar"] }}',
@@ -600,7 +601,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '_0 _1' );
 	});
 
-	QUnit.test( 'Computations can depend on array values (#1747)', t => {
+	test( 'Computations can depend on array values (#1747)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{count}} {{count === 4}}',
@@ -645,7 +646,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'foo:foobar-foo:foobar' );
 	});*/
 
-	QUnit.test( 'Computations depending up computed values cascade while updating (#1383)', ( t ) => {
+	test( 'Computations depending up computed values cascade while updating (#1383)', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#if a < 10}}less{{else}}more{{/if}}',
@@ -662,7 +663,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'more' );
 	});
 
-	QUnit.test( 'Setting an Array to [] does not recompute removed values (#2069)', t => {
+	test( 'Setting an Array to [] does not recompute removed values (#2069)', t => {
 		const called = { func: 0, f1: 0, f2: 0, f3: 0 };
 		const ractive = new Ractive({
 			el: fixture,
@@ -687,7 +688,7 @@ export default function() {
 		t.deepEqual( called, { func: 3, f1: 1, f2: 1, f3: 1 });
 	});
 
-	QUnit.test( 'ComputationChild dependencies are captured (#2132)', t => {
+	test( 'ComputationChild dependencies are captured (#2132)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -712,7 +713,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>d/d</p><p>e/e</p>' );
 	});
 
-	QUnit.test( 'reference expression proxy should play nicely with capture (#2550)', t => {
+	test( 'reference expression proxy should play nicely with capture (#2550)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with wat[idx]}}{{ident(.)}}{{/with}}`,
@@ -733,7 +734,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '4' );
 	});
 
-	QUnit.test( 'computations should not recompute when spliced out', t => {
+	test( 'computations should not recompute when spliced out', t => {
 		let count = 0;
 
 		const r = new Ractive({
@@ -757,7 +758,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( 'computations with a reference expression should update with the full reference too', t => {
+	test( 'computations with a reference expression should update with the full reference too', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{foo[v].wat + '!'}}`,
@@ -772,7 +773,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep!' );
 	});
 
-	QUnit.test( 'computations should not recompute when parent section is destroyed', t => {
+	test( 'computations should not recompute when parent section is destroyed', t => {
 		let count = 0;
 
 		const ractive = new Ractive({
@@ -809,7 +810,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( 'computations should not recompute when parent component is destroyed', t => {
+	test( 'computations should not recompute when parent component is destroyed', t => {
 		let count = 0;
 
 		const Foo = Ractive.extend({
@@ -854,7 +855,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( 'expressions in conditional branches should not be re-evaluated', t => {
+	test( 'expressions in conditional branches should not be re-evaluated', t => {
 		let count = 0;
 		new Ractive({
 			el: fixture,
@@ -870,7 +871,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( 'expressions should shuffle correctly', t => {
+	test( 'expressions should shuffle correctly', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each list}}{{.foo + 1}}{{~/list.0.foo + 1}}{{/each}}`,
@@ -886,7 +887,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '4434' );
 	});
 
-	QUnit.test( 'expressions with mappings shuffle correctly', t => {
+	test( 'expressions with mappings shuffle correctly', t => {
 		const cmp = Ractive.extend({
 			template: '{{foo.foo + 1}}{{bar.foo + 1}}'
 		});
@@ -906,7 +907,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '4434' );
 	});
 
-	QUnit.test( 'computations update correctly during a shuffle', t => {
+	test( 'computations update correctly during a shuffle', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{foo.foo}}{{foo.foo + 1}}',
@@ -927,7 +928,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '12' );
 	});
 
-	QUnit.test( `expression proxies shouldn't cause deps to re-order while handling changes from a mapping (#2678)`, t => {
+	test( `expression proxies shouldn't cause deps to re-order while handling changes from a mapping (#2678)`, t => {
 		const cmp = Ractive.extend({
 			template: '{{yield}}'
 		});
@@ -943,7 +944,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep-yep' );
 	});
 
-	QUnit.test( `expression proxies shouldn't cause deps to re-order while handling any changes (#2680)`, t => {
+	test( `expression proxies shouldn't cause deps to re-order while handling any changes (#2680)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#foo(bat)}}{{#if . === 'nope'}}never{{/if}}{{#if ~/bat === 'yep'}}yep{{else}}hey{{/if}}{{/}}`,
@@ -958,7 +959,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'hey' );
 	});
 
-	QUnit.test( `computation changes can be observed`, t => {
+	test( `computation changes can be observed`, t => {
 		t.expect( 3 );
 
 		const r = new Ractive({
@@ -987,7 +988,7 @@ export default function() {
 		r.set( 'bar', 'goof' );
 	});
 
-	QUnit.test( `computation changes are included in recursive observers`, t => {
+	test( `computation changes are included in recursive observers`, t => {
 		t.expect( 2 );
 
 		let fluff = 'bar';
@@ -1023,7 +1024,7 @@ export default function() {
 		r.set( 'bar', 'goof' );
 	});
 
-	QUnit.test( `computations can have child values set when allowed`, t => {
+	test( `computations can have child values set when allowed`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `
@@ -1054,7 +1055,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<i>3</i><i>3</i><i>3</i>' );
 	});
 
-	QUnit.test( `computations with dotted names can be accessed (#2807)`, t => {
+	test( `computations with dotted names can be accessed (#2807)`, t => {
 		const r = new Ractive({
 			computed: {
 				'foo.bar': '${baz} + 1'
@@ -1071,7 +1072,7 @@ export default function() {
 		t.equal( r.get( 'foo\\.bar' ), 10 );
 	});
 
-	QUnit.test( `computations that return objects fire with recursive observers`, t => {
+	test( `computations that return objects fire with recursive observers`, t => {
 		t.expect( 2 );
 
 		const r = new Ractive({
@@ -1101,7 +1102,7 @@ export default function() {
 	// phantom just doesn't execute this test... no error, just nothing
 	// even >>> log messages don't come out. passes chrome and ff, though
 	if ( !/phantom/i.test( navigator.userAgent ) ) {
-		QUnit.test( `various spread expressions compute correctly`, t => {
+		test( `various spread expressions compute correctly`, t => {
 			new Ractive({
 				el: fixture,
 				template: `{{ JSON.stringify([ foo, bar, ...baz, ...bat( { bip, bop: 42, ...whimmy.wham( ...[ zat, wozzle, ...qux, bar ], zip ), bif: 84 } ), bar, foo ]) }}`,

--- a/tests/browser/events/basic.js
+++ b/tests/browser/events/basic.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'events/basic.js' );
 
-	QUnit.test( 'sharing names with array mutator functions doesn\'t break events', t => {
+	test( 'sharing names with array mutator functions doesn\'t break events', t => {
 		const eventNames = ['sort', 'reverse', 'push', 'pop', 'shift', 'unshift', 'fhtagn']; // the last one just tests the test
 		const results = new Object( null );
 
@@ -21,7 +22,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Empty event names are safe, though do not fire', t => {
+	test( 'Empty event names are safe, though do not fire', t => {
 		const ractive = new Ractive();
 
 		t.expect( 1 );
@@ -32,7 +33,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'Calling ractive.off() without a keypath removes all handlers', t => {
+	test( 'Calling ractive.off() without a keypath removes all handlers', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: 'doesn\'t matter'
@@ -59,7 +60,7 @@ export default function() {
 		ractive.fire( 'baz' );
 	});
 
-	QUnit.test( 'Multiple space-separated events can be handled with a single callback (#731)', t => {
+	test( 'Multiple space-separated events can be handled with a single callback (#731)', t => {
 		const ractive = new Ractive({});
 		let count = 0;
 
@@ -86,7 +87,7 @@ export default function() {
 		t.equal( count, 4 );
 	});
 
-	QUnit.test( `events also initially fire in the implicit this namespace`, t => {
+	test( `events also initially fire in the implicit this namespace`, t => {
 		let thisFoo = 0;
 		let starFoo = 0;
 		let justFoo = 0;
@@ -111,7 +112,7 @@ export default function() {
 		t.equal( star, 1 );
 	});
 
-	QUnit.test( `events that bubble drop the this namespace on their way up`, t => {
+	test( `events that bubble drop the this namespace on their way up`, t => {
 		const cmp = Ractive.extend();
 		const r = new Ractive({
 			target: fixture,
@@ -131,14 +132,14 @@ export default function() {
 		t.equal( starStarFoo, 0 );
 	});
 
-	QUnit.test( 'ractive.off() is chainable (#677)', t => {
+	test( 'ractive.off() is chainable (#677)', t => {
 		const ractive = new Ractive();
 		const returnedValue = ractive.off( 'foo' );
 
 		t.equal( returnedValue, ractive );
 	});
 
-	QUnit.test( 'handlers can use pattern matching', t => {
+	test( 'handlers can use pattern matching', t => {
 		t.expect( 4 );
 
 		const ractive = new Ractive();
@@ -151,7 +152,7 @@ export default function() {
 		ractive.fire( 'some.event' );
 	});
 
-	QUnit.test( '.once() event functionality', t => {
+	test( '.once() event functionality', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive( {} );
@@ -165,7 +166,7 @@ export default function() {
 		ractive.fire( 'bar' );
 	});
 
-	QUnit.test( 'wildcard and multi-part listeners have correct event name', t => {
+	test( 'wildcard and multi-part listeners have correct event name', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<span id="test" on-click="foo"/>'
@@ -183,7 +184,7 @@ export default function() {
 		t.deepEqual( fired, events );
 	});
 
-	QUnit.test( 'Inflight unsubscribe works (#1504)', t => {
+	test( 'Inflight unsubscribe works (#1504)', t => {
 		t.expect( 3 );
 
 		const ractive = new Ractive( {} );
@@ -203,7 +204,7 @@ export default function() {
 		ractive.fire( 'foo' );
 	});
 
-	QUnit.test( `hyphens in event names can be escaped`, t => {
+	test( `hyphens in event names can be escaped`, t => {
 		const cmp = Ractive.extend();
 		const r = new Ractive({
 			target: fixture,
@@ -219,7 +220,7 @@ export default function() {
 		t.equal( r.get( 'foo' ), 'yep' );
 	});
 
-	QUnit.test( `events can be silenced and resumed`, t => {
+	test( `events can be silenced and resumed`, t => {
 		let count = 0;
 		const r = new Ractive();
 		const handle = r.on( 'foo', function ( ctx, num ) {
@@ -242,7 +243,7 @@ export default function() {
 		t.equal( handle.isSilenced(), false );
 	});
 
-	QUnit.test( `event handle cancels all events when multiple events are subscribed`, t => {
+	test( `event handle cancels all events when multiple events are subscribed`, t => {
 		let count = 0;
 		const r = new Ractive();
 		const obj = r.on({

--- a/tests/browser/events/bubbling.js
+++ b/tests/browser/events/bubbling.js
@@ -1,5 +1,6 @@
 import { initModule, beforeEach } from '../../helpers/test-config';
 import { fire } from 'simulant';
+import { test } from 'qunit';
 
 export default function() {
 	let Component;
@@ -50,7 +51,7 @@ export default function() {
 			verify: ( ctx, arg ) => arg === 'foo'
 		}
 	].forEach( ({ type, callback, verify }) => {
-		QUnit.test( `Events bubble under "eventname", and also "Component.eventname" above firing component (${type})`, t => {
+		test( `Events bubble under "eventname", and also "Component.eventname" above firing component (${type})`, t => {
 			t.expect( 3 );
 
 			const ractive = new Subclass({ el: fixture });
@@ -69,7 +70,7 @@ export default function() {
 			callback( ractive.findComponent( 'Component' ) );
 		});
 
-		QUnit.test( `arguments bubble (${type})`, t => {
+		test( `arguments bubble (${type})`, t => {
 			t.expect( 3 );
 
 			Component.prototype.template = '<span id="test" on-click="@this.fire("someEvent", event, "foo")">click me</span>';
@@ -90,7 +91,7 @@ export default function() {
 			callback( ractive.findComponent( 'Component' ) );
 		});
 
-		QUnit.test( `bubbling events can be stopped by returning false (${type})`, t => {
+		test( `bubbling events can be stopped by returning false (${type})`, t => {
 			t.expect( 2 );
 
 			const ractive = new Subclass({ el: fixture });
@@ -111,7 +112,7 @@ export default function() {
 			callback( ractive.findComponent( 'Component' ) );
 		});
 
-		QUnit.test( `bubbling events with event object have component reference (${type})`, t => {
+		test( `bubbling events with event object have component reference (${type})`, t => {
 			t.expect( 3 );
 
 			const ractive = new Subclass({ el: fixture });
@@ -132,7 +133,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'bubbling handlers can use pattern matching', t => {
+	test( 'bubbling handlers can use pattern matching', t => {
 		t.expect( 4 );
 
 		const Component = Ractive.extend({
@@ -158,7 +159,7 @@ export default function() {
 		ractive.off();
 	});
 
-	QUnit.test( 'component "on-someEvent" implicitly cancels bubbling', t => {
+	test( 'component "on-someEvent" implicitly cancels bubbling', t => {
 		t.expect( 1 );
 
 		const Component = Ractive.extend({
@@ -178,7 +179,7 @@ export default function() {
 		fire( component.find( '#test' ), 'click' );
 	});
 
-	QUnit.test( 'component "on-" wildcards match', t => {
+	test( 'component "on-" wildcards match', t => {
 		t.expect( 3 );
 
 		const Component = Ractive.extend({
@@ -199,7 +200,7 @@ export default function() {
 		fire( component.find( '#test' ), 'click' );
 	});
 
-	QUnit.test( 'component "on-" do not get auto-namespaced events', t => {
+	test( 'component "on-" do not get auto-namespaced events', t => {
 		t.expect( 1 );
 
 		const Component = Ractive.extend({
@@ -219,7 +220,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'cancelling an event from a bubbled handler also cancels the root event (#2844)', t => {
+	test( 'cancelling an event from a bubbled handler also cancels the root event (#2844)', t => {
 		t.expect( 0 );
 
 		const cmp = Ractive.extend({
@@ -237,7 +238,7 @@ export default function() {
 		fire( r.find( 'button' ), 'click' );
 	});
 
-	QUnit.test( 'firing an event from an event directive cancels bubble if the sub-event also cancels', t => {
+	test( 'firing an event from an event directive cancels bubble if the sub-event also cancels', t => {
 		t.expect( 0 );
 
 		const r = new Ractive({

--- a/tests/browser/events/conditional.js
+++ b/tests/browser/events/conditional.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'events/conditional.js' );
 
-	QUnit.test( 'event is added and removed with conditional', t => {
+	test( 'event is added and removed with conditional', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<a {{#if foo}}on-click="@this.add('count')"{{/if}}>click me</a>`,
@@ -25,7 +26,7 @@ export default function() {
 		t.equal( r.get( 'count' ), 2 );
 	});
 
-	QUnit.test( 'events work with else', t => {
+	test( 'events work with else', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<a {{#if foo}}on-click="@this.add('count1')"{{else}}on-click="@this.add('count2')"{{/if}}>click me</a>`,
@@ -49,7 +50,7 @@ export default function() {
 		t.equal( r.get( 'count2' ), 2 );
 	});
 
-	QUnit.test( `conditional event listeners work with components`, t => {
+	test( `conditional event listeners work with components`, t => {
 		let count = 0;
 		const r1 = Ractive.extend({
 			template: ''
@@ -69,7 +70,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( `conditional event listeners work with anchors`, t => {
+	test( `conditional event listeners work with anchors`, t => {
 		let count = 0;
 		const r1 = new Ractive({
 			template: ''

--- a/tests/browser/events/custom-proxy-events.js
+++ b/tests/browser/events/custom-proxy-events.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'events/custom-proxy-events.js' );
 
-	QUnit.test( 'custom event invoked and torndown', t => {
+	test( 'custom event invoked and torndown', t => {
 		t.expect( 3 );
 
 		const custom = ( node, fire ) => {

--- a/tests/browser/events/delegate.js
+++ b/tests/browser/events/delegate.js
@@ -1,10 +1,11 @@
 import { initModule } from '../../helpers/test-config';
 import { fire } from 'simulant';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'events/delegate.js' );
 
-	QUnit.test( `basic delegation`, t => {
+	test( `basic delegation`, t => {
 		t.expect( 6 );
 
 		const addEventListener = Element.prototype.addEventListener;
@@ -38,7 +39,7 @@ export default function() {
 		fire( other, 'click' );
 	});
 
-	QUnit.test( `delegated method event`, t => {
+	test( `delegated method event`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `<div>{{#each [1]}}{{#with ~/foo}}<div on-click="event.set('.bar', 42)" />{{/with}}{{/each}}</div>`,
@@ -50,7 +51,7 @@ export default function() {
 		t.equal( r.get( 'foo.bar' ), 42 );
 	});
 
-	QUnit.test( `library delegated event cancellation`, t => {
+	test( `library delegated event cancellation`, t => {
 		t.expect( 1 );
 
 		const r = new Ractive({
@@ -66,7 +67,7 @@ export default function() {
 		fire( yep, 'click' );
 	});
 
-	QUnit.test( `multiple delegated events don't interfere with each other`, t => {
+	test( `multiple delegated events don't interfere with each other`, t => {
 		t.expect( 1 );
 
 		const r = new Ractive({
@@ -82,7 +83,7 @@ export default function() {
 		simulant.fire( yep, 'mouseenter' );
 	});
 
-	QUnit.test( `delegated event context is correct`, t => {
+	test( `delegated event context is correct`, t => {
 		t.expect( 2 );
 
 		const r = new Ractive({
@@ -99,7 +100,7 @@ export default function() {
 		fire( inner, 'click' );
 	});
 
-	QUnit.test( `delegated events can also be raised`, t => {
+	test( `delegated events can also be raised`, t => {
 		t.expect( 1 );
 
 		const r = new Ractive({
@@ -113,7 +114,7 @@ export default function() {
 		r.getNodeInfo( r.findAll( 'div' )[1] ).raise( 'click', {} );
 	});
 
-	QUnit.test( `dom events within components can also be delegated`, t => {
+	test( `dom events within components can also be delegated`, t => {
 		const addEventListener = Element.prototype.addEventListener;
 		let count = 0;
 		Element.prototype.addEventListener = function () {
@@ -149,7 +150,7 @@ export default function() {
 		fire( other, 'click' );
 	});
 
-	QUnit.test( `delegation can be turned off`, t => {
+	test( `delegation can be turned off`, t => {
 		const addEventListener = Element.prototype.addEventListener;
 		let count = 0;
 		Element.prototype.addEventListener = function () {
@@ -178,7 +179,7 @@ export default function() {
 		t.ok( other._ractive.proxy.events[0].events.length === 1 );
 	});
 
-	QUnit.test( `delegation can be turned off for specific elements with no-delegation`, t => {
+	test( `delegation can be turned off for specific elements with no-delegation`, t => {
 		const addEventListener = Element.prototype.addEventListener;
 		let count = 0;
 		Element.prototype.addEventListener = function () {
@@ -207,7 +208,7 @@ export default function() {
 		t.ok( other._ractive.proxy.events[0].events.length === 0 );
 	});
 
-	QUnit.test( `delegated events work with non-ractive nodes (#2871)`, t => {
+	test( `delegated events work with non-ractive nodes (#2871)`, t => {
 		let div;
 		const r = new Ractive({
 			target: fixture,
@@ -230,7 +231,7 @@ export default function() {
 		t.equal( r.get( 'foo.bar' ), 42 );
 	});
 
-	QUnit.test( `delegation in a yielder`, t => {
+	test( `delegation in a yielder`, t => {
 		t.expect( 1 );
 
 		const cmp = Ractive.extend({

--- a/tests/browser/events/dom-proxy-events.js
+++ b/tests/browser/events/dom-proxy-events.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'events/dom-proxy-events.js' );
 
-	QUnit.test( 'on-click="someEvent" fires an event when user clicks the element', t => {
+	test( 'on-click="someEvent" fires an event when user clicks the element', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -20,7 +21,7 @@ export default function() {
 		fire( ractive.find( '#test' ), 'click' );
 	});
 
-	QUnit.test( 'empty event on-click="" ok', t => {
+	test( 'empty event on-click="" ok', t => {
 		t.expect( 0 );
 
 		const ractive = new Ractive({
@@ -31,7 +32,7 @@ export default function() {
 		fire( ractive.find( '#test' ), 'click' );
 	});
 
-	QUnit.test( 'on-click="someEvent" does not fire event when unrendered', t => {
+	test( 'on-click="someEvent" does not fire event when unrendered', t => {
 		t.expect( 0 );
 
 		const ractive = new Ractive({
@@ -49,7 +50,7 @@ export default function() {
 		fire( node, 'click' );
 	});
 
-	QUnit.test( 'Standard events have correct properties: node, original, name', t => {
+	test( 'Standard events have correct properties: node, original, name', t => {
 		t.expect( 3 );
 
 		const ractive = new Ractive({
@@ -66,7 +67,7 @@ export default function() {
 		fire( ractive.find( '#test' ), 'click' );
 	});
 
-	QUnit.test( 'preventDefault and stopPropagation if event handler returned false', t => {
+	test( 'preventDefault and stopPropagation if event handler returned false', t => {
 		t.expect( 9 );
 
 		const ractive = new Ractive({
@@ -129,7 +130,7 @@ export default function() {
 		t.ok( preventedDefault && stoppedPropagation );
 	});
 
-	QUnit.test( 'event keypath is set to the innermost context', t => {
+	test( 'event keypath is set to the innermost context', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -148,7 +149,7 @@ export default function() {
 		fire( ractive.find( '#test' ), 'click' );
 	});
 
-	QUnit.test( 'event keypath is set to the mapped keypath in a component', t => {
+	test( 'event keypath is set to the mapped keypath in a component', t => {
 		t.expect( 4 );
 
 		const cmp = Ractive.extend({
@@ -181,7 +182,7 @@ export default function() {
 		fire( ractive.find( '#test2' ), 'click' );
 	});
 
-	QUnit.test( 'event rootpath is set to the non-mapped keypath in a component', t => {
+	test( 'event rootpath is set to the non-mapped keypath in a component', t => {
 		t.expect( 4 );
 
 		const cmp = Ractive.extend({
@@ -214,7 +215,7 @@ export default function() {
 		fire( ractive.find( '#test2' ), 'click' );
 	});
 
-	QUnit.test( 'events can correctly retrieve index refs', t => {
+	test( 'events can correctly retrieve index refs', t => {
 		t.expect( 4 );
 
 		const ractive = new Ractive({
@@ -235,7 +236,7 @@ export default function() {
 		fire( ractive.find( '#item_2' ), 'click' );
 	});
 
-	QUnit.test( 'events can correctly retrieve nested index refs', t => {
+	test( 'events can correctly retrieve nested index refs', t => {
 		t.expect( 4 );
 
 		const ractive = new Ractive({
@@ -259,7 +260,7 @@ export default function() {
 		fire( ractive.find( '#test_001' ), 'click' );
 	});
 
-	QUnit.test( 'Splicing arrays correctly modifies two-way bindings', t => {
+	test( 'Splicing arrays correctly modifies two-way bindings', t => {
 		t.expect( 25 );
 
 		const items = [
@@ -338,7 +339,7 @@ export default function() {
 		t.equal( ractive.findAll( 'input' ).length, 2 );
 	});
 
-	QUnit.test( 'Changes triggered by two-way bindings propagate properly (#460)', t => {
+	test( 'Changes triggered by two-way bindings propagate properly (#460)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -385,7 +386,7 @@ export default function() {
 		t.htmlEqual( ractive.find( '.result' ).innerHTML, '0' );
 	});
 
-	QUnit.test( 'Multiple events can share the same directive', t => {
+	test( 'Multiple events can share the same directive', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div on-click-mouseover="foo"></div>'
@@ -404,7 +405,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( 'Superfluous whitespace is ignored', t => {
+	test( 'Superfluous whitespace is ignored', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div class="one" on-click=" foo "></div><div class="two" {{#bar}}on-click=" bar "{{/}}></div>'
@@ -433,7 +434,7 @@ export default function() {
 		t.equal( barCount, 1 );
 	});
 
-	QUnit.test( '@index can be used in proxy event directives', t => {
+	test( '@index can be used in proxy event directives', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -454,7 +455,7 @@ export default function() {
 		fire( ractive.findAll( 'button[class=method]' )[1], 'click' );
 	});
 
-	QUnit.test( 'component "on-" supply own event proxy arguments (but original args are tacked on)', t => {
+	test( 'component "on-" supply own event proxy arguments (but original args are tacked on)', t => {
 		t.expect( 5 );
 
 		const Component = Ractive.extend({
@@ -489,7 +490,7 @@ export default function() {
 		component.fire( 'bizz', 'buzz' );
 	});
 
-	QUnit.test( 'component "on-" handles reproxy of arguments correctly', t => {
+	test( 'component "on-" handles reproxy of arguments correctly', t => {
 		t.expect( 5 );
 
 		const Component = Ractive.extend({
@@ -521,7 +522,7 @@ export default function() {
 		component.fire( 'bizz' );
 	});
 
-	QUnit.test( `event expressions that return an appropriately formed array fire a proxy event`, t => {
+	test( `event expressions that return an appropriately formed array fire a proxy event`, t => {
 		t.expect( 2 );
 
 		const r = new Ractive({
@@ -539,7 +540,7 @@ export default function() {
 	});
 
 	// This fails as of 0.8.0... does that matter? Seems unnecessary to support
-	//QUnit.test( 'Events really do not call addEventListener when no proxy name', t => {
+	//test( 'Events really do not call addEventListener when no proxy name', t => {
 	// 	var ractive,
 	// 		addEventListener = Element.prototype.addEventListener,
 	// 		errorAdd = function(){

--- a/tests/browser/events/expression.js
+++ b/tests/browser/events/expression.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule('event/expression.js');
 
-	QUnit.test( 'events can be handled as expressions', t => {
+	test( 'events can be handled as expressions', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<button on-click="@this.set('foo', 42)">click me</button>`,
@@ -17,7 +18,7 @@ export default function() {
 		t.equal( r.get( 'foo' ), 42 );
 	});
 
-	QUnit.test( 'expression events can handle arguments refs', t => {
+	test( 'expression events can handle arguments refs', t => {
 		t.expect(1);
 
 		const r = new Ractive({
@@ -31,7 +32,7 @@ export default function() {
 		r.getNodeInfo( 'button' ).raise( 'click', {}, 'foo' );
 	});
 
-	QUnit.test( 'expression events can handle dollar refs', t => {
+	test( 'expression events can handle dollar refs', t => {
 		t.expect(1);
 
 		const r = new Ractive({
@@ -45,7 +46,7 @@ export default function() {
 		r.getNodeInfo( 'button' ).raise( 'click', {}, 'foo' );
 	});
 
-	QUnit.test( 'expression events can handle spread args', t => {
+	test( 'expression events can handle spread args', t => {
 		t.expect(1);
 
 		const r = new Ractive({
@@ -59,7 +60,7 @@ export default function() {
 		r.getNodeInfo( 'button' ).raise( 'click', {}, 'foo' );
 	});
 
-	QUnit.test( 'expression events can handle argument keypath access', t => {
+	test( 'expression events can handle argument keypath access', t => {
 		t.expect(1);
 
 		const r = new Ractive({
@@ -73,7 +74,7 @@ export default function() {
 		r.getNodeInfo( 'button' ).raise( 'click', {}, 'foo' );
 	});
 
-	QUnit.test( 'expression events can handle dollar arg keypath access', t => {
+	test( 'expression events can handle dollar arg keypath access', t => {
 		t.expect(1);
 
 		const r = new Ractive({
@@ -87,7 +88,7 @@ export default function() {
 		r.getNodeInfo( 'button' ).raise( 'click', {}, 'foo' );
 	});
 
-	QUnit.test( 'expression events work with complex expressions', t => {
+	test( 'expression events work with complex expressions', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<button on-click="@this.set('foo', 42) && @this.toggle('bar')">click me</button>`
@@ -99,7 +100,7 @@ export default function() {
 		t.equal( r.get( 'bar' ), true );
 	});
 
-	QUnit.test( 'comma-ish operator can be used with expression events', t => {
+	test( 'comma-ish operator can be used with expression events', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<button on-click="@this.set('foo', 42), @this.toggle('bar')">click me</button>`

--- a/tests/browser/events/method-calls.js
+++ b/tests/browser/events/method-calls.js
@@ -1,11 +1,12 @@
 /*global window */
 import { fire } from 'simulant';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'events/method-calls.js' );
 
-	QUnit.test( 'Calling a builtin method', t => {
+	test( 'Calling a builtin method', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `<button on-click='@this.set("foo",foo+1)'>{{foo}}</button>`,
@@ -17,7 +18,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<button>1</button>' );
 	});
 
-	QUnit.test( 'Calling a custom method', t => {
+	test( 'Calling a custom method', t => {
 		t.expect( 2 );
 
 		const Widget = Ractive.extend({
@@ -35,7 +36,7 @@ export default function() {
 		fire( ractive.find( 'button' ), 'click' );
 	});
 
-	QUnit.test( 'Calling an unknown method', t => {
+	test( 'Calling an unknown method', t => {
 		t.expect( 1 );
 
 		const Widget = Ractive.extend({
@@ -60,7 +61,7 @@ export default function() {
 		window.onerror = onerror;
 	});
 
-	QUnit.test( 'Passing the event object to a method', t => {
+	test( 'Passing the event object to a method', t => {
 		t.expect( 1 );
 
 		const Widget = Ractive.extend({
@@ -77,7 +78,7 @@ export default function() {
 		fire( ractive.find( 'button' ), 'click' );
 	});
 
-	QUnit.test( 'Passing a child of the event object to a method', t => {
+	test( 'Passing a child of the event object to a method', t => {
 		t.expect( 1 );
 
 		const Widget = Ractive.extend({
@@ -95,7 +96,7 @@ export default function() {
 	});
 
 	// Bit of a cheeky workaround...
-	QUnit.test( 'Passing a reference to this.event', t => {
+	test( 'Passing a reference to this.event', t => {
 		t.expect( 1 );
 
 		const Widget = Ractive.extend({
@@ -115,7 +116,7 @@ export default function() {
 		fire( ractive.find( 'button' ), 'click' );
 	});
 
-	QUnit.test( 'Current event is available to method handler as this.event (#1403)', t => {
+	test( 'Current event is available to method handler as this.event (#1403)', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -130,7 +131,7 @@ export default function() {
 		fire( ractive.find( 'button' ), 'click' );
 	});
 
-	QUnit.test( 'component "on-" can call methods', t => {
+	test( 'component "on-" can call methods', t => {
 		t.expect( 2 );
 
 		const Component = Ractive.extend({
@@ -154,7 +155,7 @@ export default function() {
 		component.fire( 'bar', 'bar' );
 	});
 
-	QUnit.test( 'component "on-" with ...arguments', t => {
+	test( 'component "on-" with ...arguments', t => {
 		t.expect( 4 );
 
 		const Component = Ractive.extend({
@@ -180,7 +181,7 @@ export default function() {
 		component.fire( 'bar', 'bar', 100 );
 	});
 
-	QUnit.test( 'component "on-" with additive ...arguments', t => {
+	test( 'component "on-" with additive ...arguments', t => {
 		t.expect( 6 );
 
 		const Component = Ractive.extend({
@@ -208,7 +209,7 @@ export default function() {
 		component.fire( 'bar', 'bar', 100 );
 	});
 
-	QUnit.test( 'component "on-" with arguments[n]', t => {
+	test( 'component "on-" with arguments[n]', t => {
 		t.expect( 4 );
 
 		const Component = Ractive.extend({
@@ -234,7 +235,7 @@ export default function() {
 		component.fire( 'bar', 'bar' );
 	});
 
-	QUnit.test( 'component "on-" with $n', t => {
+	test( 'component "on-" with $n', t => {
 		t.expect( 4 );
 
 		const Component = Ractive.extend({
@@ -261,7 +262,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'preventDefault and stopPropagation if method returns false', t => {
+	test( 'preventDefault and stopPropagation if method returns false', t => {
 		t.expect( 6 );
 
 		const ractive = new Ractive({

--- a/tests/browser/events/misc.js
+++ b/tests/browser/events/misc.js
@@ -1,12 +1,13 @@
 import { fire } from 'simulant';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'events/misc.js' );
 
 	// TODO finish moving these into more sensible locations
 
-	QUnit.test( 'Grandchild component teardown when nested in element (#1360)', t => {
+	test( 'Grandchild component teardown when nested in element (#1360)', t => {
 		const torndown = [];
 
 		const Child = Ractive.extend({
@@ -50,7 +51,7 @@ export default function() {
 		t.equal( torndown.length, 4 );
 	});
 
-	QUnit.test( 'event references in method call handler should not create a null resolver (#1438)', t => {
+	test( 'event references in method call handler should not create a null resolver (#1438)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `{{#foo}}<button on-click="@this.test(event.keypath + '.foo')">Click</button>{{/}}`,
@@ -66,7 +67,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( 'event actions and parameter references have context', t => {
+	test( 'event actions and parameter references have context', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -88,7 +89,7 @@ export default function() {
 		fire( ractive.find( '#test1' ), 'click' );
 	});
 
-	QUnit.test( 'Attribute directives on fragments that get re-used (partials) should stick around for re-use', t => {
+	test( 'Attribute directives on fragments that get re-used (partials) should stick around for re-use', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#list}}{{>partial}}{{/}}',
@@ -110,7 +111,7 @@ export default function() {
 		t.equal( ractive.get( 'list.1.foo' ), 'b' );
 	});
 
-	QUnit.test( 'Regression test for #2046', t => {
+	test( 'Regression test for #2046', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -127,7 +128,7 @@ export default function() {
 		fire( el, 'click' );
 	});
 
-	QUnit.test( 'Regression test for #1971', t => {
+	test( 'Regression test for #1971', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -149,7 +150,7 @@ export default function() {
 		fire( el, 'click' );
 	});
 
-	QUnit.test( 'correct function scope for this.bar() in template', t => {
+	test( 'correct function scope for this.bar() in template', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -175,7 +176,7 @@ export default function() {
 		fire( document.createElement( 'div' ), 'input' );
 		fire( document.createElement( 'div' ), 'blur' );
 
-		QUnit.test( 'lazy may be overridden on a per-element basis', t => {
+		test( 'lazy may be overridden on a per-element basis', t => {
 			let ractive = new Ractive({
 				el: fixture,
 				template: '<input value="{{foo}}" lazy="true" />',
@@ -203,7 +204,7 @@ export default function() {
 			t.equal( ractive.get( 'foo' ), 'bar' );
 		});
 
-		QUnit.test( 'lazy may be set to a number to trigger on a timeout', t => {
+		test( 'lazy may be set to a number to trigger on a timeout', t => {
 			const done = t.async();
 
 			const ractive = new Ractive({
@@ -227,7 +228,7 @@ export default function() {
 			}, 30 );
 		});
 
-		QUnit.test( 'invalid content in method call event directive should have a reasonable error message', t => {
+		test( 'invalid content in method call event directive should have a reasonable error message', t => {
 			t.throws(() => {
 				new Ractive({
 					el: fixture,
@@ -239,7 +240,7 @@ export default function() {
 		// do nothing
 	}
 
-	QUnit.test( 'events in nested elements are torn down properly (#2608)', t => {
+	test( 'events in nested elements are torn down properly (#2608)', t => {
 		let count = 0;
 		const r = new Ractive({
 			el: fixture,
@@ -268,7 +269,7 @@ export default function() {
 		r.toggle( 'foo' );
 	});
 
-	QUnit.test( `a subscriber that cancels during event firing should not fire (#2698)`, t => {
+	test( `a subscriber that cancels during event firing should not fire (#2698)`, t => {
 		t.expect( 0 );
 
 		const r = new Ractive();
@@ -280,7 +281,7 @@ export default function() {
 		r.fire( 'foo' );
 	});
 
-	QUnit.test( `re-fired event names get the new name`, t => {
+	test( `re-fired event names get the new name`, t => {
 		t.expect( 1 );
 
 		const r = new Ractive({
@@ -294,7 +295,7 @@ export default function() {
 		fire( r.find( 'div' ), 'click' );
 	});
 
-	QUnit.test( `special ref @context is available to events and replaces event`, t => {
+	test( `special ref @context is available to events and replaces event`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `<div on-click="@.check(@context)" />`,
@@ -309,7 +310,7 @@ export default function() {
 		fire( r.find( 'div' ), 'click' );
 	});
 
-	QUnit.test( `the actual dom event is available as @event and event and original in @context`, t => {
+	test( `the actual dom event is available as @event and event and original in @context`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: '<div on-click="@.check(@event, @context)" />',
@@ -323,7 +324,7 @@ export default function() {
 		fire( r.find( 'div' ), 'click' );
 	});
 
-	QUnit.test( `custom event plugins can pass along a source dom event`, t => {
+	test( `custom event plugins can pass along a source dom event`, t => {
 		t.expect( 4 );
 
 		const r = new Ractive({
@@ -350,7 +351,7 @@ export default function() {
 		fire( r.find( 'div' ), 'click' );
 	});
 
-	QUnit.test( `the event directive's node is exposed as @node`, t => {
+	test( `the event directive's node is exposed as @node`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `{{#with foo}}<input twoway=false on-change="@context.set('.bar', @node.value)" />{{/with}}`,

--- a/tests/browser/events/this.event.js
+++ b/tests/browser/events/this.event.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'events/this.event.js' );
 
-	QUnit.test( 'this.event set to current event object', t => {
+	test( 'this.event set to current event object', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -19,7 +20,7 @@ export default function() {
 		fire( ractive.find( '#test' ), 'click' );
 	});
 
-	QUnit.test( 'this.event exists on ractive.fire()', t => {
+	test( 'this.event exists on ractive.fire()', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -37,7 +38,7 @@ export default function() {
 		ractive.fire( 'foo' );
 	});
 
-	QUnit.test( 'method calls that fire events do not clobber this.events', t => {
+	test( 'method calls that fire events do not clobber this.events', t => {
 		t.expect( 4 );
 
 		let methodEvent;

--- a/tests/browser/events/touch-events.js
+++ b/tests/browser/events/touch-events.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { onWarn, initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'events/touch-events.js' );
 
-	QUnit.test( 'touch events safe to include when they don\'t exist in browser', t => {
+	test( 'touch events safe to include when they don\'t exist in browser', t => {
 		t.expect( 1 );
 
 		onWarn( () => {} ); // suppress

--- a/tests/browser/forms.js
+++ b/tests/browser/forms.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { initModule } from '../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'forms.js' );
 
-	QUnit.test( 'Resetting a form resets an input with two-way binding', t => {
+	test( 'Resetting a form resets an input with two-way binding', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -27,7 +28,7 @@ export default function() {
 		t.equal( ractive.get( 'value' ), 'foo' );
 	});
 
-	QUnit.test( 'Resetting a form resets widgets with one-way bindings', t => {
+	test( 'Resetting a form resets widgets with one-way bindings', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -66,7 +67,7 @@ export default function() {
 		t.equal( nodes.textarea.value, 'qwert' );
 	});
 
-	QUnit.test( 'Resetting a form resets widgets with no bindings', t => {
+	test( 'Resetting a form resets widgets with no bindings', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -104,7 +105,7 @@ export default function() {
 		t.equal( nodes.textarea.value, 'qwert' );
 	});
 
-	QUnit.test( 'textarea with html content and no bindings should render the html text as a normal textarea would (#2198)', t => {
+	test( 'textarea with html content and no bindings should render the html text as a normal textarea would (#2198)', t => {
 		new Ractive({
 			el: fixture,
 			template: '<textarea><div class="foo"><strong>bar</strong></div><p>WAT</p></textarea>'
@@ -113,7 +114,7 @@ export default function() {
 		t.equal( fixture.querySelector( 'textarea' ).value, '<div class="foo"><strong>bar</strong></div><p>WAT</p>' );
 	});
 
-	QUnit.test( 'textareas without binding allow any template content (#2063)', t => {
+	test( 'textareas without binding allow any template content (#2063)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '<textarea><i>{{foo}}</i>{{bar}} {{{baz}}}</textarea>',
@@ -129,7 +130,7 @@ export default function() {
 		t.equal( fixture.querySelector( 'textarea' ).value, '<i>change1</i>change2 <strong>change3</strong>' );
 	});
 
-	QUnit.test( 'input that has binding change to undefined should be blank (#2279)', t => {
+	test( 'input that has binding change to undefined should be blank (#2279)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '<input value="{{foo}}" />'
@@ -140,7 +141,7 @@ export default function() {
 		t.equal( r.find( 'input' ).value, '' );
 	});
 
-	QUnit.test( 'forms should unrender properly #2352', t => {
+	test( 'forms should unrender properly #2352', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: 'foo: {{#if foo}}<form>Yep</form>{{/if}}',

--- a/tests/browser/getCSS.js
+++ b/tests/browser/getCSS.js
@@ -1,5 +1,6 @@
 import { initModule } from '../helpers/test-config';
 import { createIsolatedEnv } from '../helpers/Environment';
+import { test } from 'qunit';
 
 export default function() {
 	initModule('getCss.js');
@@ -16,7 +17,7 @@ export default function() {
 
 	}
 
-	QUnit.test('getCSS with a single component definition', t => {
+	test('getCSS with a single component definition', t => {
 
 		const Component = createComponentDefinition(Ractive);
 
@@ -27,7 +28,7 @@ export default function() {
 
 	});
 
-	QUnit.test('getCSS with multiple components definition', t => {
+	test('getCSS with multiple components definition', t => {
 
 		const ComponentA = createComponentDefinition(Ractive);
 
@@ -44,7 +45,7 @@ export default function() {
 	});
 
 	if (!window.__karma__) {
-		QUnit.test('getCSS with component definitions constructed from Ractive of different environments', t => {
+		test('getCSS with component definitions constructed from Ractive of different environments', t => {
 			t.expect(5);
 
 			const done1 = t.async();

--- a/tests/browser/init/config.js
+++ b/tests/browser/init/config.js
@@ -3,11 +3,12 @@ import config from '../../../src/Ractive/config/config';
 import registries from '../../../src/Ractive/config/registries';
 import { findInViewHierarchy } from '../../../src/shared/registry';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'init/config.js' );
 
-	QUnit.test( 'Ractive.defaults', t => {
+	test( 'Ractive.defaults', t => {
 		t.equal( Ractive.defaults, Ractive.prototype, 'defaults aliases prototype' );
 
 		for( const key in defaults ) {
@@ -15,7 +16,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'instance has config options', t => {
+	test( 'instance has config options', t => {
 		const ractive = new Ractive();
 		const registryNames = registries.map( r => r.name );
 
@@ -32,7 +33,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'find registry in hierarchy', t => {
+	test( 'find registry in hierarchy', t => {
 		const adaptor1 = {};
 		const adaptor2 = {};
 		const parent = new Ractive( { adaptors: { foo: adaptor1 } } );
@@ -44,7 +45,7 @@ export default function() {
 		t.equal( findInViewHierarchy( 'adaptors', ractive, 'bar' ), adaptor2 );
 	});
 
-	QUnit.test( 'non-configurations options are added to instance', t => {
+	test( 'non-configurations options are added to instance', t => {
 		const ractive = new Ractive({
 			foo: 'bar',
 			fumble () {
@@ -56,7 +57,7 @@ export default function() {
 		t.ok( ractive.fumble() );
 	});
 
-	QUnit.test( 'target element can be specified with target as well as el (#1848)', t => {
+	test( 'target element can be specified with target as well as el (#1848)', t => {
 		const r = new Ractive({
 			target: fixture,
 			template: 'yep'
@@ -67,7 +68,7 @@ export default function() {
 		t.strictEqual( fixture, r.el );
 	});
 
-	QUnit.test( 'events can be subscribed with the on option', t => {
+	test( 'events can be subscribed with the on option', t => {
 		t.expect( 2 );
 
 		const r = new Ractive({
@@ -85,7 +86,7 @@ export default function() {
 		r.fire( 'bar' );
 	});
 
-	QUnit.test( 'observers can be subscribed with the observe option', t => {
+	test( 'observers can be subscribed with the observe option', t => {
 		t.expect( 4 );
 
 		const r = new Ractive({

--- a/tests/browser/init/extend.js
+++ b/tests/browser/init/extend.js
@@ -1,9 +1,10 @@
 import { hasUsableConsole, onWarn, initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'init/extend.js' );
 
-	QUnit.test( 'multiple options arguments applied left to right', t => {
+	test( 'multiple options arguments applied left to right', t => {
 		const X = Ractive.extend({
 			template: 'ignore',
 			data: { foo: 'foo' }
@@ -24,7 +25,7 @@ export default function() {
 		t.equal( ractive.template, 'good' );
 	});
 
-	QUnit.test( 'data is inherited from grand parent extend (#923)', t => {
+	test( 'data is inherited from grand parent extend (#923)', t => {
 		const Child = Ractive.extend({
 			append: true,
 			template: 'title:{{format(title)}}',
@@ -50,7 +51,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'title:CHILDtitle:GRANDCHILD' );
 	});
 
-	QUnit.test( 'instantiated .extend() component with data function called on initialize', t => {
+	test( 'instantiated .extend() component with data function called on initialize', t => {
 		const data = { foo: 'bar' };
 
 		const Component = Ractive.extend({
@@ -61,7 +62,7 @@ export default function() {
 		t.strictEqual( ractive.viewmodel.value, data );
 	});
 
-	QUnit.test( 'extend data option includes Ractive defaults.data', t => {
+	test( 'extend data option includes Ractive defaults.data', t => {
 		const defaultData = Ractive.defaults.data;
 		Ractive.defaults.data = {
 			format () { return 'default'; },
@@ -89,7 +90,7 @@ export default function() {
 		Ractive.defaults.data = defaultData;
 	});
 
-	QUnit.test( 'instantiated .extend() with template function called on initialize', t => {
+	test( 'instantiated .extend() with template function called on initialize', t => {
 		const Component = Ractive.extend({
 			template () { return '{{foo}}'; }
 		});
@@ -102,7 +103,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'extend template replaces Ractive defaults.template', t => {
+	test( 'extend template replaces Ractive defaults.template', t => {
 		const defaultTemplate = Ractive.defaults.template;
 		Ractive.defaults.template = function () { return '{{fizz}}'; };
 
@@ -120,7 +121,7 @@ export default function() {
 		Ractive.defaults.template = defaultTemplate;
 	});
 
-	QUnit.test( '"this" refers to ractive instance in init method with _super (#840)', t => {
+	test( '"this" refers to ractive instance in init method with _super (#840)', t => {
 		t.expect( 4 );
 
 		let cThis;
@@ -149,7 +150,7 @@ export default function() {
 	});
 
 
-	QUnit.test( '"parent" and "root" properties are correctly set', t => {
+	test( '"parent" and "root" properties are correctly set', t => {
 		const GrandChild = Ractive.extend({
 			template: 'this space for rent'
 		});
@@ -179,7 +180,7 @@ export default function() {
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'data function returning wrong value causes error/warning', t => {
+		test( 'data function returning wrong value causes error/warning', t => {
 			// non-objects are an error
 			const Bad = Ractive.extend({
 				data () {
@@ -206,7 +207,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'children inherit subscribers', t => {
+	test( 'children inherit subscribers', t => {
 		t.expect( 7 );
 
 		const cmp = Ractive.extend({
@@ -235,7 +236,7 @@ export default function() {
 		r.toggle( 'bar' );
 	});
 
-	QUnit.test( `an existing constructor can be specified using the class option`, t => {
+	test( `an existing constructor can be specified using the class option`, t => {
 		class Foo extends Ractive {
 			constructor ( opts ) {
 				super( opts );
@@ -258,7 +259,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'hello, classy' );
 	});
 
-	QUnit.test( `existing constructors supplied to extend should inherit from Ractive`, t => {
+	test( `existing constructors supplied to extend should inherit from Ractive`, t => {
 		t.expect( 1 );
 
 		class Foo {}
@@ -268,7 +269,7 @@ export default function() {
 		}, /inherit the appropriate prototype/ );
 	});
 
-	QUnit.test( `existing constructors supplied to extend should call super`, t => {
+	test( `existing constructors supplied to extend should call super`, t => {
 		t.expect( 1 );
 
 		class Foo extends Ractive {}
@@ -278,7 +279,7 @@ export default function() {
 		}, /call super/ );
 	});
 
-	QUnit.test( `multiple construction objects with functions passed to extend are layered correctly`, t => {
+	test( `multiple construction objects with functions passed to extend are layered correctly`, t => {
 		t.expect( 5 );
 
 		let count = 0;
@@ -316,7 +317,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '1 2' );
 	});
 
-	QUnit.test( `trying to extend with a component  arg throws`, t => {
+	test( `trying to extend with a component  arg throws`, t => {
 		const cmp = Ractive.extend();
 		t.throws( () => {
 			Ractive.extend( cmp );

--- a/tests/browser/init/hooks/misc.js
+++ b/tests/browser/init/hooks/misc.js
@@ -1,9 +1,10 @@
 import { hasUsableConsole, onWarn, onLog, initModule } from '../../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'init/hooks/misc.js' );
 
-	QUnit.test( 'detach and insert hooks fire', t => {
+	test( 'detach and insert hooks fire', t => {
 		const fired = [];
 
 		const ractive = new Ractive({
@@ -23,7 +24,7 @@ export default function() {
 		t.deepEqual( fired, [ 'ondetach', 'oninsert' ] );
 	});
 
-	QUnit.test( 'late-comer components on render still fire init', t => {
+	test( 'late-comer components on render still fire init', t => {
 		const Widget = Ractive.extend({
 			template: '{{~/init}}',
 			oninit () {
@@ -47,7 +48,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'yes' );
 	});
 
-	QUnit.test( 'component with data dependency can be found in oninit', t => {
+	test( 'component with data dependency can be found in oninit', t => {
 		const Component = Ractive.extend();
 		let component = null;
 
@@ -62,7 +63,7 @@ export default function() {
 		t.ok( component );
 	});
 
-	QUnit.test( 'render hooks are not fired until after DOM updates (#1367)', t => {
+	test( 'render hooks are not fired until after DOM updates (#1367)', t => {
 		t.expect( 0 );
 
 		const ractive = new Ractive({
@@ -92,7 +93,7 @@ export default function() {
 		ractive.set( 'bool', true );
 	});
 
-	QUnit.test( 'correct behaviour of deprecated beforeInit hook (#1395)', t => {
+	test( 'correct behaviour of deprecated beforeInit hook (#1395)', t => {
 		t.expect( 6 );
 
 		let count;
@@ -136,7 +137,7 @@ export default function() {
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'error in oncomplete sent to console', t => {
+		test( 'error in oncomplete sent to console', t => {
 			t.expect( 2 );
 
 			const done = t.async();
@@ -168,7 +169,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'hooks include the source ractive instance as the last argument', t => {
+	test( 'hooks include the source ractive instance as the last argument', t => {
 		const done = t.async();
 		t.expect( 3 );
 

--- a/tests/browser/init/hooks/onconstruct.js
+++ b/tests/browser/init/hooks/onconstruct.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'init/hooks/onconstruct.js' );
 
-	QUnit.test( 'has access to options', t => {
+	test( 'has access to options', t => {
 		const View = Ractive.extend({
 			onconstruct ( ctx, options ){
 				options.template = '{{foo}}';

--- a/tests/browser/init/hooks/order.js
+++ b/tests/browser/init/hooks/order.js
@@ -1,4 +1,5 @@
 import { initModule } from '../../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'init/hooks/order.js' );
@@ -11,7 +12,7 @@ export default function() {
 		'onteardown'
 	];
 
-	QUnit.test( 'basic order', t => {
+	test( 'basic order', t => {
 		const options = {
 			el: fixture,
 			template: 'foo'
@@ -40,7 +41,7 @@ export default function() {
 		t.deepEqual( fired, [ 'onconstruct' ].concat( hooks ) );
 	});
 
-	QUnit.test( 'hooks call _super', t => {
+	test( 'hooks call _super', t => {
 		const superOptions = {};
 		let options = {};
 
@@ -75,7 +76,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Component hooks called in consistent order (gh #589)', t => {
+	test( 'Component hooks called in consistent order (gh #589)', t => {
 		const done = t.async();
 
 		// construct and config temporarily commented out, see #1381
@@ -160,7 +161,7 @@ export default function() {
 	});
 
 	function testHierarchy ( hook, expected ) {
-		QUnit.test( hook, t => {
+		test( hook, t => {
 			const done = t.async();
 
 			const fired = [];
@@ -211,7 +212,7 @@ export default function() {
 	testHierarchy( 'onunrender', bottomUp );
 	testHierarchy( 'onteardown', bottomUp );
 
-	QUnit.test( 'destruct hook fires after everything is completely torn down, including element removal after transitions', t => {
+	test( 'destruct hook fires after everything is completely torn down, including element removal after transitions', t => {
 		const done = t.async();
 
 		let finish;

--- a/tests/browser/init/initialisation/data.js
+++ b/tests/browser/init/initialisation/data.js
@@ -1,4 +1,5 @@
 import { hasUsableConsole, afterEach, onWarn, initModule } from '../../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	const defaultData = Ractive.defaults.data;
@@ -11,7 +12,7 @@ export default function() {
 
 	initModule( 'init/initialisation/data.js' );
 
-	QUnit.test( 'default data function called on initialize', t => {
+	test( 'default data function called on initialize', t => {
 		const data = { foo: 'bar' } ;
 
 		Ractive.defaults.data = function () { return data; };
@@ -19,7 +20,7 @@ export default function() {
 		t.strictEqual( ractive.viewmodel.value, data );
 	});
 
-	QUnit.test( 'instance data function called on initialize', t => {
+	test( 'instance data function called on initialize', t => {
 		const data = { foo: 'bar' } ;
 
 		const ractive = new Ractive({
@@ -29,7 +30,7 @@ export default function() {
 	});
 
 	// TODO is this important/desirable?
-	//QUnit.test( 'Instance data is used as data object when parent is also object', t => {
+	//test( 'Instance data is used as data object when parent is also object', t => {
 	//
 	// 	var ractive, data = { foo: 'bar' };
 	//
@@ -40,7 +41,7 @@ export default function() {
 	// });
 
 	// TODO see above...
-	//QUnit.test( 'Data functions are inherited and pojo keys are copied', t => {
+	//test( 'Data functions are inherited and pojo keys are copied', t => {
 	// 	var ractive, data1 = { bizz: 'bop' }, data2 = { foo: 'bar' };
 	//
 	// 	Ractive.defaults.data = function () { return data1; };
@@ -51,7 +52,7 @@ export default function() {
 	// 	t.equal( ractive.get('bizz'), 'bop' );
 	// });
 
-	QUnit.test( 'instance data function is added to default data function', t => {
+	test( 'instance data function is added to default data function', t => {
 		Ractive.defaults.data = () => ({ foo: 'fizz' });
 
 		const ractive = new Ractive({
@@ -65,7 +66,7 @@ export default function() {
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'initing data with a non-POJO results in a warning', t => {
+		test( 'initing data with a non-POJO results in a warning', t => {
 			t.expect( 2 );
 
 			onWarn( warning => {
@@ -84,7 +85,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'instance data takes precedence over default data but includes unique properties', t => {
+	test( 'instance data takes precedence over default data but includes unique properties', t => {
 		Ractive.defaults.data = {
 			unique () { return; },
 			format () { return 'not me'; }
@@ -103,7 +104,7 @@ export default function() {
 		t.equal( ractive.get( 'format' )(), 'foo' );
 	});
 
-	QUnit.test( 'initing data with a primitive results in an error', t => {
+	test( 'initing data with a primitive results in an error', t => {
 		t.expect( 1 );
 
 		try {
@@ -117,7 +118,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'data and computed properties available in onconfig and later', t => {
+	test( 'data and computed properties available in onconfig and later', t => {
 		t.expect( 3 );
 
 		const ractive = new Ractive({

--- a/tests/browser/init/initialisation/misc.js
+++ b/tests/browser/init/initialisation/misc.js
@@ -1,15 +1,16 @@
 import { hasUsableConsole, onWarn, initModule } from '../../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'init/initialisation/misc.js' );
 
-	QUnit.test( 'initialize with no options ok', t => {
+	test( 'initialize with no options ok', t => {
 		const ractive = new Ractive();
 		t.ok( ractive );
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'functions that conflict with default properties are ignored and trigger warning', t => {
+		test( 'functions that conflict with default properties are ignored and trigger warning', t => {
 			let warned;
 			onWarn( message => warned = message );
 

--- a/tests/browser/init/initialisation/template.js
+++ b/tests/browser/init/initialisation/template.js
@@ -1,4 +1,5 @@
 import { afterEach, initModule } from '../../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	const defaultData = Ractive.defaults.data;
@@ -20,7 +21,7 @@ export default function() {
 		script.textContent = template;
 	}
 
-	QUnit.test( 'hash is retrieved from element Id', t => {
+	test( 'hash is retrieved from element Id', t => {
 		createScriptTemplate( '{{foo}}' );
 
 		new Ractive({
@@ -32,7 +33,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'non-existant element id throws', t => {
+	test( 'non-existant element id throws', t => {
 		t.throws( () => {
 			new Ractive({
 				el: fixture,
@@ -41,7 +42,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Ractive.defaults.template used on initialize', t => {
+	test( 'Ractive.defaults.template used on initialize', t => {
 		Ractive.defaults.template = '{{foo}}';
 
 		new Ractive({
@@ -52,7 +53,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'Ractive.defaults.template function called on initialize', t => {
+	test( 'Ractive.defaults.template function called on initialize', t => {
 		Ractive.defaults.template = () => '{{foo}}';
 
 		new Ractive( {
@@ -63,7 +64,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'template function has helper object', t => {
+	test( 'template function has helper object', t => {
 		t.expect( 3 );
 
 		createScriptTemplate( '{{foo}}' );
@@ -85,7 +86,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'fizzbizz' );
 	});
 
-	QUnit.test( 'non-script tag for template throws error', t => {
+	test( 'non-script tag for template throws error', t => {
 		const div = document.createElement( 'DIV' );
 		div.id = 'template';
 		fixture.appendChild( div );

--- a/tests/browser/init/insertion.js
+++ b/tests/browser/init/insertion.js
@@ -1,4 +1,5 @@
 import { beforeEach, initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	let target;
@@ -18,7 +19,7 @@ export default function() {
 
 	initModule( 'init/insertion.js' );
 
-	QUnit.test( 'Element by id selector', t => {
+	test( 'Element by id selector', t => {
 		new Ractive({
 			el: '#target',
 			template: '<div>foo</div>'
@@ -27,7 +28,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="target"><div>foo</div></div>' );
 	});
 
-	QUnit.test( 'Element by id (hashless)', t => {
+	test( 'Element by id (hashless)', t => {
 		new Ractive({
 			el: 'target',
 			template: '<div>foo</div>'
@@ -36,7 +37,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="target"><div>foo</div></div>' );
 	});
 
-	QUnit.test( 'Element by query selector', t => {
+	test( 'Element by query selector', t => {
 		new Ractive({
 			el: 'div[id=target]',
 			template: '<div>foo</div>'
@@ -45,7 +46,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="target"><div>foo</div></div>' );
 	});
 
-	QUnit.test( 'Element by node', t => {
+	test( 'Element by node', t => {
 		new Ractive({
 			el: target,
 			template: '<div>foo</div>'
@@ -54,7 +55,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="target"><div>foo</div></div>' );
 	});
 
-	QUnit.test( 'Element by nodelist', t => {
+	test( 'Element by nodelist', t => {
 		new Ractive({
 			el: fixture.querySelectorAll('div'),
 			template: '<div>foo</div>'
@@ -63,7 +64,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="target"><div>foo</div></div>' );
 	});
 
-	QUnit.test( 'Element by any array-like', t => {
+	test( 'Element by any array-like', t => {
 		new Ractive({
 			el: [target],
 			template: '<div>foo</div>'
@@ -72,7 +73,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="target"><div>foo</div></div>' );
 	});
 
-	QUnit.test( 'Default replaces content', t => {
+	test( 'Default replaces content', t => {
 		new Ractive({
 			el: target,
 			template: '<div>foo</div>'
@@ -81,7 +82,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="target"><div>foo</div></div>' );
 	});
 
-	QUnit.test( 'Default replaces content', t => {
+	test( 'Default replaces content', t => {
 		new Ractive({
 			el: target,
 			template: '<div>foo</div>'
@@ -90,7 +91,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="target"><div>foo</div></div>' );
 	});
 
-	QUnit.test( 'Append false (normal default) replaces content', t => {
+	test( 'Append false (normal default) replaces content', t => {
 		new Ractive({
 			el: target,
 			template: '<div>foo</div>',
@@ -100,7 +101,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="target"><div>foo</div></div>' );
 	});
 
-	QUnit.test( 'Append true option inserts as last child node', t => {
+	test( 'Append true option inserts as last child node', t => {
 		new Ractive({
 			el: target,
 			template: '<div>foo</div>',
@@ -110,7 +111,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="target"><div>bar</div><div>foo</div></div>' );
 	});
 
-	QUnit.test( 'Append with anchor inserts before anchor', t => {
+	test( 'Append with anchor inserts before anchor', t => {
 		new Ractive({
 			el: target,
 			template: '<div>foo</div>',

--- a/tests/browser/init/registries.js
+++ b/tests/browser/init/registries.js
@@ -1,10 +1,11 @@
 import registries from '../../../src/Ractive/config/registries';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'init/registries.js' );
 
-	QUnit.test( 'has globally registered', t => {
+	test( 'has globally registered', t => {
 		const foo = {};
 
 		registries.forEach( r => {

--- a/tests/browser/init/template.js
+++ b/tests/browser/init/template.js
@@ -2,6 +2,7 @@ import { beforeEach, initModule } from '../../helpers/test-config';
 import { TEMPLATE_VERSION } from '../../../src/config/template';
 import config from '../../../src/Ractive/config/custom/template';
 import { isObject } from '../../../src/utils/is';
+import { test } from 'qunit';
 
 export default function() {
 	let MockRactive;
@@ -32,7 +33,7 @@ export default function() {
 		config.extend( MockRactive, Component.prototype, template || {} );
 	}
 
-	QUnit.test( 'Default create', t => {
+	test( 'Default create', t => {
 		const template = MockRactive.defaults.template;
 
 		t.ok( template, 'on defaults' );
@@ -42,7 +43,7 @@ export default function() {
 		t.equal( template.t.length, 0, 'main template has no items' );
 	});
 
-	QUnit.test( 'Empty extend inherits parent', t => {
+	test( 'Empty extend inherits parent', t => {
 		mockExtend();
 		const template = Component.defaults.template;
 
@@ -53,12 +54,12 @@ export default function() {
 		t.equal( template.t.length, 0, 'main template has no items' );
 	});
 
-	QUnit.test( 'Extend with template', t => {
+	test( 'Extend with template', t => {
 		mockExtend( templateOpt1 );
 		t.deepEqual( Component.defaults.template, { v: TEMPLATE_VERSION, t: [{ r: 'foo', t: 2 }] } );
 	});
 
-	QUnit.test( 'Extend twice with different templates', t => {
+	test( 'Extend twice with different templates', t => {
 		config.extend( MockRactive, Component.prototype, templateOpt1 );
 		const Child = Object.create( Component );
 		config.extend( Component, Child.prototype, templateOpt2 );
@@ -66,33 +67,33 @@ export default function() {
 		t.deepEqual( Child.prototype.template, { v: TEMPLATE_VERSION, t: [{ r: 'bar', t: 2 }] } );
 	});
 
-	QUnit.test( 'Init template', t => {
+	test( 'Init template', t => {
 		config.init( MockRactive, ractive, templateOpt1 );
 
 		t.ok( !ractive.defaults );
 		t.deepEqual( ractive.template, [{ r: 'foo', t: 2 }] );
 	});
 
-	QUnit.test( 'Init with pure string template', t => {
+	test( 'Init with pure string template', t => {
 		config.init( MockRactive, ractive, { template: 'foo' } );
 		t.equal( ractive.template, 'foo' );
 	});
 
-	QUnit.test( 'Init take precedence over default', t => {
+	test( 'Init take precedence over default', t => {
 		config.extend( MockRactive, Component.prototype, templateOpt1 );
 		config.init( Component, ractive, templateOpt2 );
 
 		t.deepEqual( ractive.template, [{ r: 'bar', t: 2 }] );
 	});
 
-	QUnit.test( 'Extend with template function', t => {
+	test( 'Extend with template function', t => {
 		config.extend( MockRactive, Component.prototype, templateOpt1fn );
 		config.init( Component, ractive, {} );
 
 		t.deepEqual( ractive.template, [{ r: 'foo', t: 2 }] );
 	});
 
-	QUnit.test( 'Extend uses child parse options', t => {
+	test( 'Extend uses child parse options', t => {
 		Component.defaults.delimiters = [ '<#', '#>' ];
 
 		config.extend( MockRactive, Component.prototype, { template: '<#foo#>' } );
@@ -101,12 +102,12 @@ export default function() {
 		t.deepEqual( ractive.template, [{ r: 'foo', t: 2 }] );
 	});
 
-	QUnit.test( 'Init with template function', t => {
+	test( 'Init with template function', t => {
 		config.init( MockRactive, ractive, templateOpt1fn );
 		t.deepEqual( ractive.template, [{ r: 'foo', t: 2 }] );
 	});
 
-	QUnit.test( 'Overwrite after extend before init', t => {
+	test( 'Overwrite after extend before init', t => {
 		config.extend( MockRactive, Component.prototype, templateOpt1 );
 		Component.defaults.template = templateOpt2.template;
 
@@ -114,7 +115,7 @@ export default function() {
 		t.deepEqual( ractive.template, [{ r: 'bar', t: 2 }] );
 	});
 
-	QUnit.test( 'Template with partial', t => {
+	test( 'Template with partial', t => {
 		ractive.partials = {};
 
 		config.init( MockRactive, ractive, {
@@ -126,7 +127,7 @@ export default function() {
 		t.deepEqual( ractive.partials.bar, [{ r: 'bar', t: 2 }] );
 	});
 
-	QUnit.test( 'Template with partial extended', t => {
+	test( 'Template with partial extended', t => {
 		const options = { template: '{{foo}}{{#partial bar}}{{bar}}{{/partial}}' };
 
 		Component.partials = {};
@@ -135,7 +136,7 @@ export default function() {
 		t.deepEqual( Component.defaults.template, { v: TEMPLATE_VERSION, t: [{r: 'foo', t: 2 } ], p: {bar: [{r: 'bar', t: 2 } ] } });
 	});
 
-	QUnit.test( 'Template with partial added and takes precedence over option partials', t => {
+	test( 'Template with partial added and takes precedence over option partials', t => {
 		ractive.partials = {
 			bar: '{{bop}}',
 			bizz: '{{buzz}}'

--- a/tests/browser/methods/add.js
+++ b/tests/browser/methods/add.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/add.js' );
 
-	QUnit.test( 'ractive.add("foo") adds 1 to the value of foo', t => {
+	test( 'ractive.add("foo") adds 1 to the value of foo', t => {
 		const ractive = new Ractive({
 			data: { foo: 0 }
 		});
@@ -15,7 +16,7 @@ export default function() {
 		t.equal( ractive.get( 'foo' ), 2 );
 	});
 
-	QUnit.test( 'ractive.add("foo",x) adds x to the value of foo', t => {
+	test( 'ractive.add("foo",x) adds x to the value of foo', t => {
 		const ractive = new Ractive({
 			data: { foo: 0 }
 		});
@@ -27,7 +28,7 @@ export default function() {
 		t.equal( ractive.get( 'foo' ), 5 );
 	});
 
-	QUnit.test( 'non-numeric values are an error', t => {
+	test( 'non-numeric values are an error', t => {
 		const ractive = new Ractive({
 			data: { foo: 'potato' }
 		});
@@ -35,7 +36,7 @@ export default function() {
 		t.throws( () => ractive.add( 'foo' ), /Cannot add to a non-numeric value/ );
 	});
 
-	QUnit.test( 'each keypath that matches a wildcard is added to individually (#1604)', t => {
+	test( 'each keypath that matches a wildcard is added to individually (#1604)', t => {
 		const items = [
 			{ count: 1 },
 			{ count: 2 },

--- a/tests/browser/methods/animate.js
+++ b/tests/browser/methods/animate.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/animate.js' );
 
-	QUnit.test( 'Values that cannot be interpolated change to their final value immediately', t => {
+	test( 'Values that cannot be interpolated change to their final value immediately', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<p>{{name}}</p>',
@@ -16,7 +17,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>bar</p>' );
 	});
 
-	QUnit.test( 'ractive.animate() returns a promise that resolves when the animation completes (#1047)', t => {
+	test( 'ractive.animate() returns a promise that resolves when the animation completes (#1047)', t => {
 		const done = t.async();
 
 		const ractive = new Ractive({
@@ -31,7 +32,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'ractive.animate() returns a promise even if nothing changes', t => {
+	test( 'ractive.animate() returns a promise even if nothing changes', t => {
 		t.expect( 3 );
 
 		const ractive = new Ractive();
@@ -42,7 +43,7 @@ export default function() {
 		t.ok( promise.stop );
 	});
 
-	QUnit.test( `ractive.animate() on a linked path returns a promise`, t => {
+	test( `ractive.animate() on a linked path returns a promise`, t => {
 		const done = t.async();
 
 		const r = new Ractive({
@@ -62,7 +63,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'all animations are updated in a single batch', t => {
+	test( 'all animations are updated in a single batch', t => {
 		const done = t.async();
 
 		let fooSteps = 0;
@@ -109,7 +110,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'animations cancel existing animations on the same keypath', t => {
+	test( 'animations cancel existing animations on the same keypath', t => {
 		t.expect( 1 );
 
 		const done = t.async();
@@ -138,7 +139,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'set operations cancel existing animations on the same keypath', t => {
+	test( 'set operations cancel existing animations on the same keypath', t => {
 		t.expect( 1 );
 
 		const done = t.async();
@@ -166,7 +167,7 @@ export default function() {
 		setTimeout( done, 50 );
 	});
 
-	QUnit.test( 'interpolates correctly between objects with identical properties', t => {
+	test( 'interpolates correctly between objects with identical properties', t => {
 		t.expect( 3 );
 
 		const done = t.async();
@@ -194,7 +195,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Named easing functions are taken from the instance', t => {
+	test( 'Named easing functions are taken from the instance', t => {
 		t.expect( 0 );
 
 		const ractive = new Ractive({
@@ -204,7 +205,7 @@ export default function() {
 		ractive.animate( 'x', 1, { easing: 'easeOut' });
 	});
 
-	QUnit.test( `animating an array animates the values in the array`, t => {
+	test( `animating an array animates the values in the array`, t => {
 		const done = t.async();
 
 		const r = new Ractive({

--- a/tests/browser/methods/attachChild.js
+++ b/tests/browser/methods/attachChild.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/attachChild.js' );
 
-	QUnit.test( 'child instances can be attached to an anchor', t => {
+	test( 'child instances can be attached to an anchor', t => {
 		const r1 = new Ractive({
 			template: '<#foo />',
 			el: fixture
@@ -17,7 +18,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'hello' );
 	});
 
-	QUnit.test( 'targeted child instances are rendered and unrendered with their anchor', t => {
+	test( 'targeted child instances are rendered and unrendered with their anchor', t => {
 		const r1 = new Ractive({
 			template: '{{#if show}}<#foo />{{/if}}',
 			el: fixture
@@ -35,7 +36,7 @@ export default function() {
 		t.equal( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( 'non-targeted instances stay where they are when attached', t => {
+	test( 'non-targeted instances stay where they are when attached', t => {
 		fixture.innerHTML = '<div id="r1"></div><div id="r2"></div>';
 		const r1 = new Ractive({
 			el: fixture.children[0],
@@ -51,7 +52,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1</div><div id="r2">r2</div>' );
 	});
 
-	QUnit.test( 'targeted instances are unrendered before being attached', t => {
+	test( 'targeted instances are unrendered before being attached', t => {
 		fixture.innerHTML = '<div id="r1"></div><div id="r2"></div>';
 		const r1 = new Ractive({
 			el: fixture.children[0],
@@ -67,7 +68,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1r2</div><div id="r2"></div>' );
 	});
 
-	QUnit.test( 'targeted instances are unrendered event if their anchor doesn\'t exist when attached', t => {
+	test( 'targeted instances are unrendered event if their anchor doesn\'t exist when attached', t => {
 		fixture.innerHTML = '<div id="r1"></div><div id="r2"></div>';
 		const r1 = new Ractive({
 			el: fixture.children[0],
@@ -83,7 +84,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="r1">r1</div><div id="r2"></div>' );
 	});
 
-	QUnit.test( 'anchors render the attached chile with an index corresponding to their position in the template', t => {
+	test( 'anchors render the attached chile with an index corresponding to their position in the template', t => {
 		const r1 = new Ractive({
 			template: '<#foo />',
 			el: fixture
@@ -106,7 +107,7 @@ export default function() {
 		t.equal( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( 'same-named anchors distribute multiple attached children in template order by attached index', t => {
+	test( 'same-named anchors distribute multiple attached children in template order by attached index', t => {
 		const r1 = new Ractive({
 			template: '{{#each @this.children.byName.foo}}<#foo />{{/each}}',
 			el: fixture
@@ -129,7 +130,7 @@ export default function() {
 		t.equal( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( 'attached children\'s events bubble to the parent', t => {
+	test( 'attached children\'s events bubble to the parent', t => {
 		fixture.innerHTML = '<div id="r1"></div><div id="r2"></div>';
 		const r1 = new Ractive({
 			el: fixture.children[0],
@@ -153,7 +154,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( 'attaching an already attached child throws an appropriate error', t => {
+	test( 'attaching an already attached child throws an appropriate error', t => {
 		const r1 = new Ractive({});
 		const r2 = new Ractive({});
 
@@ -164,7 +165,7 @@ export default function() {
 		}, /already attached.*this instance/ );
 	});
 
-	QUnit.test( 'attaching child that is attached elsewhere throws an appropriate error', t => {
+	test( 'attaching child that is attached elsewhere throws an appropriate error', t => {
 		const r1 = new Ractive({});
 		const r2 = new Ractive({});
 		const r3 = new Ractive({});
@@ -176,7 +177,7 @@ export default function() {
 		}, /already attached.*different instance/ );
 	});
 
-	QUnit.test( `attaching and detaching a child triggers transitions`, t => {
+	test( `attaching and detaching a child triggers transitions`, t => {
 		let ins = 0;
 		let outs = 0;
 		function go ( trans ) {
@@ -201,7 +202,7 @@ export default function() {
 		t.equal( outs, 1 );
 	});
 
-	QUnit.test( `transitions while detaching and reattaching child should carry on`, t => {
+	test( `transitions while detaching and reattaching child should carry on`, t => {
 		let ins = 0;
 		let outs = 0;
 		const done = t.async();
@@ -239,7 +240,7 @@ export default function() {
 		}, 60 );
 	});
 
-	QUnit.test( `anchors can supply mappings`, t => {
+	test( `anchors can supply mappings`, t => {
 		const r1 = new Ractive({
 			template: '{{foo}}'
 		});
@@ -262,7 +263,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( `children default to attach append`, t => {
+	test( `children default to attach append`, t => {
 		const r1 = new Ractive({
 			template: 'r1'
 		});
@@ -283,7 +284,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'r1r2r3' );
 	});
 
-	QUnit.test( `children can be attached prepend`, t => {
+	test( `children can be attached prepend`, t => {
 		const r1 = new Ractive({
 			template: 'r1'
 		});
@@ -300,7 +301,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'r2r1' );
 	});
 
-	QUnit.test( `children can be inserted at a specific index`, t => {
+	test( `children can be inserted at a specific index`, t => {
 		const r1 = new Ractive({
 			template: 'r1'
 		});
@@ -325,7 +326,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'r1r4r3r2' );
 	});
 
-	QUnit.test( `attached children can have their templates reset`, t => {
+	test( `attached children can have their templates reset`, t => {
 		fixture.innerHTML = '<div id="r1-spot"></div><div id="r2-spot"></div>';
 		const r1 = new Ractive({
 			el: fixture.querySelector( '#r1-spot' ),
@@ -343,7 +344,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="r1-spot">hey1</div><div id="r2-spot">hey2</div>' );
 	});
 
-	QUnit.test( `attached anchored children can have their templates reset`, t => {
+	test( `attached anchored children can have their templates reset`, t => {
 		const r1 = new Ractive({
 			template: 'r1'
 		});
@@ -358,7 +359,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'hey1' );
 	});
 
-	QUnit.test( `attached anchored children can be supplied with inline partials`, t => {
+	test( `attached anchored children can be supplied with inline partials`, t => {
 		const r1 = new Ractive({
 			template: '{{>thing}}{{>content}}'
 		});
@@ -372,7 +373,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yepmaybe' );
 	});
 
-	QUnit.test( `anchors attach and detach event proxies`, t => {
+	test( `anchors attach and detach event proxies`, t => {
 		let count = 0;
 		const r1 = new Ractive({
 			template: ''
@@ -391,7 +392,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( 'attached children have their parent and root ref updated', t => {
+	test( 'attached children have their parent and root ref updated', t => {
 		const p1 = new Ractive({
 			data: { foo: 'p1' }
 		});

--- a/tests/browser/methods/detachChild.js
+++ b/tests/browser/methods/detachChild.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/detachChild.js' );
 
-	QUnit.test( `detached children are unrendered if they are targeted`, t => {
+	test( `detached children are unrendered if they are targeted`, t => {
 		fixture.innerHTML = '<div id="r1"></div><div id="r2"></div>';
 		const r1 = new Ractive({
 			template: 'r1',
@@ -25,7 +26,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="r1"></div><div id="r2">r2</div>' );
 	});
 
-	QUnit.test( `detaching a non-attached child throws an error`, t => {
+	test( `detaching a non-attached child throws an error`, t => {
 		const r = new Ractive({
 			el: fixture
 		});
@@ -36,7 +37,7 @@ export default function() {
 		}, /not attached/ );
 	});
 
-	QUnit.test( `detaching an anchored child updates children.byName`, t => {
+	test( `detaching an anchored child updates children.byName`, t => {
 		const r1 = new Ractive();
 		const r = new Ractive({
 			el: fixture,

--- a/tests/browser/methods/find.js
+++ b/tests/browser/methods/find.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/find.js' );
 
-	QUnit.test( 'find() works with a string-only template', t => {
+	test( 'find() works with a string-only template', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<p>foo</p><p>bar</p>'
@@ -12,7 +13,7 @@ export default function() {
 		t.ok( ractive.find( 'p' ).innerHTML === 'foo' );
 	});
 
-	QUnit.test( 'find() works with a template containing mustaches', t => {
+	test( 'find() works with a template containing mustaches', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<p>{{foo}}</p><p>{{bar}}</p>',
@@ -22,7 +23,7 @@ export default function() {
 		t.ok( ractive.find( 'p' ).innerHTML === 'one' );
 	});
 
-	QUnit.test( 'find() works with nested elements', t => {
+	test( 'find() works with nested elements', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div class="outer"><div class="inner"><p>{{foo}}</p><p>{{bar}}</p></div></div>',
@@ -32,7 +33,7 @@ export default function() {
 		t.ok( ractive.find( 'p' ).innerHTML === 'one' );
 	});
 
-	QUnit.test( 'ractive.find() throws error if instance is unrendered (#2008)', t => {
+	test( 'ractive.find() throws error if instance is unrendered (#2008)', t => {
 		const ractive = new Ractive({
 			template: '<p>unrendered</p>'
 		});
@@ -43,7 +44,7 @@ export default function() {
 	});
 
 
-	QUnit.test( `find() finds elements in targeted attached children`, t => {
+	test( `find() finds elements in targeted attached children`, t => {
 		const r1 = new Ractive({
 			template: '<div id="r1"></div>'
 		});
@@ -62,7 +63,7 @@ export default function() {
 		t.ok( r2.find( 'div' ).id === 'r1' );
 	});
 
-	QUnit.test( `find() doesn't find elements in non-targeted attached children by default`, t => {
+	test( `find() doesn't find elements in non-targeted attached children by default`, t => {
 		fixture.innerHTML = '<div></div><div></div>';
 		const r1 = new Ractive({
 			el: fixture.children[0],
@@ -83,7 +84,7 @@ export default function() {
 		t.ok( r2.find( 'div' ) === undefined );
 	});
 
-	QUnit.test( `find() finds elements in non-targeted attached children when asked to`, t => {
+	test( `find() finds elements in non-targeted attached children when asked to`, t => {
 		fixture.innerHTML = '<div></div><div></div>';
 		const r1 = new Ractive({
 			el: fixture.children[0],
@@ -104,7 +105,7 @@ export default function() {
 		t.ok( r2.find( 'div', { remote: true } ).id === 'r1' );
 	});
 
-	QUnit.test( `find() finds elements in triples`, t => {
+	test( `find() finds elements in triples`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: '{{{bar}}}{{{foo}}}',

--- a/tests/browser/methods/findAll.js
+++ b/tests/browser/methods/findAll.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/findAll.js' );
 
-	QUnit.test( 'findAll() gets an array of all nodes matching a selector', t => {
+	test( 'findAll() gets an array of all nodes matching a selector', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div><div><div>{{foo}}</div></div></div>'
@@ -13,7 +14,7 @@ export default function() {
 		t.equal( divs.length, 3 );
 	});
 
-	QUnit.test( 'findAll() works with a string-only template', t => {
+	test( 'findAll() works with a string-only template', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div><p>foo</p><p>bar</p></div>'
@@ -26,7 +27,7 @@ export default function() {
 		t.ok( paragraphs[1].innerHTML === 'bar' );
 	});
 
-	QUnit.test( 'ractive.findAll() throws error if instance is unrendered (#2008)', t => {
+	test( 'ractive.findAll() throws error if instance is unrendered (#2008)', t => {
 		const ractive = new Ractive({
 			template: '<p>unrendered</p>'
 		});
@@ -36,7 +37,7 @@ export default function() {
 		}, /Cannot call ractive\.findAll\('p', \.\.\.\) unless instance is rendered to the DOM/ );
 	});
 
-	QUnit.test( 'ractive.findAll() throws error if instance is unrendered (#2008)', t => {
+	test( 'ractive.findAll() throws error if instance is unrendered (#2008)', t => {
 		const ractive = new Ractive({
 			template: '<p>unrendered</p>'
 		});
@@ -46,7 +47,7 @@ export default function() {
 		}, /Cannot call ractive\.findAll\('p', \.\.\.\) unless instance is rendered to the DOM/ );
 	});
 
-	QUnit.test( 'findAll skips non-target instances by default', t => {
+	test( 'findAll skips non-target instances by default', t => {
 		fixture.innerHTML = '<div></div><div></div>';
 		const r1 = new Ractive({
 			el: fixture.children[0],
@@ -65,7 +66,7 @@ export default function() {
 		t.strictEqual( all[0], r1.find( '#r1' ) );
 	});
 
-	QUnit.test( 'findAll searches non-targeted attached children, when asked, last', t => {
+	test( 'findAll searches non-targeted attached children, when asked, last', t => {
 		fixture.innerHTML = '<div></div><div></div>';
 		const r1 = new Ractive({
 			el: fixture.children[0],
@@ -85,7 +86,7 @@ export default function() {
 		t.strictEqual( all[1], r2.find( '#r2' ) );
 	});
 
-	QUnit.test( 'findAll searches targeted attached children in order', t => {
+	test( 'findAll searches targeted attached children in order', t => {
 		const r1 = new Ractive({
 			el: fixture,
 			template: '<#anchor /><div id="r1" />'
@@ -103,7 +104,7 @@ export default function() {
 		t.strictEqual( all[0], r2.find( '#r2' ) );
 	});
 
-	QUnit.test( `findAll() finds elements in triples`, t => {
+	test( `findAll() finds elements in triples`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `{{{foo}}}{{{bar}}}`,

--- a/tests/browser/methods/findAllComponents.js
+++ b/tests/browser/methods/findAllComponents.js
@@ -1,4 +1,5 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/findAllComponents.js' );
@@ -15,7 +16,7 @@ export default function() {
 		components: { Widget, Decoy }
 	});
 
-	QUnit.test( 'ractive.findAllComponents() finds all components, of any type', ( t ) => {
+	test( 'ractive.findAllComponents() finds all components, of any type', ( t ) => {
 		const ractive = new MockRactive({
 			el: fixture,
 			template: '{{{ covered }}}<Widget/><Widget/><Widget/>',
@@ -28,7 +29,7 @@ export default function() {
 		t.ok( widgets[0] instanceof Widget && widgets[1] instanceof Widget && widgets[2] instanceof Widget );
 	});
 
-	QUnit.test( 'ractive.findAllComponents(selector) finds all components of type `selector`', ( t ) => {
+	test( 'ractive.findAllComponents(selector) finds all components of type `selector`', ( t ) => {
 		const ractive = new MockRactive({
 			el: fixture,
 			template: '<Widget/><Decoy/><Widget/>'
@@ -40,7 +41,7 @@ export default function() {
 		t.ok( widgets[0] instanceof Widget && widgets[1] instanceof Widget );
 	});
 
-	QUnit.test( 'Components containing other components work as expected with ractive.findAllComponents()', ( t ) => {
+	test( 'Components containing other components work as expected with ractive.findAllComponents()', ( t ) => {
 		const Compound = MockRactive.extend({
 			template: '<Widget content="foo"/><div><Widget content="bar"/></div>'
 		});
@@ -64,7 +65,7 @@ export default function() {
 		t.equal( widgets.length, 0 );
 	});
 
-	QUnit.test( 'findAllComponents searches non-targeted attached children, when asked, last', t => {
+	test( 'findAllComponents searches non-targeted attached children, when asked, last', t => {
 		fixture.innerHTML = '<div></div><div></div>';
 		const r1 = new Ractive({
 			el: fixture.children[0],
@@ -85,7 +86,7 @@ export default function() {
 		t.ok( all[1] === r2 );
 	});
 
-	QUnit.test( 'findAllComponents searches targeted attached children in order', t => {
+	test( 'findAllComponents searches targeted attached children in order', t => {
 		const r1 = new Ractive({
 			el: fixture,
 			template: '<#anchor /><cmp/>',
@@ -103,7 +104,7 @@ export default function() {
 		t.ok( all[0] === r2 );
 	});
 
-	QUnit.test( 'findAllComponents finds anchored components by anchor name when there is no instance name', t => {
+	test( 'findAllComponents finds anchored components by anchor name when there is no instance name', t => {
 		const cmp1 = new Ractive();
 		const cmp2 = new Ractive();
 		const r = new Ractive({
@@ -117,7 +118,7 @@ export default function() {
 		t.ok( r.findAllComponents( 'bar' )[0] === cmp1, 'same instance' );
 	});
 
-	QUnit.test( 'findAllComponents finds anchored components by instance name when available', t => {
+	test( 'findAllComponents finds anchored components by instance name when available', t => {
 		const cmp1 = new Ractive();
 		const cmp2 = new Ractive();
 		const r = new Ractive({

--- a/tests/browser/methods/findComponent.js
+++ b/tests/browser/methods/findComponent.js
@@ -1,4 +1,5 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/findComponent.js' );
@@ -15,7 +16,7 @@ export default function() {
 		components: { Widget, Decoy }
 	});
 
-	QUnit.test( 'ractive.findComponent() finds the first component, of any type', ( t ) => {
+	test( 'ractive.findComponent() finds the first component, of any type', ( t ) => {
 		const ractive = new MockRactive({
 			el: fixture,
 			template: '{{{ covered }}}<Widget/>',
@@ -27,7 +28,7 @@ export default function() {
 		t.ok( widget instanceof Widget );
 	});
 
-	QUnit.test( 'ractive.findComponent(selector) finds the first component of type `selector`', ( t ) => {
+	test( 'ractive.findComponent(selector) finds the first component of type `selector`', ( t ) => {
 		const ractive = new MockRactive({
 			el: fixture,
 			template: '<Decoy/><Widget/>'
@@ -38,7 +39,7 @@ export default function() {
 		t.ok( widget instanceof Widget );
 	});
 
-	QUnit.test( 'findComponent and findAllComponents work through {{>content}}', t => {
+	test( 'findComponent and findAllComponents work through {{>content}}', t => {
 		const Component = Ractive.extend({});
 		const Wrapper = Ractive.extend({
 			template: '<p>{{>content}}</p>',
@@ -58,7 +59,7 @@ export default function() {
 		t.equal( findAll.length, 1);
 	});
 
-	QUnit.test( 'findComponent finds non-targeted attached children last when asked', t => {
+	test( 'findComponent finds non-targeted attached children last when asked', t => {
 		const cmp = Ractive.extend({});
 		const r = new Ractive({
 			el: fixture,
@@ -84,7 +85,7 @@ export default function() {
 		t.ok( res && res === r2 );
 	});
 
-	QUnit.test( 'findComponent finds targeted attached children in template order', t => {
+	test( 'findComponent finds targeted attached children in template order', t => {
 		const cmp = Ractive.extend({});
 		const r = new Ractive({
 			el: fixture,
@@ -104,7 +105,7 @@ export default function() {
 		t.ok( res && res === r2 );
 	});
 
-	QUnit.test( 'findComponent finds anchored components by anchor name when the instance has no name', t => {
+	test( 'findComponent finds anchored components by anchor name when the instance has no name', t => {
 		const cmp = new Ractive();
 		const r = new Ractive({
 			el: fixture,
@@ -115,7 +116,7 @@ export default function() {
 		t.ok( r.findComponent( 'foo' ) === cmp, 'same instance' );
 	});
 
-	QUnit.test( 'findComponent finds anchored components by given name when the instance has one', t => {
+	test( 'findComponent finds anchored components by given name when the instance has one', t => {
 		const cmp = new Ractive();
 		const r = new Ractive({
 			el: fixture,

--- a/tests/browser/methods/findContainer.js
+++ b/tests/browser/methods/findContainer.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/findContainer.js' );
 
-	QUnit.test( '.findContainer() finds container component', t => {
+	test( '.findContainer() finds container component', t => {
 		const ractive = new Ractive({
 			template: '<Outer><Mid><Inner/></Mid></Outer>',
 			components: {

--- a/tests/browser/methods/findParent.js
+++ b/tests/browser/methods/findParent.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/findParent.js' );
 
-	QUnit.test( '.findParent() finds parent', t => {
+	test( '.findParent() finds parent', t => {
 		const C4 = Ractive.extend({
 			template: 'this space for rent'
 		});

--- a/tests/browser/methods/get.js
+++ b/tests/browser/methods/get.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/get.js' );
 
-	QUnit.test( 'getting and adapted keypath should return the adaptee (#2513)', t => {
+	test( 'getting and adapted keypath should return the adaptee (#2513)', t => {
 		function Foo ( content ) {
 			this.content = content;
 		}
@@ -39,7 +40,7 @@ export default function() {
 		t.ok( foo instanceof Foo );
 	});
 
-	QUnit.test( 'Returns mappings on root .get()', t => {
+	test( 'Returns mappings on root .get()', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `<Widget bar='{{foo}}' qux='{{qux}}'/>`,
@@ -62,7 +63,7 @@ export default function() {
 		t.deepEqual( fixture.innerHTML, JSON.stringify( expected ) );
 	});
 
-	QUnit.test( `get doesn't return children unless they are a value or virtual`, t => {
+	test( `get doesn't return children unless they are a value or virtual`, t => {
 		const r = new Ractive({
 			data: { base: { foo: 1, bar: 2, baz: { bat: 3 } } }
 		});
@@ -81,7 +82,7 @@ export default function() {
 		t.equal( r.get().bar, 3 );
 	});
 
-	QUnit.test( `get doesn't return links in non-root models unless asked`, t => {
+	test( `get doesn't return links in non-root models unless asked`, t => {
 		const r = new Ractive({
 			data: { base: { foo: { baz: 2 }, bar: 1 } }
 		});
@@ -91,7 +92,7 @@ export default function() {
 		t.ok( 'bar' in r.get( 'base.foo', { virtual: true } ) );
 	});
 
-	QUnit.test( `get returns links in root models unless asked not to`, t => {
+	test( `get returns links in root models unless asked not to`, t => {
 		const r = new Ractive({
 			data: { base: { foo: { baz: 2 }, bar: 1 } }
 		});

--- a/tests/browser/methods/link.js
+++ b/tests/browser/methods/link.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/link.js' );
 
-	QUnit.test( 'Keypaths can be linked', t => {
+	test( 'Keypaths can be linked', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{ foo }} {{ bar.baz.bat }}',
@@ -19,7 +20,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'bip bip' );
 	});
 
-	QUnit.test( 'Deep references on links should work as expected', t => {
+	test( 'Deep references on links should work as expected', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{ person.name }} is {{ person.status }}',
@@ -40,7 +41,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'Marty is Awesome&tm;' );
 	});
 
-	QUnit.test( 'Re-linking overwrites the existing link', t => {
+	test( 'Re-linking overwrites the existing link', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{ dog.name }}',
@@ -56,7 +57,7 @@ export default function() {
 	});
 
 	// only for non-mapped links
-	QUnit.test( 'Links can be set to nested paths', t => {
+	test( 'Links can be set to nested paths', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{ foo.baz.bar }}',
@@ -68,7 +69,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '1' );
 	});
 
-	QUnit.test( 'Links cannot have overlapping paths', t => {
+	test( 'Links cannot have overlapping paths', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '',
@@ -83,7 +84,7 @@ export default function() {
 		}, /to itself/ );
 	});
 
-	QUnit.test( 'Links should not outlive their instance', t => {
+	test( 'Links should not outlive their instance', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#if foo}}<bar />{{/if}}',
@@ -110,7 +111,7 @@ export default function() {
 		t.ok(r.viewmodel.joinAll(['bip', 'bop']).deps.length === 0);
 	});
 
-	QUnit.test( 'deeply nested links can be retrieved', t => {
+	test( 'deeply nested links can be retrieved', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{ bat.bop.bip }}',
@@ -127,7 +128,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( 'links work with root paths too', t => {
+	test( 'links work with root paths too', t => {
 		t.expect(2);
 
 		const parent = new Ractive();

--- a/tests/browser/methods/merge.js
+++ b/tests/browser/methods/merge.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/merge.js' );
 
-	QUnit.test( 'Merging an array of strings only creates the necessary fragments', ( t ) => {
+	test( 'Merging an array of strings only creates the necessary fragments', ( t ) => {
 		let entered = 0;
 
 		const ractive = new Ractive({
@@ -40,7 +41,7 @@ export default function() {
 		t.ok( baz === ractive.find( '#baz ' ));
 	});
 
-	QUnit.test( 'Merging an array of strings only removes the necessary fragments', ( t ) => {
+	test( 'Merging an array of strings only removes the necessary fragments', ( t ) => {
 		let entered = 0;
 		let exited = 0;
 
@@ -79,7 +80,7 @@ export default function() {
 		t.ok( baz === ractive.find( '#baz ' ));
 	});
 
-	QUnit.test( 'Merging an array of same-looking objects only adds/removes the necessary fragments if `compare` is `JSON.stringify`', ( t ) => {
+	test( 'Merging an array of same-looking objects only adds/removes the necessary fragments if `compare` is `JSON.stringify`', ( t ) => {
 		let entered = 0;
 		let exited = 0;
 
@@ -120,7 +121,7 @@ export default function() {
 		t.ok( baz === ractive.find( '#baz ' ));
 	});
 
-	QUnit.test( 'Merging an array of same-looking objects only adds/removes the necessary fragments if `compare` is a string id field', ( t ) => {
+	test( 'Merging an array of same-looking objects only adds/removes the necessary fragments if `compare` is a string id field', ( t ) => {
 		let entered = 0;
 		let exited = 0;
 
@@ -161,7 +162,7 @@ export default function() {
 		t.ok( baz === ractive.find( '#baz ' ));
 	});
 
-	QUnit.test( 'Merging an array of same-looking objects only adds/removes the necessary fragments if `compare` is a comparison function', ( t ) => {
+	test( 'Merging an array of same-looking objects only adds/removes the necessary fragments if `compare` is a comparison function', ( t ) => {
 		let entered = 0;
 		let exited = 0;
 
@@ -204,7 +205,7 @@ export default function() {
 		t.ok( baz === ractive.find( '#baz ' ));
 	});
 
-	QUnit.test( 'If identity comparison fails, the resulting shape of the DOM is still correct', ( t ) => {
+	test( 'If identity comparison fails, the resulting shape of the DOM is still correct', ( t ) => {
 		let entered = 0;
 		let exited = 0;
 
@@ -245,7 +246,7 @@ export default function() {
 		t.ok( baz !== ractive.find( '#baz ' ));
 	});
 
-	QUnit.test( 'Merging will trigger upstream updates regardless of whether items are being added/removed', ( t ) => {
+	test( 'Merging will trigger upstream updates regardless of whether items are being added/removed', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{items}} {{JSON.stringify(items)}}',
@@ -259,7 +260,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'b,a,c ["b","a","c"]' );
 	});
 
-	QUnit.test( '#if section with merged array (#952)', ( t ) => {
+	test( '#if section with merged array (#952)', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#if list}}yes{{else}}no{{/if}}',
@@ -274,7 +275,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yes' );
 	});
 
-	QUnit.test( 'Unbound sections disregard merge instructions (#967)', ( t ) => {
+	test( 'Unbound sections disregard merge instructions (#967)', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -292,7 +293,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<ul><li>a: ac</li><li>c: ac</li></ul>' );
 	});
 
-	QUnit.test( 'Shuffling the order of array members', ( t ) => {
+	test( 'Shuffling the order of array members', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<ul>{{#each items}}<li>{{this}}</li>{{/each}}</ul>',
@@ -305,7 +306,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<ul><li>c</li><li>b</li><li>d</li><li>a</li></ul>' );
 	});
 
-	QUnit.test( 'Merging works with unrendered instances (#1314)', ( t ) => {
+	test( 'Merging works with unrendered instances (#1314)', ( t ) => {
 		const ractive = new Ractive({
 			template: '{{#items}}{{.}}{{/}}',
 			data: {
@@ -317,7 +318,7 @@ export default function() {
 		t.htmlEqual( ractive.toHTML(), 'ba' );
 	});
 
-	QUnit.test( 'Expressions with index references survive a merge', t => {
+	test( 'Expressions with index references survive a merge', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -340,7 +341,7 @@ export default function() {
 		return !node.parentNode || node.parentNode instanceof HTMLDocument;
 	}
 
-	QUnit.test( 'arrays merge safely with themselves', t => {
+	test( 'arrays merge safely with themselves', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{list.0.key}}{{#each list}}<span>{{.key}}</span>{{/each}}`,
@@ -370,7 +371,7 @@ export default function() {
 		t.equal( postB.myId, 'b' );
 	});
 
-	QUnit.test( 'arrays merge with themselves when no array is given', t => {
+	test( 'arrays merge with themselves when no array is given', t => {
 		const list = [ 1, 2, 3 ];
 		const r = new Ractive({
 			el: fixture,
@@ -386,7 +387,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '243' );
 	});
 
-	QUnit.test( 'arrays merge safely with themselves even if they are not rendered', t => {
+	test( 'arrays merge safely with themselves even if they are not rendered', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{list.0.key}}',

--- a/tests/browser/methods/observe.js
+++ b/tests/browser/methods/observe.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/observe.js' );
 
-	QUnit.test( 'Observers fire before the DOM updates', t => {
+	test( 'Observers fire before the DOM updates', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -20,7 +21,7 @@ export default function() {
 		ractive.set( 'foo', true );
 	});
 
-	QUnit.test( 'Observers with { defer: true } fire after the DOM updates', t => {
+	test( 'Observers with { defer: true } fire after the DOM updates', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -36,7 +37,7 @@ export default function() {
 		ractive.set( 'foo', true );
 	});
 
-	QUnit.test( 'Observers with { defer: true } fire after non-transitioned nodes removed from DOM (#1869)', t => {
+	test( 'Observers with { defer: true } fire after non-transitioned nodes removed from DOM (#1869)', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -52,7 +53,7 @@ export default function() {
 		ractive.pop( 'items' );
 	});
 
-	QUnit.test( 'Observer can be created without an options argument', t => {
+	test( 'Observer can be created without an options argument', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -66,7 +67,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Observers fire on init when no matching data', t => {
+	test( 'Observers fire on init when no matching data', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -82,7 +83,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'Uninitialised observers do not fire if their keypath is set to the same value', t => {
+	test( 'Uninitialised observers do not fire if their keypath is set to the same value', t => {
 		t.expect( 0 );
 
 		const ractive = new Ractive({
@@ -98,7 +99,7 @@ export default function() {
 		ractive.set( 'foo', 'bar' );
 	});
 
-	QUnit.test( 'Uninitialised observers correctly report initial value on first fire (#1137)', t => {
+	test( 'Uninitialised observers correctly report initial value on first fire (#1137)', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -113,7 +114,7 @@ export default function() {
 		ractive.set( 'foo', 'baz' );
 	});
 
-	QUnit.test( 'Observers fire on downstream changes (#1393)', t => {
+	test( 'Observers fire on downstream changes (#1393)', t => {
 		t.expect( 4 );
 
 		const ractive = new Ractive({
@@ -133,7 +134,7 @@ export default function() {
 		ractive.set( 'config.foo', 'baz' );
 	});
 
-	QUnit.test( 'Observers do NOT fire on downstream changes with strict: true', t => {
+	test( 'Observers do NOT fire on downstream changes with strict: true', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: 'blah',
@@ -155,7 +156,7 @@ export default function() {
 		t.equal( observed, 1 );
 	});
 
-	QUnit.test( 'Observers can observe multiple keypaths, separated by a space', t => {
+	test( 'Observers can observe multiple keypaths, separated by a space', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: 'irrelevant'
@@ -185,7 +186,7 @@ export default function() {
 		t.deepEqual( results, { foo: 'one', bar: 'two', baz: 'three', a: 1, b: 2 });
 	});
 
-	QUnit.test( 'Promises from set() operations inside observers resolve (#765)', t => {
+	test( 'Promises from set() operations inside observers resolve (#765)', t => {
 		t.expect( 1 );
 
 		const done = t.async();
@@ -208,7 +209,7 @@ export default function() {
 		ractive.set( 'bar', true );
 	});
 
-	QUnit.test( 'set() operations inside observers affect the DOM immediately (related to #765)', t => {
+	test( 'set() operations inside observers affect the DOM immediately (related to #765)', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -227,7 +228,7 @@ export default function() {
 		ractive.set( 'bar', true );
 	});
 
-	QUnit.test( 'Errors inside observers are not caught', t => {
+	test( 'Errors inside observers are not caught', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -253,7 +254,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'Setting up and cancelling a regular observer', t => {
+	test( 'Setting up and cancelling a regular observer', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: 'unimportant',
@@ -273,7 +274,7 @@ export default function() {
 		observer.cancel();
 	});
 
-	QUnit.test( '.observeOnce() functionality', t => {
+	test( '.observeOnce() functionality', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({ data: { foo: 'bar' } });
@@ -286,7 +287,7 @@ export default function() {
 		ractive.set( 'foo', 'qux' );
 	});
 
-	QUnit.test( 'Observer with no keypath argument (#1868)', t => {
+	test( 'Observer with no keypath argument (#1868)', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive();
@@ -295,7 +296,7 @@ export default function() {
 		ractive.set( 'answer', 42 );
 	});
 
-	QUnit.test( 'Observer with empty string keypath argument (#1868)', t => {
+	test( 'Observer with empty string keypath argument (#1868)', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive();
@@ -307,7 +308,7 @@ export default function() {
 	// This is a casualty of 0.8 – the `foo` observer will be called
 	// when it turns `false`, immediately before the component that
 	// owns the observer is torn down. The observer *is* torn down, though
-	QUnit.test( 'Observers are removed on teardown (#1865)', t => {
+	test( 'Observers are removed on teardown (#1865)', t => {
 		let rendered = 0;
 		let observed = 0;
 
@@ -339,7 +340,7 @@ export default function() {
 		t.equal( observed, 3 ); // formerly 2. (the important thing is it's not 3)
 	});
 
-	QUnit.test( 'Observers should not fire twice when an upstream change is already a change (#1695)', t => {
+	test( 'Observers should not fire twice when an upstream change is already a change (#1695)', t => {
 		let count = 0;
 
 		const ractive = new Ractive({
@@ -354,7 +355,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( 'Pattern observers fire on changes to keypaths that match their pattern', t => {
+	test( 'Pattern observers fire on changes to keypaths that match their pattern', t => {
 		t.expect( 4 );
 
 		const ractive = new Ractive({
@@ -375,7 +376,7 @@ export default function() {
 	});
 
 	// TODO why not deletes? was this discussed?
-	QUnit.test( 'Pattern observers fire on changes and adds, but not deletes', t => {
+	test( 'Pattern observers fire on changes and adds, but not deletes', t => {
 		let newName;
 		let oldName;
 		let keypath;
@@ -407,7 +408,7 @@ export default function() {
 		t.equal( index, 1 );
 	});
 
-	QUnit.test( 'Pattern observers fire on adds and changes in full array set', t => {
+	test( 'Pattern observers fire on adds and changes in full array set', t => {
 		let observed = 0;
 
 		const ractive = new Ractive({
@@ -423,7 +424,7 @@ export default function() {
 		t.equal( observed, 2 );
 	});
 
-	QUnit.test( 'Pattern observers do NOT fire on init when no matching data', t => {
+	test( 'Pattern observers do NOT fire on init when no matching data', t => {
 		t.expect( 0 );
 
 		const ractive = new Ractive({
@@ -437,7 +438,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Pattern observers fire on changes to keypaths downstream of their pattern', t => {
+	test( 'Pattern observers fire on changes to keypaths downstream of their pattern', t => {
 		t.expect( 4 );
 
 		const ractive = new Ractive({
@@ -458,7 +459,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'observe has correct context #2087', t => {
+	test( 'observe has correct context #2087', t => {
 		t.expect( 4 );
 
 		const ractive = new Ractive({
@@ -479,7 +480,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'Pattern observers fire on changes to keypaths upstream of their pattern', t => {
+	test( 'Pattern observers fire on changes to keypaths upstream of their pattern', t => {
 		t.expect( 4 );
 
 		const ractive = new Ractive({
@@ -499,7 +500,7 @@ export default function() {
 		ractive.set( 'foo', { bar: { baz: 2 } });
 	});
 
-	QUnit.test( 'Pattern observers fire on changes to keypaths upstream of their pattern only if their value has changed', t => {
+	test( 'Pattern observers fire on changes to keypaths upstream of their pattern only if their value has changed', t => {
 		t.expect( 7 );
 
 		let foo = { bar: { baz: 1 } };
@@ -531,7 +532,7 @@ export default function() {
 		ractive.set( 'foo', foo );
 	});
 
-	QUnit.test( 'Pattern observers can have multiple wildcards', t => {
+	test( 'Pattern observers can have multiple wildcards', t => {
 		t.expect( 4 );
 
 		const ractive = new Ractive({
@@ -551,7 +552,7 @@ export default function() {
 		ractive.set( 'foo.bar', { baz: 2 });
 	});
 
-	QUnit.test( 'The first key in a pattern observer\'s pattern can be a wildcard', t => {
+	test( 'The first key in a pattern observer\'s pattern can be a wildcard', t => {
 		t.expect( 4 );
 
 		const ractive = new Ractive({
@@ -571,7 +572,7 @@ export default function() {
 		ractive.set( 'gup.foo.bar', { baz: 2 });
 	});
 
-	QUnit.test( 'Pattern observers fire when ractive.update() is called without parameters', t => {
+	test( 'Pattern observers fire when ractive.update() is called without parameters', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -589,7 +590,7 @@ export default function() {
 		ractive.update();
 	});
 
-	QUnit.test( 'Pattern observers can start with wildcards (#629)', t => {
+	test( 'Pattern observers can start with wildcards (#629)', t => {
 		const ractive = new Ractive({
 			data: {
 				foo: { number: 0 },
@@ -618,7 +619,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Pattern observers on arrays fire correctly after mutations', t => {
+	test( 'Pattern observers on arrays fire correctly after mutations', t => {
 		const ractive = new Ractive({
 			data: {
 				items: [ 'a', 'b', 'c' ]
@@ -655,7 +656,7 @@ export default function() {
 		t.ok( observedLengthChange );
 	});
 
-	QUnit.test( 'Pattern observers receive additional arguments corresponding to the wildcards', t => {
+	test( 'Pattern observers receive additional arguments corresponding to the wildcards', t => {
 		const ractive = new Ractive({
 			data: {
 				array: [ 'a', 'b', 'c' ],
@@ -694,13 +695,13 @@ export default function() {
 		t.equal( lastB, 'five' );
 	});
 
-	QUnit.test( 'Pattern observers work with an empty array (#760)', t => {
+	test( 'Pattern observers work with an empty array (#760)', t => {
 		const ractive = new Ractive({});
 		ractive.observe( 'foo.*.bar', () => {});
 		t.ok( true );
 	});
 
-	QUnit.test( 'Pattern observers work with an property of array (#760) variant', t => {
+	test( 'Pattern observers work with an property of array (#760) variant', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({ data: { foo: [] } } );
@@ -714,7 +715,7 @@ export default function() {
 		ractive.push( 'foo', bar );
 	});
 
-	QUnit.test( 'Setting up and cancelling a pattern observer', t => {
+	test( 'Setting up and cancelling a pattern observer', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: 'unimportant',
@@ -734,7 +735,7 @@ export default function() {
 		observer.cancel();
 	});
 
-	QUnit.test( 'Deferred pattern observers work correctly (#1079)', t => {
+	test( 'Deferred pattern observers work correctly (#1079)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: 'unimportant',
@@ -756,7 +757,7 @@ export default function() {
 		observer.cancel();
 	});
 
-	QUnit.test( 'Asterisks should not be left in computation keypaths (#1472)', t => {
+	test( 'Asterisks should not be left in computation keypaths (#1472)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{foo * 2}}',
@@ -782,7 +783,7 @@ export default function() {
 		fire( document.createElement( 'div' ), 'input' );
 		fire( document.createElement( 'div' ), 'blur' );
 
-		QUnit.test( 'Pattern observers used as validators behave correctly on blur (#1475)', t => {
+		test( 'Pattern observers used as validators behave correctly on blur (#1475)', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: `
@@ -826,7 +827,7 @@ export default function() {
 		// do nothing
 	}
 
-	QUnit.test( 'Observer fires on initialisation for computed properties', t => {
+	test( 'Observer fires on initialisation for computed properties', t => {
 		const ractive = new Ractive({
 			data: { num: 21 },
 			computed: {
@@ -843,7 +844,7 @@ export default function() {
 		t.deepEqual( observed, { num: 21, doubled: 42 });
 	});
 
-	QUnit.test( `observers that cause a shuffle shouldn't throw (#2222)`, t => {
+	test( `observers that cause a shuffle shouldn't throw (#2222)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `-{{#each items}}{{.}}{{/each}}
@@ -863,7 +864,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '-12 1 - items.0 2 - items.1' );
 	});
 
-	QUnit.test( `a pattern observer that is shuffled with objects should only notify on the new keys`, t => {
+	test( `a pattern observer that is shuffled with objects should only notify on the new keys`, t => {
 		let count = 0;
 
 		const r = new Ractive({
@@ -886,7 +887,7 @@ export default function() {
 		t.equal( count, 7 );
 	});
 
-	QUnit.test( `wildcard * and root fire in components for mapped and local data`, t => {
+	test( `wildcard * and root fire in components for mapped and local data`, t => {
 		t.expect(16);
 
 		let wckeypath = 'value';
@@ -930,7 +931,7 @@ export default function() {
 		r.findComponent( 'widget' ).set( 'bizz', 'buzz' );
 	});
 
-	QUnit.test( 'wildcard * and root include computed but not expressions', t => {
+	test( 'wildcard * and root include computed but not expressions', t => {
 		let wildcard = 0;
 		let root = 0;
 
@@ -956,7 +957,7 @@ export default function() {
 		t.equal( root, 1, 'root count' );
 	});
 
-	QUnit.test( 'Pattern observer expects * to only apply to arrays and objects (#1923)', t => {
+	test( 'Pattern observer expects * to only apply to arrays and objects (#1923)', t => {
 		t.expect(0);
 		const ractive = new Ractive({
 			data: { msg: 'hello world' }
@@ -967,7 +968,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'pattern observers only observe changed values (#2420)', t => {
+	test( 'pattern observers only observe changed values (#2420)', t => {
 		t.expect( 3 );
 
 		const r = new Ractive({
@@ -985,7 +986,7 @@ export default function() {
 		r.set( 'list.1', { foo: 'yep' } );
 	});
 
-	QUnit.test( 'pattern observers only observe changed values with exact keypath matches (#2420)', t => {
+	test( 'pattern observers only observe changed values with exact keypath matches (#2420)', t => {
 		t.expect( 3 );
 
 		const r = new Ractive({
@@ -1003,7 +1004,7 @@ export default function() {
 		r.set( 'list.1.foo', 'yep' );
 	});
 
-	QUnit.test( 'subsequent single segment pattern observers still have the correct old value', t => {
+	test( 'subsequent single segment pattern observers still have the correct old value', t => {
 		t.expect( 6 );
 		let str = 'yep';
 
@@ -1024,7 +1025,7 @@ export default function() {
 		r.set( 'list.0.foo', str );
 	});
 
-	QUnit.test( 'pattern observers only observe changed values on update', t => {
+	test( 'pattern observers only observe changed values on update', t => {
 		t.expect( 2 );
 
 		const r = new Ractive({
@@ -1042,7 +1043,7 @@ export default function() {
 		r.update( 'list.1.foo' );
 	});
 
-	QUnit.test( `pattern observer doesn't die on primitive values (#2503)`, t => {
+	test( `pattern observer doesn't die on primitive values (#2503)`, t => {
 		const done = t.async();
 		const r = new Ractive({
 			el: fixture,
@@ -1060,7 +1061,7 @@ export default function() {
 		r.add( 'foo' );
 	});
 
-	QUnit.test( 'wildcard * fires on new property', t => {
+	test( 'wildcard * fires on new property', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({ data: { qux: 'qux' } });
@@ -1073,7 +1074,7 @@ export default function() {
 		ractive.set( 'foo', 'bar' );
 	});
 
-	QUnit.test( 'References to observers are not retained after cancel()', t => {
+	test( 'References to observers are not retained after cancel()', t => {
 		const ractive = new Ractive({ data: { counter: 0 } });
 		const obs = ractive.observe( 'counter', ( newValue, oldValue ) => {
 			if ( oldValue ) {
@@ -1089,7 +1090,7 @@ export default function() {
 		t.equal( ractive._observers.length, 0 );
 	});
 
-	QUnit.test( 'observers on implicit mappings should resolve correctly (#2572)', t => {
+	test( 'observers on implicit mappings should resolve correctly (#2572)', t => {
 		t.expect( 2 );
 
 		let count = 0;
@@ -1119,7 +1120,7 @@ export default function() {
 		r.add( 'foo.bar' );
 	});
 
-	QUnit.test( 'observing in an isolated component should not create implicit mappings', t => {
+	test( 'observing in an isolated component should not create implicit mappings', t => {
 		t.expect( 0 );
 
 		const cmp = Ractive.extend({
@@ -1140,7 +1141,7 @@ export default function() {
 		r.add( 'foo.bar' );
 	});
 
-	QUnit.test( 'observers should not be re-entrant when they init (#2594)', t => {
+	test( 'observers should not be re-entrant when they init (#2594)', t => {
 		let count = 0;
 		new Ractive({
 			el: fixture,
@@ -1156,7 +1157,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( 'pattern observers should not be re-entrant when they init', t => {
+	test( 'pattern observers should not be re-entrant when they init', t => {
 		let count = 0;
 		new Ractive({
 			el: fixture,
@@ -1172,7 +1173,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( 'pattern observers handle multi-key set correctly (#2631)', t => {
+	test( 'pattern observers handle multi-key set correctly (#2631)', t => {
 		const list = [];
 		const r = new Ractive({
 			data: {
@@ -1194,7 +1195,7 @@ export default function() {
 		t.deepEqual( list, [ 3, 4, 5 ] );
 	});
 
-	QUnit.test( `observers only fire for a computation when it actually changes (#2629)`, t => {
+	test( `observers only fire for a computation when it actually changes (#2629)`, t => {
 		const r = new Ractive({
 			computed: {
 				int () {
@@ -1219,7 +1220,7 @@ export default function() {
 		t.equal( r.get( 'observerCalledTimes' ), 1 );
 	});
 
-	QUnit.test( 'observers on conditional mappings fire correctly (#2636)', t => {
+	test( 'observers on conditional mappings fire correctly (#2636)', t => {
 		let val;
 
 		const cmp = Ractive.extend({
@@ -1239,7 +1240,7 @@ export default function() {
 		t.equal( val, 'hello' );
 	});
 
-	QUnit.test( `observers on ambiguous paths should not cause errors if they don't resolve before teardown (#2619)`, t => {
+	test( `observers on ambiguous paths should not cause errors if they don't resolve before teardown (#2619)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			onconfig () {
@@ -1255,7 +1256,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( `observers that modify their observed keypath should fire again when set to the pre-observed value (#2668)`, t => {
+	test( `observers that modify their observed keypath should fire again when set to the pre-observed value (#2668)`, t => {
 		let count = 0;
 
 		const r = new Ractive({
@@ -1279,7 +1280,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( `observers fire properly on upstream links (#2675)`, t => {
+	test( `observers fire properly on upstream links (#2675)`, t => {
 		let count = 0;
 		const cmp = Ractive.extend({
 			template: '{{ JSON.stringify(obj) }}',
@@ -1303,7 +1304,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '{"str":"still yep"}{"str":"still yep"}' );
 	});
 
-	QUnit.test( `pattern observers fire properly on upstream links (#2675)`, t => {
+	test( `pattern observers fire properly on upstream links (#2675)`, t => {
 		let val;
 		let path;
 		let key;
@@ -1336,7 +1337,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '{"str":"still yep"}{"str":"still yep"}' );
 	});
 
-	QUnit.test( `observers fire properly on upstream linked links (#2675)`, t => {
+	test( `observers fire properly on upstream linked links (#2675)`, t => {
 		let count = 0;
 		const cmp2 = Ractive.extend({
 			template: '{{ JSON.stringify(obj) }}',
@@ -1365,7 +1366,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '{"str":"still yep"}{"str":"still yep"}' );
 	});
 
-	QUnit.test( `pattern observers only fire once for matching keypaths (#2682)`, t => {
+	test( `pattern observers only fire once for matching keypaths (#2682)`, t => {
 		let count = 0;
 		const r = new Ractive({
 			el: fixture
@@ -1382,7 +1383,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( 'observe ignores additional empty paths (#2690)', t => {
+	test( 'observe ignores additional empty paths (#2690)', t => {
 		let count1 = 0;
 		let count2 = 0;
 		const r = new Ractive({
@@ -1399,7 +1400,7 @@ export default function() {
 		t.equal( count2, 1 );
 	});
 
-	QUnit.test( `observeOnce works from the config event, even if the data is initialized - #2725`, t => {
+	test( `observeOnce works from the config event, even if the data is initialized - #2725`, t => {
 		let count = 0;
 		const r = new Ractive({
 			target: fixture,
@@ -1415,7 +1416,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( `observers can be silenced and resumed`, t => {
+	test( `observers can be silenced and resumed`, t => {
 		let count = 0;
 		const r = new Ractive();
 		const handle = r.observe( 'foo', function () {
@@ -1437,7 +1438,7 @@ export default function() {
 		t.equal( handle.isSilenced(), false );
 	});
 
-	QUnit.test( `observer handle cancels all observers when multiple observers are created`, t => {
+	test( `observer handle cancels all observers when multiple observers are created`, t => {
 		let count = 0;
 		const r = new Ractive();
 		const handle = r.observe( 'foo bar baz', () => count++, { init: false } );
@@ -1452,7 +1453,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( `pattern observer only fires a partial update once (#2800)`, t => {
+	test( `pattern observer only fires a partial update once (#2800)`, t => {
 		const counts = { a: 0, b: 0 };
 		const r = new Ractive();
 		r.observe( 'foo.*', ( n, o, kp, k ) => {
@@ -1466,7 +1467,7 @@ export default function() {
 		t.equal( counts.b, 1 );
 	});
 
-	QUnit.test( `pattern observer only fires for an exactly matching keypath, not just a partial match (#2805)`, t => {
+	test( `pattern observer only fires for an exactly matching keypath, not just a partial match (#2805)`, t => {
 		const keys = [];
 		const r = new Ractive({ data: { foo: [ {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} ] } });
 		r.observe('foo.*', ( n, o, kp, k ) => {
@@ -1482,7 +1483,7 @@ export default function() {
 		t.equal( keys[0], '20' );
 	});
 
-	QUnit.test( `inserting array elements without using modification methods should still mark length (#2806)`, t => {
+	test( `inserting array elements without using modification methods should still mark length (#2806)`, t => {
 		const r = new Ractive({
 			data: { foo: [] }
 		});
@@ -1496,7 +1497,7 @@ export default function() {
 		r.set( 'foo.6', 'b' );
 	});
 
-	QUnit.test( 'List observers report array modifications', t => {
+	test( 'List observers report array modifications', t => {
 		let shuffle;
 
 		const ractive = new Ractive({
@@ -1519,7 +1520,7 @@ export default function() {
 		t.equal( shuffle.start, 1 );
 	});
 
-	QUnit.test( 'List observers correctly report value change on no init', t => {
+	test( 'List observers correctly report value change on no init', t => {
 		let shuffle;
 
 		const ractive = new Ractive({
@@ -1538,7 +1539,7 @@ export default function() {
 		t.equal( shuffle.start, 1 );
 	});
 
-	QUnit.test( 'List observers report full array value changes as inserted/deleted', t => {
+	test( 'List observers report full array value changes as inserted/deleted', t => {
 		let shuffle;
 
 		const ractive = new Ractive({
@@ -1556,7 +1557,7 @@ export default function() {
 		t.deepEqual( shuffle.deleted, [ 'apple', 'orange', 'banana' ] );
 	});
 
-	QUnit.test( 'Pattern observers on arrays fire correctly after mutations', t => {
+	test( 'Pattern observers on arrays fire correctly after mutations', t => {
 		const ractive = new Ractive({
 			data: {
 				items: [ 'a', 'b', 'c' ]
@@ -1584,7 +1585,7 @@ export default function() {
 		t.equal( deleted[0], 'd' );
 	});
 
-	QUnit.test( 'array observers can be single fire', t => {
+	test( 'array observers can be single fire', t => {
 		let count = 0;
 		const r = new Ractive({
 			observe: {
@@ -1603,7 +1604,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( 'array observers can be deferred', t => {
+	test( 'array observers can be deferred', t => {
 		t.expect( 2 );
 
 		const r = new Ractive({
@@ -1624,7 +1625,7 @@ export default function() {
 		r.push( 'list', 1 );
 	});
 
-	QUnit.test( `plain observers allow a hook to set the 'old' value`, t => {
+	test( `plain observers allow a hook to set the 'old' value`, t => {
 		t.expect( 4 );
 
 		let target = 0;
@@ -1647,7 +1648,7 @@ export default function() {
 		r.push( 'list', 1 );
 	});
 
-	QUnit.test( `plain observer old value hook gets a lifelong context on top of the ractive instance`, t => {
+	test( `plain observer old value hook gets a lifelong context on top of the ractive instance`, t => {
 		t.expect( 3 );
 
 		const r = new Ractive({
@@ -1679,7 +1680,7 @@ export default function() {
 		r.set( 'foo', 'asdf' );
 	});
 
-	QUnit.test( `recursive observers from root`, t => {
+	test( `recursive observers from root`, t => {
 		const r = new Ractive();
 		const vals = [
 			[ { baz: 'yep' }, undefined, 'foo.bar' ],
@@ -1700,7 +1701,7 @@ export default function() {
 		r.set( 'foo.bar.baz', 'yep again' );
 	});
 
-	QUnit.test( `recursive observers from path`, t => {
+	test( `recursive observers from path`, t => {
 		const r = new Ractive();
 		const vals = [
 			[ { baz: 'yep' }, undefined, 'some.path.foo.bar', 'foo.bar' ],
@@ -1722,7 +1723,7 @@ export default function() {
 		r.set( 'not.relevant', 'yep' );
 	});
 
-	QUnit.test( `recursive observers and links`, t => {
+	test( `recursive observers and links`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: '<cmp foozle="{{thing}}" />',
@@ -1743,7 +1744,7 @@ export default function() {
 		ob2.cancel();
 	});
 
-	QUnit.test( `recursive observers catch changes on a root of link (#2862)`, t => {
+	test( `recursive observers catch changes on a root of link (#2862)`, t => {
 		t.expect( 12 );
 
 		const src = new Ractive({

--- a/tests/browser/methods/pop.js
+++ b/tests/browser/methods/pop.js
@@ -1,10 +1,11 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/pop.js' );
 
 	[ true, false ].forEach( modifyArrays => {
-		QUnit.test( `ractive.pop() (modifyArrays: ${modifyArrays})`, t => {
+		test( `ractive.pop() (modifyArrays: ${modifyArrays})`, t => {
 			t.expect( 2 );
 
 			const done = t.async();

--- a/tests/browser/methods/push.js
+++ b/tests/browser/methods/push.js
@@ -1,10 +1,11 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/push.js' );
 
 	[ true, false ].forEach( modifyArrays => {
-		QUnit.test( `ractive.push() (modifyArrays: ${modifyArrays})`, t => {
+		test( `ractive.push() (modifyArrays: ${modifyArrays})`, t => {
 			const items = [ 'alice', 'bob', 'charles' ];
 
 			const ractive = new Ractive({
@@ -23,7 +24,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Array method proxies return a promise that resolves on transition complete', t => {
+	test( 'Array method proxies return a promise that resolves on transition complete', t => {
 		t.expect( 2 );
 
 		const done = t.async();
@@ -55,7 +56,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'grow an array if pushing to an undefined keypath', t => {
+	test( 'grow an array if pushing to an undefined keypath', t => {
 		const done = t.async();
 
 		const r = new Ractive({
@@ -69,7 +70,7 @@ export default function() {
 		result.then( res => t.equal( res, 1 ) ).then( done, done );
 	});
 
-	QUnit.test( 'Interpolators that directly reference arrays are updated on array mutation (#1074)', t => {
+	test( 'Interpolators that directly reference arrays are updated on array mutation (#1074)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{letters}}',

--- a/tests/browser/methods/readLink.js
+++ b/tests/browser/methods/readLink.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/readLink.js' );
 
-	QUnit.test( `readLink returns the immediately linked path by default`, t => {
+	test( `readLink returns the immediately linked path by default`, t => {
 		const r = new Ractive({
 			target: fixture
 		});
@@ -17,7 +18,7 @@ export default function() {
 		t.ok( r.readLink( 'bop' ).ractive === r );
 	});
 
-	QUnit.test( `readLink on a non-link returns undefined`, t => {
+	test( `readLink on a non-link returns undefined`, t => {
 		const r = new Ractive({
 			target: fixture
 		});
@@ -26,7 +27,7 @@ export default function() {
 		t.ok( r.readLink( 'bop' ) === undefined );
 	});
 
-	QUnit.test( `readLink with a mapped path returns the source instance`, t => {
+	test( `readLink with a mapped path returns the source instance`, t => {
 		const cmp = Ractive.extend();
 		const r = new Ractive({
 			on: { init() { this.set( 'foo.bar.baz.bat', true ); } },
@@ -40,7 +41,7 @@ export default function() {
 		t.ok( child.readLink( 'bop' ).ractive === r );
 	});
 
-	QUnit.test( `readLink is canonical by default`, t => {
+	test( `readLink is canonical by default`, t => {
 		const cmp1 = Ractive.extend({
 			template: '<cmp2 fizz="{{bop}}" />',
 			isolated: false
@@ -58,7 +59,7 @@ export default function() {
 		t.ok( child.readLink( 'fizz' ).ractive === r );
 	});
 
-	QUnit.test( `readLink can optionally be uncanonical`, t => {
+	test( `readLink can optionally be uncanonical`, t => {
 		const cmp1 = Ractive.extend({
 			template: '<cmp2 fizz="{{bop}}" />',
 			isolated: false

--- a/tests/browser/methods/reset.js
+++ b/tests/browser/methods/reset.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/reset.js' );
 
-	QUnit.test( 'Basic reset', t => {
+	test( 'Basic reset', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{one}}{{two}}{{three}}',
@@ -14,7 +15,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '4' );
 	});
 
-	QUnit.test( 'Invalid arguments', t => {
+	test( 'Invalid arguments', t => {
 		const ractive = new Ractive({
 			el: fixture
 		});
@@ -32,7 +33,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'ractive.reset() returns a promise', t => {
+	test( 'ractive.reset() returns a promise', t => {
 		t.expect( 6 );
 
 		const done = t.async();
@@ -59,7 +60,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( 'Dynamic template functions are recalled on reset', t => {
+	test( 'Dynamic template functions are recalled on reset', t => {
 		const done = t.async();
 
 		const ractive = new Ractive({
@@ -78,7 +79,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Promise with dynamic template functions are recalled on reset', t => {
+	test( 'Promise with dynamic template functions are recalled on reset', t => {
 		t.expect( 5 );
 
 		const done = t.async();
@@ -108,7 +109,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'fizz' );
 	});
 
-	QUnit.test( 'resetTemplate rerenders with new template', t => {
+	test( 'resetTemplate rerenders with new template', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{foo}}',
@@ -123,7 +124,7 @@ export default function() {
 	// Removed this functionality for now as not apparent
 	// what purpose of calling resetTemplate() without rerender
 	/*
-QUnit.test( 'resetTemplate with no template change doesnt rerender', t => {
+test( 'resetTemplate with no template change doesnt rerender', t => {
 		var p, ractive = new Ractive({
 			el: fixture,
 			template: '<p>{{foo}}</p>',
@@ -141,7 +142,7 @@ QUnit.test( 'resetTemplate with no template change doesnt rerender', t => {
 	});
 	*/
 
-	QUnit.test( 'Reset retains parent default data (#572)', t => {
+	test( 'Reset retains parent default data (#572)', t => {
 		const Widget = Ractive.extend({
 			data: {
 				uppercase ( str ) {
@@ -160,7 +161,7 @@ QUnit.test( 'resetTemplate with no template change doesnt rerender', t => {
 		t.htmlEqual( fixture.innerHTML, 'BIZZ' );
 	});
 
-	QUnit.test( 'Reset inserts { target, anchor } el option correctly', t => {
+	test( 'Reset inserts { target, anchor } el option correctly', t => {
 		const target = document.createElement('div');
 		const anchor = document.createElement('div');
 
@@ -183,7 +184,7 @@ QUnit.test( 'resetTemplate with no template change doesnt rerender', t => {
 		t.htmlEqual( fixture.innerHTML, '<div id="target"><div>foo</div><div>bar</div></div>' );
 	});
 
-	QUnit.test( 'resetTemplate removes an inline component from the DOM (#928)', t => {
+	test( 'resetTemplate removes an inline component from the DOM (#928)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<Widget type="{{type}}"/>',
@@ -207,7 +208,7 @@ QUnit.test( 'resetTemplate with no template change doesnt rerender', t => {
 		t.htmlEqual( fixture.innerHTML, 'TWO' );
 	});
 
-	QUnit.test( 'reset removes correctly from the DOM (#941)', t => {
+	test( 'reset removes correctly from the DOM (#941)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#active}}active{{/active}}{{^active}}not active{{/active}}',
@@ -221,7 +222,7 @@ QUnit.test( 'resetTemplate with no template change doesnt rerender', t => {
 		t.htmlEqual( fixture.innerHTML, 'active' );
 	});
 
-	QUnit.test( 'reset does not re-render if template does not change', t => {
+	test( 'reset does not re-render if template does not change', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<p>me</p>',
@@ -236,7 +237,7 @@ QUnit.test( 'resetTemplate with no template change doesnt rerender', t => {
 		t.equal( ractive.find('p'), p );
 	});
 
-	QUnit.test( 'reset does not re-render if template function does not change', t => {
+	test( 'reset does not re-render if template function does not change', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template ( data ) {
@@ -253,7 +254,7 @@ QUnit.test( 'resetTemplate with no template change doesnt rerender', t => {
 		t.equal( ractive.find('p'), p );
 	});
 
-	QUnit.test( 'reset does re-render if template changes', t => {
+	test( 'reset does re-render if template changes', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template () {
@@ -270,7 +271,7 @@ QUnit.test( 'resetTemplate with no template change doesnt rerender', t => {
 		t.notEqual( ractive.find('p'), p );
 	});
 
-	QUnit.test( 'reset removes an inline component from the DOM', t => {
+	test( 'reset removes an inline component from the DOM', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<widget type="{{type}}"/>',
@@ -295,7 +296,7 @@ QUnit.test( 'resetTemplate with no template change doesnt rerender', t => {
 		t.htmlEqual( fixture.innerHTML, 'TWO' );
 	});
 
-	QUnit.test( 'resetting an instance of a component with a data function (#1745)', t => {
+	test( 'resetting an instance of a component with a data function (#1745)', t => {
 		const Widget = Ractive.extend({
 			data () {
 				return { foo: 'bar' };
@@ -310,7 +311,7 @@ QUnit.test( 'resetTemplate with no template change doesnt rerender', t => {
 		t.equal( widget.get( 'foo' ), 'bar' );
 	});
 
-	QUnit.test( 'resetting the template of a component (#2658)', t => {
+	test( 'resetting the template of a component (#2658)', t => {
 		const cmp = Ractive.extend({
 			template: 'hello'
 		});

--- a/tests/browser/methods/reverse.js
+++ b/tests/browser/methods/reverse.js
@@ -1,10 +1,11 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/reverse.js' );
 
 	[ true, false ].forEach( modifyArrays => {
-		QUnit.test( `ractive.reverse() (modifyArrays: ${modifyArrays})`, t => {
+		test( `ractive.reverse() (modifyArrays: ${modifyArrays})`, t => {
 			const items = [ 'alice', 'bob', 'charles' ];
 
 			const ractive = new Ractive({

--- a/tests/browser/methods/set.js
+++ b/tests/browser/methods/set.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/set.js' );
 
-	QUnit.test( `deep set merges data into the existing model tree`, t => {
+	test( `deep set merges data into the existing model tree`, t => {
 		const r = new Ractive({
 			data: { foo: { bar: 42, bip: 'yep' } }
 		});
@@ -12,7 +13,7 @@ export default function() {
 		t.deepEqual( r.get( 'foo' ), { bar: { bat: 42 }, bip: 'yep', baz: [ true ] } );
 	});
 
-	QUnit.test( `deep setting with numeric keys will update array indices`, t => {
+	test( `deep setting with numeric keys will update array indices`, t => {
 		const r = new Ractive({
 			data: { foo: [ 1, 2, 3 ] }
 		});
@@ -25,7 +26,7 @@ export default function() {
 	});
 
 
-	QUnit.test( `keep set does not discard vdom or dom, where non-keep does`, t => {
+	test( `keep set does not discard vdom or dom, where non-keep does`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `{{#if show}}{{#each [1,2]}}<span>{{.}}</span>{{/each}}<cmp />{{/if}}`,
@@ -49,7 +50,7 @@ export default function() {
 		t.ok( cmp === r.findComponent( '*' ) );
 	});
 
-	QUnit.test( `kept fragments aren't considered during find, findAll, and friends`, t => {
+	test( `kept fragments aren't considered during find, findAll, and friends`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `{{#if show}}<div /><cmp />{{/if}}`,
@@ -71,7 +72,7 @@ export default function() {
 		t.ok( cmp === r.findComponent( 'cmp' ), 'cmp instance is same' );
 	});
 
-	QUnit.test( `kept fragments still intro and outro`, t => {
+	test( `kept fragments still intro and outro`, t => {
 		let count = 0;
 
 		const r = new Ractive({
@@ -95,7 +96,7 @@ export default function() {
 		t.equal( count, 3 );
 	});
 
-	QUnit.test( `kept fragments with triples work correctly`, t => {
+	test( `kept fragments with triples work correctly`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `{{#if show}}{{{html}}}{{/if}}`,

--- a/tests/browser/methods/shift.js
+++ b/tests/browser/methods/shift.js
@@ -1,10 +1,11 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/shift.js' );
 
 	[ true, false ].forEach( modifyArrays => {
-		QUnit.test( `ractive.shift() (modifyArrays: ${modifyArrays})`, t => {
+		test( `ractive.shift() (modifyArrays: ${modifyArrays})`, t => {
 			t.expect( 2 );
 
 			const done = t.async();
@@ -31,7 +32,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'shifting an empty array', t => {
+	test( 'shifting an empty array', t => {
 		t.expect( 0 );
 
 		const ractive = new Ractive({

--- a/tests/browser/methods/sort.js
+++ b/tests/browser/methods/sort.js
@@ -1,10 +1,11 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/sort.js' );
 
 	[ true, false ].forEach( modifyArrays => {
-		QUnit.test( `ractive.sort() (modifyArrays: ${modifyArrays})`, t => {
+		test( `ractive.sort() (modifyArrays: ${modifyArrays})`, t => {
 			const items = [ 'alice', 'bob', 'charles' ];
 
 			const ractive = new Ractive({

--- a/tests/browser/methods/splice.js
+++ b/tests/browser/methods/splice.js
@@ -1,11 +1,12 @@
 import { fire } from 'simulant';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/splice.js' );
 
 	[ true, false ].forEach( modifyArrays => {
-		QUnit.test( `ractive.splice() (modifyArrays: ${modifyArrays})`, t => {
+		test( `ractive.splice() (modifyArrays: ${modifyArrays})`, t => {
 			t.expect( 5 );
 
 			const done = t.async();
@@ -43,7 +44,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Unbound sections disregard splice instructions (#967)', t => {
+	test( 'Unbound sections disregard splice instructions (#967)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -61,7 +62,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<ul><li>a: ac</li><li>c: ac</li></ul>' );
 	});
 
-	QUnit.test( 'splice with net additions should make all indices greater than start update', t => {
+	test( 'splice with net additions should make all indices greater than start update', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{foo.2}}',
@@ -74,7 +75,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '1' );
 	});
 
-	QUnit.test( 'splice with one argument (#1943)', t => {
+	test( 'splice with one argument (#1943)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items}}{{this}}{{/}}',
@@ -88,7 +89,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '1' );
 	});
 
-	QUnit.test( 'a nested object iteration should rebind with an outer array iteration when it is spliced (#2321)', t => {
+	test( 'a nested object iteration should rebind with an outer array iteration when it is spliced (#2321)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each arr}}{{#each .obj:k}}{{k}}-{{.}}{{/each}}{{/each}}`,
@@ -102,7 +103,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'name-Marty' );
 	});
 
-	QUnit.test( 'splicing should not make node index info get out of sync (#2400)', t => {
+	test( 'splicing should not make node index info get out of sync (#2400)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each arr:i}}<span>{{.}}</span>{{/each}}`,
@@ -114,7 +115,7 @@ export default function() {
 		t.equal( Ractive.getNodeInfo( r.findAll( 'span' )[1] ).get( 'i' ), 1 );
 	});
 
-	QUnit.test( 'splicing should not make event index info get out of sync (#2399)', t => {
+	test( 'splicing should not make event index info get out of sync (#2399)', t => {
 		t.expect( 2 );
 
 		const r = new Ractive({
@@ -133,7 +134,7 @@ export default function() {
 		fire( r.findAll( 'span' )[1], 'click' );
 	});
 
-	QUnit.test( 'splicing with an undefined index should be equivalent to 0', t => {
+	test( 'splicing with an undefined index should be equivalent to 0', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each arr}}{{.}}{{/each}}`,
@@ -146,7 +147,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '654' );
 	});
 
-	QUnit.test( 'splicing arrays that have been updated out of band doesn\'t create duplicates', t => {
+	test( 'splicing arrays that have been updated out of band doesn\'t create duplicates', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each list}}{{.name}}{{/each}}`,
@@ -160,7 +161,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'cab' );
 	});
 
-	QUnit.test( 'splicing a mapped array properly shuffles the mapped model (#2659)', t => {
+	test( 'splicing a mapped array properly shuffles the mapped model (#2659)', t => {
 		const cmp = Ractive.extend({
 			template: '{{#each list}}<p>{{.name}} {{.sel ? "[x]" : "[ ]"}}</p>{{/each}}',
 			onrender () {

--- a/tests/browser/methods/subtract.js
+++ b/tests/browser/methods/subtract.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/subtract.js' );
 
-	QUnit.test( 'ractive.subtract("foo") subtracts 1 from the value of foo', t => {
+	test( 'ractive.subtract("foo") subtracts 1 from the value of foo', t => {
 		const ractive = new Ractive({
 			data: { foo: 10 }
 		});
@@ -15,7 +16,7 @@ export default function() {
 		t.equal( ractive.get( 'foo' ), 8 );
 	});
 
-	QUnit.test( 'ractive.subtract("foo",x) subtracts x from the value of foo', t => {
+	test( 'ractive.subtract("foo",x) subtracts x from the value of foo', t => {
 		const ractive = new Ractive({
 			data: { foo: 10 }
 		});

--- a/tests/browser/methods/toCSS.js
+++ b/tests/browser/methods/toCSS.js
@@ -1,5 +1,6 @@
 import { initModule } from '../../helpers/test-config';
 import { createIsolatedEnv } from '../../helpers/Environment';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/toCSS.js' );
@@ -18,7 +19,7 @@ export default function() {
 
 	}
 
-	QUnit.test( 'toCSS with a single component instance', t => {
+	test( 'toCSS with a single component instance', t => {
 
 		const Component = Ractive.extend( {
 			template: `<div></div>`,
@@ -43,7 +44,7 @@ export default function() {
 
 	} );
 
-	QUnit.test( 'toCSS with nested component instances', t => {
+	test( 'toCSS with nested component instances', t => {
 
 		const GrandChildComponent = Ractive.extend( {
 			template: `<div></div>`,
@@ -105,7 +106,7 @@ export default function() {
 	} );
 
 	if (!window.__karma__) {
-		QUnit.test( 'toCSS with components constructed from Ractive of different environments', t => {
+		test( 'toCSS with components constructed from Ractive of different environments', t => {
 			t.expect( 5 );
 
 			const done1 = t.async();
@@ -158,7 +159,7 @@ export default function() {
 		} );
 	}
 
-	QUnit.test( 'toCSS with a Ractive instance', t => {
+	test( 'toCSS with a Ractive instance', t => {
 
 		const app = new Ractive( {
 			el: fixture,

--- a/tests/browser/methods/toggle.js
+++ b/tests/browser/methods/toggle.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/toggle.js' );
 
-	QUnit.test( 'ractive.toggle("foo") toggles the value of foo', t => {
+	test( 'ractive.toggle("foo") toggles the value of foo', t => {
 		const ractive = new Ractive({
 			data: { foo: false }
 		});
@@ -15,7 +16,7 @@ export default function() {
 		t.ok( !ractive.get( 'foo' ) );
 	});
 
-	QUnit.test( 'non-boolean values are effectively coerced', t => {
+	test( 'non-boolean values are effectively coerced', t => {
 		const ractive = new Ractive({
 			data: {
 				foo: null,
@@ -35,7 +36,7 @@ export default function() {
 		t.ok(  ractive.get( 'qux' ) );
 	});
 
-	QUnit.test( 'each keypath that matches a wildcard is toggled individually (#1604)', t => {
+	test( 'each keypath that matches a wildcard is toggled individually (#1604)', t => {
 		const items = [
 			{ active: true },
 			{ active: false },

--- a/tests/browser/methods/transition.js
+++ b/tests/browser/methods/transition.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/transition.js' );
 
-	QUnit.test( 'Transitions method', t => {
+	test( 'Transitions method', t => {
 		const done = t.async();
 		t.expect(3);
 
@@ -37,7 +38,7 @@ export default function() {
 
 	// this test really likes to randomly fail on phantom
 	if ( !/phantom/i.test( navigator.userAgent ) ) {
-		QUnit.test( 'Use transitions from event with implicit node', t => {
+		test( 'Use transitions from event with implicit node', t => {
 			const done = t.async();
 			t.expect(2);
 

--- a/tests/browser/methods/unshift.js
+++ b/tests/browser/methods/unshift.js
@@ -1,11 +1,12 @@
 import { initModule } from '../../helpers/test-config';
 import { fire } from 'simulant';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/unshift.js' );
 
 	[ true, false ].forEach( modifyArrays => {
-		QUnit.test( `ractive.unshift() (modifyArrays: ${modifyArrays})`, t => {
+		test( `ractive.unshift() (modifyArrays: ${modifyArrays})`, t => {
 			const items = [ 'alice', 'bob', 'charles' ];
 
 			const ractive = new Ractive({
@@ -24,7 +25,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'unshift should make all indices update (#1729)', t => {
+	test( 'unshift should make all indices update (#1729)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{foo.0}}',
@@ -36,7 +37,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'second' );
 	});
 
-	QUnit.test( 'array modification with non-shuffle-able deps should update correctly', t => {
+	test( 'array modification with non-shuffle-able deps should update correctly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#foo}}{{.}}{{/}}{{foo.0}}',
@@ -48,7 +49,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '0120' );
 	});
 
-	QUnit.test( 'Check for this.model existence when rebinding (#2114)', t => {
+	test( 'Check for this.model existence when rebinding (#2114)', t => {
 		const list = [ {} ];
 
 		const ractive = new Ractive({
@@ -64,7 +65,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'yepnope' );
 	});
 
-	QUnit.test( 'Nested sections don\'t grow a context on rebind during smart updates #1737', t => {
+	test( 'Nested sections don\'t grow a context on rebind during smart updates #1737', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -94,7 +95,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'outer.0.inner.0 <span>outer.0.inner.0</span><br/>outer.1.inner.0 <span>outer.1.inner.0</span><br/>outer.1.inner.1 <span>outer.1.inner.1</span><br/>' );
 	});
 
-	QUnit.test( 'Array updates cause sections to shuffle with correct results', t => {
+	test( 'Array updates cause sections to shuffle with correct results', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#each items}}{{.title}}{{#each .tags}}{{.}}{{/each}}{{/each}}',
@@ -111,7 +112,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'threeoneAtwoBC' );
 	});
 
-	QUnit.test( 'nested contexts in iterative sections update correctly (#2660)', t => {
+	test( 'nested contexts in iterative sections update correctly (#2660)', t => {
 		t.expect( 1 );
 
 		const r = new Ractive({

--- a/tests/browser/methods/update.js
+++ b/tests/browser/methods/update.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/update.js' );
 
-	QUnit.test( 'resolves any unresolved references from parent contexts (#2141)', t => {
+	test( 'resolves any unresolved references from parent contexts (#2141)', t => {
 		const foo = {};
 		const r = new Ractive({
 			el: fixture,
@@ -17,7 +18,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( 'mappings are also marked along with the rest of the model (#2574)', t => {
+	test( 'mappings are also marked along with the rest of the model (#2574)', t => {
 		const cmp = Ractive.extend({
 			template: '{{foo.bar}}'
 		});
@@ -36,7 +37,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'still yep' );
 	});
 
-	QUnit.test( `an update can be forced on a keypath by passing force: true (#1671)`, t => {
+	test( `an update can be forced on a keypath by passing force: true (#1671)`, t => {
 		let msg = 'one';
 		const r = new Ractive({
 			target: fixture,

--- a/tests/browser/methods/updateModel.js
+++ b/tests/browser/methods/updateModel.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'methods/updateModel.js' );
 
-	QUnit.test( 'Works across component boundary', t => {
+	test( 'Works across component boundary', t => {
 		const widget = Ractive.extend({
 			template: '{{bar}}'
 		});
@@ -29,7 +30,7 @@ export default function() {
 		t.equal( ractive.findComponent( 'widget' ).get( 'bar' ), 'changed' );
 	});
 
-	QUnit.test( 'one-way bindings can be used to update the model (#1963)', t => {
+	test( 'one-way bindings can be used to update the model (#1963)', t => {
 		const cmp = Ractive.extend({
 			twoway: false,
 			template: '<input value="{{obj.foo}}" /><input value="{{obj[obj.key]}}" /><input type="checkbox" checked="{{obj.bar.baz}}" />'

--- a/tests/browser/misc.js
+++ b/tests/browser/misc.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { hasUsableConsole, onWarn, initModule } from '../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'misc.js' );
 
-	QUnit.test( 'Subclass instance data extends prototype data', t => {
+	test( 'Subclass instance data extends prototype data', t => {
 		const Subclass = Ractive.extend({
 			template: '{{foo}} {{bar}}',
 			data: { foo: 1 }
@@ -19,7 +20,7 @@ export default function() {
 		t.deepEqual( instance.get(), { foo: 1, bar: 2 });
 	});
 
-	QUnit.test( 'Subclasses of subclasses inherit data, partials and transitions', t => {
+	test( 'Subclasses of subclasses inherit data, partials and transitions', t => {
 		let wiggled;
 		let shimmied;
 
@@ -48,7 +49,7 @@ export default function() {
 	});
 
 	// Commenting out - can't think of a way to test this in 0.8
-	//QUnit.test( 'Multiple identical evaluators merge', t => {
+	//test( 'Multiple identical evaluators merge', t => {
 	// 	const ractive;
 	//
 	// 	ractive = new Ractive({
@@ -64,7 +65,7 @@ export default function() {
 	// 	t.equal( ractive.viewmodel.root.properties.length, 3 );
 	// });
 
-	QUnit.test( 'Boolean attributes work as expected', t => {
+	test( 'Boolean attributes work as expected', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input id="one" type="checkbox" checked="{{falsy}}"><input id="two" type="checkbox" checked="{{truthy}}">',
@@ -75,7 +76,7 @@ export default function() {
 		t.equal( ractive.find( '#two' ).checked, true );
 	});
 
-	QUnit.test( 'Instances can be created without an element', t => {
+	test( 'Instances can be created without an element', t => {
 		const ractive = new Ractive({
 			template: '<ul>{{#items:i}}<li>{{i}}: {{.}}</li>{{/items}}</ul>',
 			data: { items: [ 'a', 'b', 'c' ] }
@@ -84,7 +85,7 @@ export default function() {
 		t.ok( ractive );
 	});
 
-	QUnit.test( 'Instances without an element can render HTML', t => {
+	test( 'Instances without an element can render HTML', t => {
 		const ractive = new Ractive({
 			template: '<ul>{{#items:i}}<li>{{i}}: {{.}}</li>{{/items}}</ul>',
 			data: { items: [ 'a', 'b', 'c' ] }
@@ -93,7 +94,7 @@ export default function() {
 		t.htmlEqual( ractive.toHTML(), '<ul><li>0: a</li><li>1: b</li><li>2: c</li></ul>' );
 	});
 
-	QUnit.test( 'Triples work with toHTML', t => {
+	test( 'Triples work with toHTML', t => {
 		const ractive = new Ractive({
 			template: '{{{ triple }}}',
 			data: { triple: '<p>test</p>' }
@@ -102,7 +103,7 @@ export default function() {
 		t.htmlEqual( ractive.toHTML(), '<p>test</p>' );
 	});
 
-	QUnit.test( 'Passing in alternative delimiters', t => {
+	test( 'Passing in alternative delimiters', t => {
 		new Ractive({
 			el: fixture,
 			template: '/~ greeting ~/, /~recipient~/! /~~ triple ~~/',
@@ -118,7 +119,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'Hello, world! <p>here is some HTML</p>' );
 	});
 
-	QUnit.test( 'Using alternative delimiters in template', t => {
+	test( 'Using alternative delimiters in template', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{=/~ ~/=}} {{{=/~~ ~~/=}}} /~ greeting ~/, /~recipient~/! /~~ triple ~~/',
@@ -132,7 +133,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'Hello, world! <p>here is some HTML</p>' );
 	});
 
-	QUnit.test( '.unshift() works with proxy event handlers, without index references', t => {
+	test( '.unshift() works with proxy event handlers, without index references', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items}}<button on-click="bla">Level1: {{ title }}</button>{{/items}}',
@@ -146,7 +147,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<button>Level1: Title0</button><button>Level1: Title1</button>' );
 	});
 
-	QUnit.test( 'Updating values with properties corresponding to unresolved references works', t => {
+	test( 'Updating values with properties corresponding to unresolved references works', t => {
 		const user = {};
 
 		const ractive = new Ractive({
@@ -161,7 +162,7 @@ export default function() {
 		t.equal( fixture.innerHTML, 'Jim' );
 	});
 
-	QUnit.test( 'Setting nested properties with a keypath correctly updates value of intermediate keypaths', t => {
+	test( 'Setting nested properties with a keypath correctly updates value of intermediate keypaths', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#foo}}{{#bar}}{{baz}}{{/bar}}{{/foo}}'
@@ -171,7 +172,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'success' );
 	});
 
-	QUnit.test( 'Functions are called with the ractive instance as context', t => {
+	test( 'Functions are called with the ractive instance as context', t => {
 		t.expect( 1 );
 
 		onWarn( () => {} ); // suppress
@@ -186,7 +187,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Methods are called with their object as context', t => {
+	test( 'Methods are called with their object as context', t => {
 		t.expect( 1 );
 
 		onWarn( () => {} ); // suppress
@@ -205,7 +206,7 @@ export default function() {
 		ractive.set( 'foo', foo );
 	});
 
-	QUnit.test( 'Delimiters can be reset globally', t => {
+	test( 'Delimiters can be reset globally', t => {
 		const oldDelimiters = Ractive.defaults.delimiters;
 		const oldTripledDelimiters = Ractive.defaults.tripleDelimiters;
 
@@ -224,7 +225,7 @@ export default function() {
 		Ractive.defaults.tripleDelimiters = oldTripledDelimiters;
 	});
 
-	QUnit.test( 'Teardown works without throwing an error (#205)', t => {
+	test( 'Teardown works without throwing an error (#205)', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -241,7 +242,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'Bindings without explicit keypaths can survive a splice operation', t => {
+	test( 'Bindings without explicit keypaths can survive a splice operation', t => {
 		t.expect( 1 );
 
 		const items = new Array( 3 );
@@ -263,7 +264,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'Keypath resolutions that trigger teardowns don\'t cause the universe to implode', t => {
+	test( 'Keypath resolutions that trigger teardowns don\'t cause the universe to implode', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -283,7 +284,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'Inverted sections aren\'t broken by unshift operations', t => {
+	test( 'Inverted sections aren\'t broken by unshift operations', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{^items}}no items{{/items}}{{#items}}{{.}}{{/items}}',
@@ -295,7 +296,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo' );
 	});
 
-	QUnit.test( 'Splice operations that try to remove more items than there are from an array are handled', t => {
+	test( 'Splice operations that try to remove more items than there are from an array are handled', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items}}{{.}}{{/items}}',
@@ -307,7 +308,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'ab' );
 	});
 
-	QUnit.test( 'Partial templates will be drawn from script tags if not already registered', t => {
+	test( 'Partial templates will be drawn from script tags if not already registered', t => {
 		const partialScr = document.createElement( 'script' );
 		partialScr.id = 'thePartial';
 		partialScr.type = 'text/ractive';
@@ -324,7 +325,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '123' );
 	});
 
-	QUnit.test( 'ractive.insert() moves an instance to a different location', t => {
+	test( 'ractive.insert() moves an instance to a different location', t => {
 		const one = document.createElement( 'div' );
 		const two = document.createElement( 'div' );
 
@@ -351,7 +352,7 @@ export default function() {
 		t.htmlEqual( three.innerHTML, '<p>before</p><p>whee!</p><p class="after">after</p>' );
 	});
 
-	QUnit.test( 'ractive.insert() throws an error if instance is not rendered (#712)', t => {
+	test( 'ractive.insert() throws an error if instance is not rendered (#712)', t => {
 		const one = document.createElement( 'div' );
 		const two = document.createElement( 'div' );
 
@@ -380,7 +381,7 @@ export default function() {
 		t.htmlEqual( three.innerHTML, '<p>before</p><p>whee!</p><p class="after">after</p>' );
 	});
 
-	QUnit.test( 'Regression test for #271', t => {
+	test( 'Regression test for #271', t => {
 		const items = [{}];
 		const ractive = new Ractive({
 			el: fixture,
@@ -401,7 +402,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>foo</p>' );
 	});
 
-	QUnit.test( 'Partials in shuffled sections are updated/removed correctly (#297)', t => {
+	test( 'Partials in shuffled sections are updated/removed correctly (#297)', t => {
 		const items = [ 'one', 'two', 'three' ];
 
 		const ractive = new Ractive({
@@ -419,7 +420,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>one</p><p>three</p>' );
 	});
 
-	QUnit.test( 'Regression test for #316', t => {
+	test( 'Regression test for #316', t => {
 		const a = [];
 		const b = [];
 
@@ -438,7 +439,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo' );
 	});
 
-	QUnit.test( 'Regression test for #321', t => {
+	test( 'Regression test for #321', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -459,7 +460,7 @@ export default function() {
 		fire( buttons[1], 'click' );
 	});
 
-	QUnit.test( 'Evaluators that have a value of undefined behave correctly', t => {
+	test( 'Evaluators that have a value of undefined behave correctly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{ list[index] }}',
@@ -475,7 +476,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( 'Regression test for #798', t => {
+	test( 'Regression test for #798', t => {
 		function ClassB () {}
 		function ClassA () {}
 		ClassA.prototype.resources = new ClassB();
@@ -492,7 +493,7 @@ export default function() {
 		t.ok( ractive.findComponent( 'Widget' ).get( 'attr' ) instanceof ClassB );
 	});
 
-	QUnit.test( 'Subclass instance oncomplete() handlers can call _super', t => {
+	test( 'Subclass instance oncomplete() handlers can call _super', t => {
 		t.expect( 1 );
 
 		const done = t.async();
@@ -513,7 +514,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'ractive.insert() with triples doesn\'t invoke Yoda (#391)', t => {
+	test( 'ractive.insert() with triples doesn\'t invoke Yoda (#391)', t => {
 		const ractive = new Ractive({
 			el: document.createElement( 'div' ),
 			template: '{{{value}}}',
@@ -526,7 +527,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, ' you are <i>very puzzled now</i>' );
 	});
 
-	QUnit.test( 'Regression test for #460', t => {
+	test( 'Regression test for #460', t => {
 		const done = t.async();
 		const items = [
 			{ desc: 'foo' },
@@ -549,7 +550,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>foo:</p><p>bar:</p>' );
 	});
 
-	QUnit.test( 'Regression test for #457', t => {
+	test( 'Regression test for #457', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#step.current == step.current}}<p>{{foo}}</p>{{/step.current == step.current}}'
@@ -566,7 +567,7 @@ export default function() {
 	});
 
 	if ( Ractive.svg ) {
-		QUnit.test( 'Case-sensitive conditional SVG attribute', t => {
+		test( 'Case-sensitive conditional SVG attribute', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '<svg {{vb}}></svg>',
@@ -577,7 +578,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'Custom delimiters apply to partials (#601)', t => {
+	test( 'Custom delimiters apply to partials (#601)', t => {
 		new Ractive({
 			el: fixture,
 			template: '([#items:i])([>foo])([/items])',
@@ -590,7 +591,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '01' );
 	});
 
-	QUnit.test( 'Rendering to an element, if `append` is false, causes any existing instances to be torn down', t => {
+	test( 'Rendering to an element, if `append` is false, causes any existing instances to be torn down', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -650,7 +651,7 @@ export default function() {
 		t.equal( tripled, 1 );
 	});*/
 
-	QUnit.test( 'Regression test for #695 (unrendering non-rendered items)', t => {
+	test( 'Regression test for #695 (unrendering non-rendered items)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{# { items: nested.items } }}{{#insert}}{{#items}}<div as-foo></div>{{/items}}{{/insert}}{{/}}',
@@ -678,7 +679,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'A Promise will be rejected if its callback throws (#759)', t => {
+	test( 'A Promise will be rejected if its callback throws (#759)', t => {
 		const done = t.async();
 
 		const p = new Promise( () => {
@@ -691,7 +692,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'A Promise will be chained and rejected if its callback throws ', t => {
+	test( 'A Promise will be chained and rejected if its callback throws ', t => {
 		const done = t.async();
 
 		const p = Promise.resolve();
@@ -704,7 +705,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Keypaths in ractive.set() can contain wildcards (#784)', t => {
+	test( 'Keypaths in ractive.set() can contain wildcards (#784)', t => {
 		const ractive = new Ractive({
 			data: {
 				array: [
@@ -723,7 +724,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'object' ), { foo: 42, bar: 42, baz: 42 });
 	});
 
-	QUnit.test( 'Wildcard keypaths do not affect array length', t => {
+	test( 'Wildcard keypaths do not affect array length', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{array.length}}',
@@ -736,7 +737,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'array.length' ), 3 );
 	});
 
-	QUnit.test( 'Regression test for #801', t => {
+	test( 'Regression test for #801', t => {
 		const ractive = new Ractive({
 			el: document.createElement( 'div' ),
 			template: '<div>{{#(foo !== "bar")}}not bar{{#(foo !== "baz")}}not baz{{/()}}{{/()}}</div>',
@@ -749,7 +750,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'Regression test for #832', t => {
+	test( 'Regression test for #832', t => {
 		const ractive = new Ractive({
 			el: document.createElement( 'div' ),
 			template: '{{#if obj[foo].length}}{{#each obj[foo]}}{{this}}{{/each}}{{/if}}',
@@ -765,7 +766,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'Regression test for #857', t => {
+	test( 'Regression test for #857', t => {
 		const ractive = new Ractive({
 			el: document.createElement( 'div' ),
 			template: '<textarea value="{{foo}}"></textarea>',
@@ -777,7 +778,7 @@ export default function() {
 		t.equal( ractive.find( 'textarea' ).value, 'works' );
 	});
 
-	QUnit.test( 'oncomplete handlers are called for lazily-rendered instances (#749)', t => {
+	test( 'oncomplete handlers are called for lazily-rendered instances (#749)', t => {
 		t.expect( 1 );
 
 		const done = t.async();
@@ -794,7 +795,7 @@ export default function() {
 		ractive.render( fixture );
 	});
 
-	QUnit.test( 'Doctype declarations are handled, and the tag name is uppercased (#877)', t => {
+	test( 'Doctype declarations are handled, and the tag name is uppercased (#877)', t => {
 		const ractive = new Ractive({
 			template: '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>{{title}}</title></head><body>{{hello}} World!</body></html>',
 			data: { title: 'hi', hello: 'Hello' }
@@ -803,7 +804,7 @@ export default function() {
 		t.equal( ractive.toHTML(), '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>hi</title></head><body>Hello World!</body></html>' );
 	});
 
-	QUnit.test( 'Resolvers are torn down (#884)', t => {
+	test( 'Resolvers are torn down (#884)', t => {
 		t.expect( 0 );
 
 		const ractive = new Ractive({
@@ -827,7 +828,7 @@ export default function() {
 		ractive.set( 'currentStep', 1 );
 	});
 
-	QUnit.test( 'Regression test for #844', t => {
+	test( 'Regression test for #844', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -859,7 +860,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'some text  <a>toggle step: 1</a>' );
 	});
 
-	QUnit.test( 'Mustaches that re-resolve to undefined behave correctly (#908)', t => {
+	test( 'Mustaches that re-resolve to undefined behave correctly (#908)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -885,7 +886,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>1: one</p>' );
 	});
 
-	QUnit.test( 'Content renders to correct place when subsequent sections have no nodes (#910)', t => {
+	test( 'Content renders to correct place when subsequent sections have no nodes (#910)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{ >partial}} <!-- foo -->',
@@ -912,7 +913,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'before after' );
 	});
 
-	QUnit.test( 'Dependants can register more than once without error (#838)', t => {
+	test( 'Dependants can register more than once without error (#838)', t => {
 		t.expect( 0 );
 
 		const ractive = new Ractive({
@@ -931,7 +932,7 @@ export default function() {
 		ractive.set( 'foo', null );
 	});
 
-	QUnit.test( 'Ractive.extend() with parsed template (#939)', t => {
+	test( 'Ractive.extend() with parsed template (#939)', t => {
 		const parsed = Ractive.parse( '<p>{{foo}}</p>' );
 		const Widget = Ractive.extend({ template: parsed });
 
@@ -939,7 +940,7 @@ export default function() {
 		t.equal( ractive.toHTML(), '<p>bar</p>' );
 	});
 
-	QUnit.test( 'Regression test for #950', t => {
+	test( 'Regression test for #950', t => {
 		t.expect( 0 );
 
 		const ractive = new Ractive({
@@ -976,7 +977,7 @@ export default function() {
 		fire( select, 'change' );
 	});
 
-	QUnit.test( 'Custom delimiters apply to inline partials (#990)', t => {
+	test( 'Custom delimiters apply to inline partials (#990)', t => {
 		const ractive = new Ractive({
 			template: '([#partial a])abc([/partial])',
 			delimiters: [ '([', '])' ]
@@ -985,7 +986,7 @@ export default function() {
 		t.deepEqual( ractive.partials, { a : [ 'abc' ] });
 	});
 
-	QUnit.test( 'Regression test for #1019', t => {
+	test( 'Regression test for #1019', t => {
 		const done = t.async();
 
 		const ractive = new Ractive({
@@ -1005,7 +1006,7 @@ export default function() {
 		}, 100);
 	});
 
-	QUnit.test( 'Another regression test for #1019', t => {
+	test( 'Another regression test for #1019', t => {
 		const done = t.async();
 
 		const ractive = new Ractive({
@@ -1025,7 +1026,7 @@ export default function() {
 		}, 100);
 	});
 
-	QUnit.test( 'Regression test for #1003', t => {
+	test( 'Regression test for #1003', t => {
 		new Ractive({
 			el: fixture,
 			template: `
@@ -1039,7 +1040,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<select><option>x</option></select>' );
 	});
 
-	QUnit.test( 'Regression test for #1055', t => {
+	test( 'Regression test for #1055', t => {
 		const _ = {
 			bind () {
 				// do nothing
@@ -1061,7 +1062,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'FOO' );
 	});
 
-	QUnit.test( 'Interpolation of script/style contents can be disabled (#1050)', t => {
+	test( 'Interpolation of script/style contents can be disabled (#1050)', t => {
 		new Ractive({
 			el: fixture,
 			template: '<script>window.TEST_VALUE = "{{uninterpolated}}";</script>',
@@ -1078,7 +1079,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'Changing the length of a section has no effect to detached ractives until they are reattached (#1053)', t => {
+	test( 'Changing the length of a section has no effect to detached ractives until they are reattached (#1053)', t => {
 		let ractive = new Ractive({
 			el: fixture,
 			template: '{{#if foo}}yes{{else}}no{{/if}}',
@@ -1110,7 +1111,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'abcdef' );
 	});
 
-	QUnit.test( 'Regression test for #1038', t => {
+	test( 'Regression test for #1038', t => {
 		t.expect( 0 );
 
 		const done = t.async();
@@ -1144,7 +1145,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Reference expressions can become invalid after being valid, without breaking (#1106)', t => {
+	test( 'Reference expressions can become invalid after being valid, without breaking (#1106)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -1169,7 +1170,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'c' );
 	});
 
-	QUnit.test( 'Implicitly-closed elements without closing section tag (#1124)', t => {
+	test( 'Implicitly-closed elements without closing section tag (#1124)', t => {
 		// this test lives here, not in render.js, due to an awkward quirk with htmlEqual -
 		// it corrects malformed HTML before stubbing it
 		let ractive = new Ractive({
@@ -1187,7 +1188,7 @@ export default function() {
 		t.equal( ractive.findAll( 'tr > td' ).length, 3 );
 	});
 
-	QUnit.test( 'Reference expressions used in component parameters teardown properly (#1130)', t => {
+	test( 'Reference expressions used in component parameters teardown properly (#1130)', t => {
 
 		const ractive = new Ractive({
 			el: fixture,
@@ -1206,7 +1207,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'Regression test for #1166 (spellcheck bug)', t => {
+	test( 'Regression test for #1166 (spellcheck bug)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input class="one" spellcheck="false"><input class="two" spellchecker="false">',
@@ -1221,7 +1222,7 @@ export default function() {
 		t.equal( two.getAttribute( 'spellchecker' ), 'false' );
 	});
 
-	QUnit.test( '. reference without any implicit or explicit context should resolve to root', t => {
+	test( '. reference without any implicit or explicit context should resolve to root', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{JSON.stringify(.)}}',
@@ -1233,7 +1234,7 @@ export default function() {
 		t.equal( fixture.innerHTML, JSON.stringify( ractive.viewmodel.value ) );
 	});
 
-	QUnit.test( 'Nested conditional computations should survive unrendering and rerendering (#1364)', ( t ) => {
+	test( 'Nested conditional computations should survive unrendering and rerendering (#1364)', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#cond}}{{# i === 1 }}1{{/}}{{# i === 2 }}2{{/}}{{/}}',
@@ -1247,12 +1248,12 @@ export default function() {
 		t.equal( fixture.innerHTML, '2' );
 	});
 
-	QUnit.test( 'DOCTYPE declarations are stringified correctly', t => {
+	test( 'DOCTYPE declarations are stringified correctly', t => {
 		const template = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html></html>';
 		t.equal( new Ractive({ template }).toHTML(), template );
 	});
 
-	QUnit.test( 'Ractive.getNodeInfo returns correct keypath, index, and ractive info', t => {
+	test( 'Ractive.getNodeInfo returns correct keypath, index, and ractive info', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div><foo /></div>{{#bars:i}}<b>b</b><foo />{{/}}{{#baz}}{{#bat}}<p>hello</p>{{/}}{{/}}',
@@ -1294,7 +1295,7 @@ export default function() {
 		t.equal( p.resolve(), 'baz.bat' );
 	});
 
-	QUnit.test( 'Boolean attributes are added/removed based on unstringified fragment value', t => {
+	test( 'Boolean attributes are added/removed based on unstringified fragment value', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<button disabled="{{foo}}"></button>',
@@ -1310,7 +1311,7 @@ export default function() {
 		t.ok( !button.disabled );
 	});
 
-	QUnit.test( 'input[type=range] values are respected regardless of attribute order (#1621)', t => {
+	test( 'input[type=range] values are respected regardless of attribute order (#1621)', t => {
 		let ractive = new Ractive({
 			el: fixture,
 			template: '<input type="range" min="0" max="200" value="150"/>'
@@ -1326,7 +1327,7 @@ export default function() {
 		t.equal( ractive.find( 'input' ).value, 150 );
 	});
 
-	QUnit.test( 'regression test for #1630', t => {
+	test( 'regression test for #1630', t => {
 		const ractive = new Ractive();
 
 		const obj = { foo: 'bar' };
@@ -1337,7 +1338,7 @@ export default function() {
 		t.equal( ractive.get( 'constructor' ), obj.constructor );
 	});
 
-	QUnit.test( 'Ractive can be instantiated without `new`', t => {
+	test( 'Ractive can be instantiated without `new`', t => {
 		t.ok( Ractive() instanceof Ractive );
 
 		const Subclass = Ractive.extend();
@@ -1345,7 +1346,7 @@ export default function() {
 		t.ok( Subclass() instanceof Ractive );
 	});
 
-	QUnit.test( 'multiple pattern keypaths can be set simultaneously (#1319)', t => {
+	test( 'multiple pattern keypaths can be set simultaneously (#1319)', t => {
 		const ractive = new Ractive({
 			data: {
 				foo: [ 1, 2, 3 ],
@@ -1362,7 +1363,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'bar' ), [ 10, 10, 10 ] );
 	});
 
-	QUnit.test( 'Promise.all works with non-promises (#1642)', t => {
+	test( 'Promise.all works with non-promises (#1642)', t => {
 		const done = t.async();
 
 		// this test is redundant in browsers that support Promise natively
@@ -1372,7 +1373,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Setting an escaped . keypath', t => {
+	test( 'Setting an escaped . keypath', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{ foo\\.bar\\.baz }}`,
@@ -1384,7 +1385,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( 'Getting an escaped . keypath', t => {
+	test( 'Getting an escaped . keypath', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{ .['foo.bar.baz'] }}`,
@@ -1395,7 +1396,7 @@ export default function() {
 		t.equal( r.get( 'foo\\.bar\\.baz' ), 'yep' );
 	});
 
-	QUnit.test( '$ can be used in keypaths', t => {
+	test( '$ can be used in keypaths', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{ $$ }}{{ .['..'] }}`,
@@ -1411,7 +1412,7 @@ export default function() {
 		t.equal( r.get( '$$' ), 'set() works as well' );
 	});
 
-	QUnit.test( '. escapes can be escaped', t => {
+	test( '. escapes can be escaped', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{ .['foo\\\\'].bar }}{{ .['foo\\\\.bar'] }}`,
@@ -1431,7 +1432,7 @@ export default function() {
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'Ractive.DEBUG can be changed', t => {
+		test( 'Ractive.DEBUG can be changed', t => {
 			t.expect( 0 );
 
 			const DEBUG = Ractive.DEBUG;
@@ -1445,7 +1446,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( '@this special ref gives access to the ractive instance', t => {
+	test( '@this special ref gives access to the ractive instance', t => {
 		const DEBUG = Ractive.DEBUG;
 		const r = new Ractive({
 			el: fixture,
@@ -1476,7 +1477,7 @@ export default function() {
 		Ractive.DEBUG = DEBUG;
 	});
 
-	QUnit.test( 'shuffled elements have the correct keypath in their node info', t => {
+	test( 'shuffled elements have the correct keypath in their node info', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#each list}}<span>{{.}}</span>{{/each}}',
@@ -1488,12 +1489,12 @@ export default function() {
 		t.equal( Ractive.getNodeInfo( r.findAll( 'span' )[2] ).resolve(), 'list.2' );
 	});
 
-	QUnit.test( 'ractive.escapeKey() works correctly', t => {
+	test( 'ractive.escapeKey() works correctly', t => {
 		t.equal( Ractive.escapeKey( 'foo.bar' ), 'foo\\.bar' );
 		t.equal( Ractive.escapeKey( 'foo\\.bar' ), 'foo\\\\\\.bar' );
 	});
 
-	QUnit.test( 'spread args can be applied to any invocation expression', t => {
+	test( 'spread args can be applied to any invocation expression', t => {
 		t.expect( 4 );
 
 		const r = new Ractive({
@@ -1516,22 +1517,22 @@ export default function() {
 		r.push( 'list', 'a', 'b', 'c' );
 	});
 
-	QUnit.test( 'ractive.unescapeKey() works correctly', t => {
+	test( 'ractive.unescapeKey() works correctly', t => {
 		t.equal( Ractive.unescapeKey( 'foo\\.bar' ), 'foo.bar' );
 		t.equal( Ractive.unescapeKey( 'foo\\\\\\.bar' ), 'foo\\.bar' );
 	});
 
-	QUnit.test( 'ractive.joinKeys() works correctly', t => {
+	test( 'ractive.joinKeys() works correctly', t => {
 		t.equal( Ractive.joinKeys( 'foo', 'bar.baz' ), 'foo.bar\\.baz' );
 		t.equal( Ractive.joinKeys( 'foo', 'bar\\.baz' ), 'foo.bar\\\\\\.baz' );
 	});
 
-	QUnit.test( 'ractive.splitKeypath() works correctly', t => {
+	test( 'ractive.splitKeypath() works correctly', t => {
 		t.deepEqual( Ractive.splitKeypath( 'foo.bar\\.baz' ), [ 'foo', 'bar.baz' ] );
 		t.deepEqual( Ractive.splitKeypath( 'foo.bar\\\\\\.baz' ), [ 'foo', 'bar\\.baz' ] );
 	});
 
-	QUnit.test( 'triple curly binding', t => {
+	test( 'triple curly binding', t => {
 		t.expect( 11 );
 
 		onWarn( message => {
@@ -1563,7 +1564,7 @@ export default function() {
 
 	// Is there a way to artificially create a FileList? Leaving this commented
 	// out until someone smarter than me figures out how
-	//QUnit.test( '{{#each}} iterates over a FileList (#1220)', t => {
+	//test( '{{#each}} iterates over a FileList (#1220)', t => {
 	// 	var input, files, ractive;
 
 	// 	input = document.createElement( 'input' );
@@ -1584,7 +1585,7 @@ export default function() {
 	// });
 
 	if ( !/phantom/i.test( navigator.userAgent ) ) {
-		QUnit.test( '<input value="{{foo}}"> where foo === null should not render a value (#390)', t => {
+		test( '<input value="{{foo}}"> where foo === null should not render a value (#390)', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '<input value="{{foo}}">',
@@ -1596,7 +1597,7 @@ export default function() {
 			t.equal( ractive.find( 'input' ).value, '' );
 		});
 
-		QUnit.test( 'ractive.detach() removes an instance from the DOM and returns a document fragment', t => {
+		test( 'ractive.detach() removes an instance from the DOM and returns a document fragment', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '<p>{{foo}}</p>',
@@ -1610,7 +1611,7 @@ export default function() {
 			t.ok( docFrag.contains( p ) );
 		});
 
-		QUnit.test( 'ractive.detach() works with a previously unrendered ractive', t => {
+		test( 'ractive.detach() works with a previously unrendered ractive', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '<p>{{foo}}</p>',
@@ -1624,7 +1625,7 @@ export default function() {
 			t.ok( docFrag.contains( p ) );
 		});
 
-		QUnit.test( 'Components with two-way bindings set parent values on initialisation', t => {
+		test( 'Components with two-way bindings set parent values on initialisation', t => {
 			const Dropdown = Ractive.extend({
 				template: '<select value="{{value}}">{{#options}}<option value="{{this}}">{{ this[ display ] }}</option>{{/options}}</select>'
 			});
@@ -1648,7 +1649,7 @@ export default function() {
 			t.deepEqual( ractive.get( 'number' ), { word: 'one', digit: 1 });
 		});
 
-		QUnit.test( 'Tearing down expression mustaches and recreating them does\'t throw errors', t => {
+		test( 'Tearing down expression mustaches and recreating them does\'t throw errors', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '{{#condition}}{{( a+b )}} {{( a+b )}} {{( a+b )}}{{/condition}}',
@@ -1664,7 +1665,7 @@ export default function() {
 			t.equal( fixture.innerHTML, '3 3 3' );
 		});
 
-		QUnit.test( 'Updating an expression section doesn\'t throw errors', t => {
+		test( 'Updating an expression section doesn\'t throw errors', t => {
 			const array = [{ foo: 1 }, { foo: 2 }, { foo: 3 }, { foo: 4 }, { foo: 5 }];
 
 			const ractive = new Ractive({
@@ -1689,7 +1690,7 @@ export default function() {
 			t.equal( fixture.innerHTML, '012' );
 		});
 
-		QUnit.test( 'noConflict reinstates original Ractive value (#2066)', t => {
+		test( 'noConflict reinstates original Ractive value (#2066)', t => {
 			const r = Ractive;
 			const noConflict = r.noConflict();
 
@@ -1699,7 +1700,7 @@ export default function() {
 			Ractive = r;
 		});
 
-		QUnit.test( 'Updating a list section with child list expressions doesn\'t throw errors', t => {
+		test( 'Updating a list section with child list expressions doesn\'t throw errors', t => {
 			const array = [
 				{ foo: [ 1, 2, 3, 4, 5 ] },
 				{ foo: [ 2, 3, 4, 5, 6 ] },
@@ -1730,7 +1731,7 @@ export default function() {
 			t.htmlEqual( fixture.innerHTML, '<p>012</p><p>123</p><p>234</p><p>345</p><p>456</p><p>567</p><p>678</p>' );
 		});
 
-		QUnit.test( `trying to set a property on a non-object doesn't break the world (#2451)`, t => {
+		test( `trying to set a property on a non-object doesn't break the world (#2451)`, t => {
 			t.expect( 1 );
 
 			onWarn( w => {
@@ -1743,7 +1744,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( `you can request more lines of context for parser errors`, t => {
+	test( `you can request more lines of context for parser errors`, t => {
 		try {
 			Ractive.parse( 'hello\n{{foo}\nworld', { contextLines: 1 } );
 		} catch (e) {
@@ -1751,7 +1752,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( `setting a null value to null does nothing`, t => {
+	test( `setting a null value to null does nothing`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `{{#if !foo}}yep{{/if}}`,
@@ -1764,7 +1765,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep' );
 	});
 
-	QUnit.test( `non-bmp characters in templates`, t => {
+	test( `non-bmp characters in templates`, t => {
 		new Ractive({
 			target: fixture,
 			template: '{{foo}}',
@@ -1774,7 +1775,7 @@ export default function() {
 		t.equal( fixture.innerHTML, '😀𠀀'  );
 	});
 
-	QUnit.test( `entities in triples survive toHTML (#2882)`, t => {
+	test( `entities in triples survive toHTML (#2882)`, t => {
 		const r = new Ractive({
 			template: '{{{html}}}',
 			data: {

--- a/tests/browser/node-info.js
+++ b/tests/browser/node-info.js
@@ -1,9 +1,10 @@
 import { initModule } from '../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule('node-info.js');
 
-	QUnit.test( 'node info relative data get' , t => {
+	test( 'node info relative data get' , t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo}}{{#bar}}<span>hello</span>{{/}}{{/with}}`,
@@ -15,7 +16,7 @@ export default function() {
 		t.equal( info.get( '../bat' ), 'yep' );
 	});
 
-	QUnit.test( 'node info relative data get with expression', t => {
+	test( 'node info relative data get with expression', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo()}}{{#bar}}<span>hello</span>{{/}}{{/with}}`,
@@ -30,7 +31,7 @@ export default function() {
 		t.equal( info.get( '../bat' ), 'yep' );
 	});
 
-	QUnit.test( 'node info alias data get' , t => {
+	test( 'node info alias data get' , t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo as wat}}{{#wat.bar}}<span>hello</span>{{/}}{{/with}}`,
@@ -42,7 +43,7 @@ export default function() {
 		t.equal( info.get( 'wat.bat' ), 'yep' );
 	});
 
-	QUnit.test( 'node info index ref get' , t => {
+	test( 'node info index ref get' , t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items:i}}<span />{{/each}}`,
@@ -54,7 +55,7 @@ export default function() {
 		t.equal( info.get( 'i' ), 0 );
 	});
 
-	QUnit.test( 'node info key ref get' , t => {
+	test( 'node info key ref get' , t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each obj:k}}<span />{{/each}}`,
@@ -66,7 +67,7 @@ export default function() {
 		t.equal( info.get( 'k' ), 'foo' );
 	});
 
-	QUnit.test( 'node info index ref get' , t => {
+	test( 'node info index ref get' , t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items}}<span />{{/each}}`,
@@ -78,7 +79,7 @@ export default function() {
 		t.equal( info.get( '@index' ), 0 );
 	});
 
-	QUnit.test( 'node info relative set' , t => {
+	test( 'node info relative set' , t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items}}<span />{{/each}}`,
@@ -91,7 +92,7 @@ export default function() {
 		t.equal( r.get( 'items.0.foo' ), 'ha' );
 	});
 
-	QUnit.test( 'node info relative set with map' , t => {
+	test( 'node info relative set with map' , t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items}}<span />{{/each}}`,
@@ -105,7 +106,7 @@ export default function() {
 		t.equal( r.get( 'items.0.bar' ), 'yep' );
 	});
 
-	QUnit.test( 'node info alias set' , t => {
+	test( 'node info alias set' , t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items as item}}<span />{{/each}}`,
@@ -118,7 +119,7 @@ export default function() {
 		t.equal( r.get( 'items.0.foo' ), 'ha' );
 	});
 
-	QUnit.test( 'node info add' , t => {
+	test( 'node info add' , t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo}}{{#bar}}<span>hello</span>{{/}}{{/with}}`,
@@ -133,7 +134,7 @@ export default function() {
 		t.equal( r.get( 'foo.bat' ), 84 );
 	});
 
-	QUnit.test( 'node info add with map', t => {
+	test( 'node info add with map', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo}}{{#bar}}<span>hello</span>{{/}}{{/with}}`,
@@ -147,7 +148,7 @@ export default function() {
 		t.equal( r.get( 'foo.bop' ), 2 );
 	});
 
-	QUnit.test( 'node info subtract' , t => {
+	test( 'node info subtract' , t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo}}{{#bar}}<span>hello</span>{{/}}{{/with}}`,
@@ -162,7 +163,7 @@ export default function() {
 		t.equal( r.get( 'foo.bat' ), -2 );
 	});
 
-	QUnit.test( 'node info subtract with map', t => {
+	test( 'node info subtract with map', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo}}{{#bar}}<span>hello</span>{{/}}{{/with}}`,
@@ -176,7 +177,7 @@ export default function() {
 		t.equal( r.get( 'foo.bop' ), -1 );
 	});
 
-	QUnit.test( 'node info animate', t => {
+	test( 'node info animate', t => {
 		const done = t.async();
 		t.expect( 1 );
 
@@ -194,7 +195,7 @@ export default function() {
 		}, done);
 	});
 
-	QUnit.test( 'node info toggle' , t => {
+	test( 'node info toggle' , t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo}}{{#bar}}<span>hello</span>{{/}}{{/with}}`,
@@ -207,7 +208,7 @@ export default function() {
 		t.equal( r.get( 'foo.bar.baz' ), false );
 	});
 
-	QUnit.test( 'node info update', t => {
+	test( 'node info update', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo.bar}}<input value={{.baz}} />{{/with}}`,
@@ -220,7 +221,7 @@ export default function() {
 		t.equal( r.get( 'foo.bar.baz' ), 'yep' );
 	});
 
-	QUnit.test( 'node info updateModel', t => {
+	test( 'node info updateModel', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo.bar}}<input value={{.baz}} />{{/with}}`,
@@ -234,7 +235,7 @@ export default function() {
 		t.equal( r.get( 'foo.bar.baz' ), 'yep' );
 	});
 
-	QUnit.test( 'node info link', t => {
+	test( 'node info link', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo.bar}}<span />{{/with}}`,
@@ -247,7 +248,7 @@ export default function() {
 		t.equal( r.get( 'str' ), 'hello' );
 	});
 
-	QUnit.test( 'node info unlink', t => {
+	test( 'node info unlink', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo.bar}}<span />{{/with}}`,
@@ -263,7 +264,7 @@ export default function() {
 		t.ok( r.get( 'str' ) !== 'yep' );
 	});
 
-	QUnit.test( `node info readLink`, t => {
+	test( `node info readLink`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `{{#with bip}}<span />{{/with}}`,
@@ -275,7 +276,7 @@ export default function() {
 		t.equal( r.getNodeInfo( 'span' ).readLink( '.bop' ).keypath, 'foo.bar.baz.bat' );
 	});
 
-	QUnit.test( 'node info shuffle set', t => {
+	test( 'node info shuffle set', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items}}<span />{{/each}}`,
@@ -293,7 +294,7 @@ export default function() {
 		t.ok( postSpans[0] === spans[1] && postSpans[1] === spans[0] );
 	});
 
-	QUnit.test( 'node info push', t => {
+	test( 'node info push', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items}}<span />{{/each}}`,
@@ -307,7 +308,7 @@ export default function() {
 		t.equal( r.findAll( 'span' ).length, 2 );
 	});
 
-	QUnit.test( 'node info pop', t => {
+	test( 'node info pop', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items}}<span />{{/each}}`,
@@ -321,7 +322,7 @@ export default function() {
 		t.equal( r.findAll( 'span' ).length, 0 );
 	});
 
-	QUnit.test( 'node info sort', t => {
+	test( 'node info sort', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items}}<span>{{.}}</span>{{/each}}`,
@@ -335,7 +336,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<span>0</span><span>1</span><span>2</span>' );
 	});
 
-	QUnit.test( 'node info sreverse', t => {
+	test( 'node info sreverse', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items}}<span>{{.}}</span>{{/each}}`,
@@ -349,7 +350,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<span>2</span><span>0</span><span>1</span>' );
 	});
 
-	QUnit.test( 'node info shift', t => {
+	test( 'node info shift', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items}}<span />{{/each}}`,
@@ -363,7 +364,7 @@ export default function() {
 		t.equal( r.findAll( 'span' ).length, 0 );
 	});
 
-	QUnit.test( 'node info unshift', t => {
+	test( 'node info unshift', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items}}<span />{{/each}}`,
@@ -377,7 +378,7 @@ export default function() {
 		t.equal( r.findAll( 'span' ).length, 2 );
 	});
 
-	QUnit.test( 'node info splice', t => {
+	test( 'node info splice', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items}}<span />{{/each}}`,
@@ -392,7 +393,7 @@ export default function() {
 		t.equal( r.get( 'items.0' ), 3 );
 	});
 
-	QUnit.test( 'node info isBound', t => {
+	test( 'node info isBound', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo.bar}}<input value={{.baz}} /> <input value="test" />{{/with}}`,
@@ -405,7 +406,7 @@ export default function() {
 		t.ok( !info.isBound() );
 	});
 
-	QUnit.test( 'node info two-way binding path', t => {
+	test( 'node info two-way binding path', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo.bar}}<input value={{.baz}} />{{/with}}`,
@@ -416,7 +417,7 @@ export default function() {
 		t.equal( info.getBindingPath(), 'foo.bar.baz' );
 	});
 
-	QUnit.test( 'node info two-way binding get value', t => {
+	test( 'node info two-way binding get value', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo.bar}}<input value={{.baz}} />{{/with}}`,
@@ -427,7 +428,7 @@ export default function() {
 		t.equal( info.getBinding(), 'hello' );
 	});
 
-	QUnit.test( 'node info two-way binding set value', t => {
+	test( 'node info two-way binding set value', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo.bar}}<input value={{.baz}} />{{/with}}`,
@@ -439,7 +440,7 @@ export default function() {
 		t.equal( r.get( 'foo.bar.baz' ), 'yep' );
 	});
 
-	QUnit.test( 'node info with query selector', t => {
+	test( 'node info with query selector', t => {
 		new Ractive({
 			el: fixture,
 			template: `{{#with foo.bar}}<span id="baz">yep</span>{{/with}}`,
@@ -449,7 +450,7 @@ export default function() {
 		t.equal( Ractive.getNodeInfo( '#baz' ).resolve(), 'foo.bar' );
 	});
 
-	QUnit.test( 'node info from instance', t => {
+	test( 'node info from instance', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo.bar}}<span id="baz">yep</span>{{/with}}`,
@@ -459,7 +460,7 @@ export default function() {
 		t.equal( r.getNodeInfo( r.find( '#baz' ) ).resolve(), 'foo.bar' );
 	});
 
-	QUnit.test( 'node info from instance with selector', t => {
+	test( 'node info from instance with selector', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo.bar}}<span id="baz">yep</span>{{/with}}`,
@@ -469,7 +470,7 @@ export default function() {
 		t.equal( r.getNodeInfo( '#baz' ).resolve(), 'foo.bar' );
 	});
 
-	QUnit.test( `decorator objects are available from node info objects`, t => {
+	test( `decorator objects are available from node info objects`, t => {
 		let flag = false;
 		const r = new Ractive({
 			target: fixture,
@@ -491,7 +492,7 @@ export default function() {
 		t.ok( flag );
 	});
 
-	QUnit.test( `context observe resolves using the context fragment`, t => {
+	test( `context observe resolves using the context fragment`, t => {
 		let count = 0;
 		const r = new Ractive({
 			target: fixture,
@@ -507,7 +508,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( `context observe works with a map and wildcards`, t => {
+	test( `context observe works with a map and wildcards`, t => {
 		let count = 0;
 		const r = new Ractive({
 			target: fixture,
@@ -529,7 +530,7 @@ export default function() {
 		t.equal( count, 3 );
 	});
 
-	QUnit.test( `context observeOnce resolves using the context fragment`, t => {
+	test( `context observeOnce resolves using the context fragment`, t => {
 		let count = 0;
 		const r = new Ractive({
 			target: fixture,
@@ -554,7 +555,7 @@ export default function() {
 		t.equal( count, 3 );
 	});
 
-	QUnit.test( `context objects can trigger events on their element`, t => {
+	test( `context objects can trigger events on their element`, t => {
 		t.expect( 1 );
 
 		const r = new Ractive({
@@ -567,7 +568,7 @@ export default function() {
 		r.getNodeInfo( 'div' ).raise( 'foo', {}, 'bar' );
 	});
 
-	QUnit.test( `context objects can trigger events on parent elements`, t => {
+	test( `context objects can trigger events on parent elements`, t => {
 		t.expect( 1 );
 
 		const cmp = Ractive.extend({
@@ -583,7 +584,7 @@ export default function() {
 		r.getNodeInfo( 'span' ).raise( 'foo' );
 	});
 
-	QUnit.test( `getting node info for a non-ractive element returns undefined (#2819)`, t => {
+	test( `getting node info for a non-ractive element returns undefined (#2819)`, t => {
 		const r = new Ractive({
 			el: fixture
 		});
@@ -592,7 +593,7 @@ export default function() {
 		t.ok( Ractive.getNodeInfo( document.body ) === undefined );
 	});
 
-	QUnit.test( `getting node info for a host element returns the context of the hosted instance if there is only one (#2865)`, t => {
+	test( `getting node info for a host element returns the context of the hosted instance if there is only one (#2865)`, t => {
 		const r1 = new Ractive({
 			target: fixture,
 			template: 'a'
@@ -613,7 +614,7 @@ export default function() {
 		t.ok( Ractive.getNodeInfo( fixture ).ractive === r2 );
 	});
 
-	QUnit.test( `force update works from a context object`, t => {
+	test( `force update works from a context object`, t => {
 		let msg = 'one';
 		const r = new Ractive({
 			target: fixture,

--- a/tests/browser/parse.js
+++ b/tests/browser/parse.js
@@ -1,5 +1,6 @@
 import tests from '../helpers/samples/parse';
 import { initModule } from '../helpers/test-config';
+import { test } from 'qunit';
 
 /* global navigator */
 
@@ -8,7 +9,7 @@ export default function() {
 
 	const phantom = /phantomjs/i.test( navigator.userAgent );
 
-	QUnit.test( 'Mismatched template version causes error', ( t ) => {
+	test( 'Mismatched template version causes error', ( t ) => {
 		t.throws( () => {
 			new Ractive({
 				template: {v:'nope',t:[]}
@@ -19,7 +20,7 @@ export default function() {
 	tests.forEach( theTest => {
 		if ( theTest.skipPhantom && phantom ) return;
 
-		QUnit.test( theTest.name, ( t ) => {
+		test( theTest.name, ( t ) => {
 			// disable for tests unless explicitly specified
 			// we can just test the signatures, so set false
 			theTest.options = theTest.options || { csp: false };

--- a/tests/browser/partials.js
+++ b/tests/browser/partials.js
@@ -1,6 +1,7 @@
 /* global document */
 import { initModule, hasUsableConsole, onWarn } from '../helpers/test-config';
 import { fire } from 'simulant';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'partials.js' );
@@ -11,7 +12,7 @@ export default function() {
 		}
 	};
 
-	QUnit.test( 'specify partial by function', t => {
+	test( 'specify partial by function', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{>foo}}',
@@ -23,7 +24,7 @@ export default function() {
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'no return of partial warns in debug', t => {
+		test( 'no return of partial warns in debug', t => {
 			t.expect( 2 );
 
 			onWarn( msg => {
@@ -44,7 +45,7 @@ export default function() {
 			});
 		});
 
-		QUnit.test( 'Warn on unknown partial', t => {
+		test( 'Warn on unknown partial', t => {
 			t.expect( 2 );
 
 			onWarn( () => t.ok( true ) );
@@ -56,7 +57,7 @@ export default function() {
 			});
 		});
 
-		QUnit.test( 'Don\'t warn on empty partial', t => {
+		test( 'Don\'t warn on empty partial', t => {
 			t.expect( 1 );
 
 			onWarn( () => {
@@ -75,7 +76,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( '`this` in function refers to ractive instance', t => {
+	test( '`this` in function refers to ractive instance', t => {
 		let thisForFoo;
 		let thisForBar;
 
@@ -105,7 +106,7 @@ export default function() {
 		t.equal( thisForBar, ractive );
 	});
 
-	QUnit.test( 'partial function has access to parser helper', t => {
+	test( 'partial function has access to parser helper', t => {
 		t.expect( 1 );
 
 		new Ractive({
@@ -120,7 +121,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'partial can be preparsed template (#942)', t => {
+	test( 'partial can be preparsed template (#942)', t => {
 		const partial = Ractive.parse( '<p>hello partial</p>' );
 
 		new Ractive({
@@ -132,7 +133,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>hello partial</p>' );
 	});
 
-	QUnit.test( 'partial functions belong to instance, not Component', t => {
+	test( 'partial functions belong to instance, not Component', t => {
 		const Component = Ractive.extend({
 			template: '{{>foo}}',
 			partials: partialsFn
@@ -150,7 +151,7 @@ export default function() {
 		t.equal( ractive2.toHTML(), '<h1>no</h1>' );
 	});
 
-	QUnit.test( 'partial functions selects same partial until reset', t => {
+	test( 'partial functions selects same partial until reset', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items}}{{>foo}}{{/items}}',
@@ -173,7 +174,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>1</p><p>2</p>' );
 	});
 
-	QUnit.test( 'reset data re-evaluates partial function', t => {
+	test( 'reset data re-evaluates partial function', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{>foo}}',
@@ -186,7 +187,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<h1>no</h1>' );
 	});
 
-	QUnit.test( 'partials functions can be found on view heirarchy', t => {
+	test( 'partials functions can be found on view heirarchy', t => {
 		const Widget = Ractive.extend({
 			template: '{{>foo}}',
 			isolated: false
@@ -205,7 +206,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<h1>no</h1>' );
 	});
 
-	QUnit.test( 'static partials are compiled on Component not instance', t => {
+	test( 'static partials are compiled on Component not instance', t => {
 		const Component = Ractive.extend({
 			template: '{{>foo}}',
 			partials: {
@@ -221,7 +222,7 @@ export default function() {
 		t.deepEqual( Component.partials.foo, [{ t:7, e: 'p', f: [{ t:2, r: 'foo' }] }] );
 	});
 
-	QUnit.test( 'Partials work in attributes (#917)', t => {
+	test( 'Partials work in attributes (#917)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div style="{{>boxAttr}}"/>',
@@ -239,7 +240,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML.replace( /\s+/g, '' ), `<div style="height: 200px;"></div>`.replace( /\s+/g, '' ) );
 	});
 
-	QUnit.test( 'Partial name can be a reference', t => {
+	test( 'Partial name can be a reference', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `{{#each items}}{{>type}}{{/each}}`,
@@ -260,7 +261,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, ':FOO:BAZ:FOO:BAZ:FOO' );
 	});
 
-	QUnit.test( 'Partial name can be an expression', t => {
+	test( 'Partial name can be an expression', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `{{>'partial_' + x}}`,
@@ -276,7 +277,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'second' );
 	});
 
-	QUnit.test( 'Expression partials can be nested', t => {
+	test( 'Expression partials can be nested', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `{{>'NESTED'.toLowerCase()}}`,
@@ -295,7 +296,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>it still works</p>' );
 	});
 
-	QUnit.test( 'Partials with expressions may also have context', ( t ) => {
+	test( 'Partials with expressions may also have context', ( t ) => {
 		new Ractive({
 			el: fixture,
 			template: '{{>(tpl + ".test") ctx}} : {{>"test." + tpl ctx.expr}}',
@@ -312,7 +313,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'inverted - 1 : normal - 2');
 	});
 
-	QUnit.test( 'Partials with context should still have access to special refs (#2164)', t => {
+	test( 'Partials with context should still have access to special refs (#2164)', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{>foo bar.baz}}',
@@ -324,7 +325,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'bar.baz.bop' );
 	});
 
-	QUnit.test( 'Partials .toString() works when not the first child of parent (#1163)', t => {
+	test( 'Partials .toString() works when not the first child of parent (#1163)', t => {
 		const ractive = new Ractive({
 			template: '<div>Foo {{>foo}}</div>',
 			partials: { foo: '...' }
@@ -333,7 +334,7 @@ export default function() {
 		t.htmlEqual( ractive.toHTML(), '<div>Foo ...</div>' );
 	});
 
-	QUnit.test( 'Dynamic partial works with shuffle set (#1313)', t => {
+	test( 'Dynamic partial works with shuffle set (#1313)', t => {
 		let fields = [
 			{ type: 'text', value: 'hello' },
 			{ type: 'number', value: 123 }
@@ -357,7 +358,7 @@ export default function() {
 		t.htmlEqual( ractive.toHTML(), 'number123texthello' );
 	});
 
-	QUnit.test( 'Nameless expressions with no matching partial don\'t throw', t => {
+	test( 'Nameless expressions with no matching partial don\'t throw', t => {
 		onWarn( msg => t.ok( /Could not find template for partial 'missing'/.test( msg ) ) );
 
 		const ractive = new Ractive({
@@ -368,7 +369,7 @@ export default function() {
 		t.htmlEqual( ractive.toHTML(), '' );
 	});
 
-	QUnit.test( 'Partials can be changed with resetPartial', t => {
+	test( 'Partials can be changed with resetPartial', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `wrapped {{>'partial'}} around`,
@@ -382,7 +383,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'wrapped ninner around' );
 	});
 
-	QUnit.test( 'Partials with variable names can be changed with resetPartial', t => {
+	test( 'Partials with variable names can be changed with resetPartial', t => {
 		onWarn( msg => t.ok( /Could not find template for partial 'partial'/.test( msg ) ) );
 
 		const ractive = new Ractive({
@@ -405,7 +406,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'wrapped nbar around' );
 	});
 
-	QUnit.test( 'Partials with expression names can be changed with resetPartial', t => {
+	test( 'Partials with expression names can be changed with resetPartial', t => {
 		onWarn( msg => t.ok( /Could not find template for partial 'undefinedPartial'/.test( msg ) ) );
 
 		const ractive = new Ractive({
@@ -423,7 +424,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'wrapped nfoo around' );
 	});
 
-	QUnit.test( 'Partials inside conditionals can be changed with resetPartial', t => {
+	test( 'Partials inside conditionals can be changed with resetPartial', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `{{#cond}}{{>partial}}{{/}}`,
@@ -439,7 +440,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'nfoo' );
 	});
 
-	QUnit.test( 'Partials (only) borrowed by components can be changed with resetPartial', t => {
+	test( 'Partials (only) borrowed by components can be changed with resetPartial', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{>foo}} {{>bar}} <component />',
@@ -467,7 +468,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'nrfoo nrbar nrfoo ncbar' );
 	});
 
-	QUnit.test( 'Partials inside iteratives can be changed with resetPartial', t => {
+	test( 'Partials inside iteratives can be changed with resetPartial', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#list}}{{>.type}}{{/}}',
@@ -488,7 +489,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'nt2' );
 	});
 
-	QUnit.test( 'Nested partials can be changed with resetPartial', t => {
+	test( 'Nested partials can be changed with resetPartial', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{>outer}}',
@@ -507,7 +508,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'outer' );
 	});
 
-	QUnit.test( 'Partials in context blocks can be changed with resetPartial', t => {
+	test( 'Partials in context blocks can be changed with resetPartial', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `{{#with { ctx: 'foo' } }}{{>ctx}}{{/with}}`,
@@ -521,7 +522,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'nfoo' );
 	});
 
-	QUnit.test( 'Partials in attributes can be changed with resetPartial', t => {
+	test( 'Partials in attributes can be changed with resetPartial', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div class="wrapped {{>foo}} around" id="{{>foo}}"></div>',
@@ -535,7 +536,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div class="wrapped around nfoo" id="nfoo"></div>' );
 	});
 
-	QUnit.test( 'Partials in attribute blocks can be changed with resetPartial', t => {
+	test( 'Partials in attribute blocks can be changed with resetPartial', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `<div {{#cond}}class="wrapped {{>foo}} around" id="{{>foo}}" {{>attr}}{{/}}></div>`,
@@ -554,7 +555,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div class="wrapped nfoo around" id="nfoo" alt="bar"></div>' );
 	});
 
-	QUnit.test( 'Partial naming requirements are relaxed', t => {
+	test( 'Partial naming requirements are relaxed', t => {
 		new Ractive({
 			el: fixture,
 			template: `{{>a-partial}}{{>10-2}}{{>a - partial}}{{>delete}}`,
@@ -572,7 +573,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'abbc' );
 	});
 
-	QUnit.test( 'Inline partials can override component partials', t => {
+	test( 'Inline partials can override component partials', t => {
 		new Ractive({
 			el: fixture,
 			template: `
@@ -594,7 +595,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'inline component' );
 	});
 
-	QUnit.test( 'Inline partials may be defined with a partial section', t => {
+	test( 'Inline partials may be defined with a partial section', t => {
 		new Ractive({
 			el: fixture,
 			template: `
@@ -615,7 +616,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo foo bar' );
 	});
 
-	QUnit.test( 'inline partials take precedent over assigned instance partials for yield', t => {
+	test( 'inline partials take precedent over assigned instance partials for yield', t => {
 		onWarn( msg => t.ok( /Could not find template for partial "foo"/.test( msg ) ) );
 
 		const Widget = Ractive.extend({
@@ -634,7 +635,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'bar foo' );
 	});
 
-	QUnit.test( 'Don\'t throw on empty partial', t => {
+	test( 'Don\'t throw on empty partial', t => {
 		t.expect( 1 );
 
 		new Ractive({
@@ -649,7 +650,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'Dynamic empty partial ok', t => {
+	test( 'Dynamic empty partial ok', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{>foo}}',
@@ -669,7 +670,7 @@ export default function() {
 
 	});
 
-	QUnit.test( 'Partials with expressions in recursive structures should not blow the stack', t => {
+	test( 'Partials with expressions in recursive structures should not blow the stack', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{#items}}{{>\'item\'}}{{/}}',
@@ -686,7 +687,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'ab' );
 	});
 
-	QUnit.test( 'Named partials should not get rebound if they happen to have the same name as a reference (#1507)', t => {
+	test( 'Named partials should not get rebound if they happen to have the same name as a reference (#1507)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -714,7 +715,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'abc c' );
 	});
 
-	QUnit.test( 'Partials from the template hierarchy should take precedent over references', t => {
+	test( 'Partials from the template hierarchy should take precedent over references', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `<p>
@@ -741,7 +742,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p> abc c</p>' );
 	});
 
-	QUnit.test( 'Partial names can have slashes', t => {
+	test( 'Partial names can have slashes', t => {
 		new Ractive({
 			el: fixture,
 			template: '<p>{{#partial foo/bar}}foobar{{/partial}}{{> foo/bar}}</p>'
@@ -750,7 +751,7 @@ export default function() {
 		t.htmlEqual( '<p>foobar</p>', fixture.innerHTML );
 	});
 
-	QUnit.test( 'Several inline partials containing elements can be defined (#1736)', t => {
+	test( 'Several inline partials containing elements can be defined (#1736)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -769,7 +770,7 @@ export default function() {
 		t.equal( ractive.partials.part2.length, 1 );
 	});
 
-	QUnit.test( 'Removing a missing partial (#1808)', t => {
+	test( 'Removing a missing partial (#1808)', t => {
 		t.expect( 1 );
 
 		onWarn( msg => t.ok( /Could not find template for partial 'item'/.test( msg ) ) );
@@ -786,7 +787,7 @@ export default function() {
 		ractive.shift( 'items' );
 	});
 
-	QUnit.test( 'Dynamic partial can be set in oninit (#1826)', t => {
+	test( 'Dynamic partial can be set in oninit (#1826)', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{> partialName }}',
@@ -805,7 +806,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'twopart' );
 	});
 
-	QUnit.test( 'Inline partials don\'t dissipate into the ether when attached to non-components (#1838)', t => {
+	test( 'Inline partials don\'t dissipate into the ether when attached to non-components (#1838)', t => {
 		new Ractive({
 			el: fixture,
 			template: '<div>{{#partial foo}}foo{{/partial}}{{>foo}}</div>'
@@ -814,7 +815,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>foo</div>' );
 	});
 
-	QUnit.test( 'Inline partials can override instance partials if they exist on a node directly up-hierarchy', t => {
+	test( 'Inline partials can override instance partials if they exist on a node directly up-hierarchy', t => {
 		new Ractive({
 			el: fixture,
 			template: `{{#partial foo}}
@@ -834,7 +835,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div><span>Something happens one</span></div><div><span>Something happens two</span></div>' );
 	});
 
-	QUnit.test( 'partial expressions will use inline content if they resolve to an object with a template string property', t => {
+	test( 'partial expressions will use inline content if they resolve to an object with a template string property', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{>foo}}',
@@ -851,7 +852,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'turnips are tasty' );
 	});
 
-	QUnit.test( 'partial expressions will use inline content if they resolve to a pre-parsed template', t => {
+	test( 'partial expressions will use inline content if they resolve to a pre-parsed template', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{>foo}}',
@@ -868,7 +869,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'turnips are tasty' );
 	});
 
-	QUnit.test( 'resetting a dynamic partial to its reference name should replace the partial (#2185)', t => {
+	test( 'resetting a dynamic partial to its reference name should replace the partial (#2185)', t => {
 		onWarn( msg => t.ok( /Could not find template for partial 'nope'/.test( msg ) ) );
 
 		const r = new Ractive({
@@ -887,7 +888,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'part1part2' );
 	});
 
-	QUnit.test( `Partials can have context that starts with '.' (#1880)`, t => {
+	test( `Partials can have context that starts with '.' (#1880)`, t => {
 		new Ractive({
 			el: fixture,
 			template: '{{#with foo}}{{>foo .bar}}{{/with}}',
@@ -902,7 +903,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'bat' );
 	});
 
-	QUnit.test( 'Context computations are not called unnecessarily (#2224)', t => {
+	test( 'Context computations are not called unnecessarily (#2224)', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -928,7 +929,7 @@ export default function() {
 		ractive.set( 'foo', null );
 	});
 
-	QUnit.test( 'Partials can be given alias context (#2298)', t => {
+	test( 'Partials can be given alias context (#2298)', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{>foo foo.bar as bat, bip.bop as boo}}',
@@ -943,7 +944,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'one two' );
 	});
 
-	QUnit.test( 'Partials can be parsed from a partial template (#1445)', t => {
+	test( 'Partials can be parsed from a partial template (#1445)', t => {
 		fixture.innerHTML = '<div id="fixture-tmp"></div>';
 		const script = document.createElement( 'script' );
 		script.setAttribute( 'type', 'text/html' );
@@ -962,7 +963,7 @@ export default function() {
 		t.htmlEqual( fixture.childNodes[0].innerHTML, 'outer inner' );
 	});
 
-	QUnit.test( 'pre-parsed dynamic inline partial from computation doesn\'t try to reset on init if a binding causes an update (#2641)', t => {
+	test( 'pre-parsed dynamic inline partial from computation doesn\'t try to reset on init if a binding causes an update (#2641)', t => {
 		const cmp = Ractive.extend({ template: '<input type="checkbox" checked="{{flag}}" />' });
 		const r = new Ractive({
 			el: fixture,
@@ -981,7 +982,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yup <input type="checkbox" />' );
 	});
 
-	QUnit.test( 'unparsed dynamic inline partial from computation doesn\'t try to reset on init if a binding causes an update (#2641)', t => {
+	test( 'unparsed dynamic inline partial from computation doesn\'t try to reset on init if a binding causes an update (#2641)', t => {
 		const cmp = Ractive.extend({ template: '<input type="checkbox" checked="{{flag}}" />' });
 		const r = new Ractive({
 			el: fixture,
@@ -1000,7 +1001,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yup <input type="checkbox" />' );
 	});
 
-	QUnit.test( 'arg for event handler from previously uninitialised partial context (#2736)', t => {
+	test( 'arg for event handler from previously uninitialised partial context (#2736)', t => {
 		let v;
 		const r = new Ractive({
 			el: fixture,
@@ -1022,7 +1023,7 @@ export default function() {
 		t.equal( v, 1123 );
 	});
 
-	QUnit.test( `partial expressions survive rebinding`, t => {
+	test( `partial expressions survive rebinding`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `{{> foo[0].bar}}`,

--- a/tests/browser/plugins/adaptors/basic.js
+++ b/tests/browser/plugins/adaptors/basic.js
@@ -1,6 +1,7 @@
 import { fire } from 'simulant';
 import Model from '../../../helpers/Model';
 import { onWarn, initModule } from '../../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'plugins/adaptors/basic.js' );
@@ -29,7 +30,7 @@ export default function() {
 		}
 	};
 
-	QUnit.test( 'Adaptors can change data as it is .set() (#442)', t => {
+	test( 'Adaptors can change data as it is .set() (#442)', t => {
 		const model = new Model({
 			foo: 'BAR',
 			percent: 150
@@ -63,7 +64,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>qux</p><p>50</p>' );
 	});
 
-	QUnit.test( 'ractive.reset() calls are forwarded to wrappers if the root data object is wrapped', t => {
+	test( 'ractive.reset() calls are forwarded to wrappers if the root data object is wrapped', t => {
 		onWarn( msg => t.ok( /plain JavaScript object/.test( msg ) ) );
 
 		let model = new Model({
@@ -95,7 +96,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>qux</p>' );
 	});
 
-	QUnit.test( 'If a wrapper\'s reset() method returns false, it should be torn down (#467)', t => {
+	test( 'If a wrapper\'s reset() method returns false, it should be torn down (#467)', t => {
 		const model1 = new Model({
 			foo: 'bar'
 		});
@@ -117,7 +118,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>baz</p>' );
 	});
 
-	QUnit.test( 'A string can be supplied instead of an array for the `adapt` option (if there\'s only one adaptor listed', t => {
+	test( 'A string can be supplied instead of an array for the `adapt` option (if there\'s only one adaptor listed', t => {
 		const FooAdaptor = {
 			filter () {},
 			wrap () {}
@@ -129,7 +130,7 @@ export default function() {
 		t.deepEqual( instance.viewmodel.adaptors, [FooAdaptor] );
 	});
 
-	QUnit.test( 'Original values are passed to event handlers (#945)', t => {
+	test( 'Original values are passed to event handlers (#945)', t => {
 		t.expect( 2 );
 
 		const ractive = new Ractive({
@@ -150,7 +151,7 @@ export default function() {
 		fire( ractive.find( 'button' ), 'click' );
 	});
 
-	QUnit.test( 'Adaptor teardown is called when used in a component (#1190)', t => {
+	test( 'Adaptor teardown is called when used in a component (#1190)', t => {
 		function Wrapped () {}
 
 		let torndown = 0;
@@ -187,7 +188,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'Adaptor called on data provided in initial options when no template (#1285)', t => {
+	test( 'Adaptor called on data provided in initial options when no template (#1285)', t => {
 		function Wrapped () {}
 
 		const obj = new Wrapped();
@@ -217,7 +218,7 @@ export default function() {
 		t.ok( !obj.enabled, 'object property should not have been set, adaptor should have been used'	);
 	});
 
-	QUnit.test( 'Components inherit modifyArrays option from environment (#1297)', t => {
+	test( 'Components inherit modifyArrays option from environment (#1297)', t => {
 		const Widget = Ractive.extend({
 			template: '{{#each items}}{{this}}{{/each}}',
 			isolated: false
@@ -238,7 +239,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'abc' );
 	});
 
-	QUnit.test( 'Computed properties are adapted', t => {
+	test( 'Computed properties are adapted', t => {
 		function Value ( value ) {
 			this._ = value;
 		}
@@ -270,7 +271,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '4' );
 	});
 
-	QUnit.test( 'display a collection from a model', t => {
+	test( 'display a collection from a model', t => {
 		function extend ( parent, child ) {
 			function Surrogate () {
 				this.constructor = child;
@@ -339,7 +340,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '-duck-chicken' );
 	});
 
-	QUnit.test( 'A component inherits adaptor config from its parent class', t => {
+	test( 'A component inherits adaptor config from its parent class', t => {
 		function Wrapped () {}
 
 		const adaptor = {
@@ -368,7 +369,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'Components inherit adaptors from their parent', t => {
+	test( 'Components inherit adaptors from their parent', t => {
 		Ractive.adaptors.foo = fooAdaptor;
 
 		Ractive.components.Widget = Ractive.extend({
@@ -394,7 +395,7 @@ export default function() {
 		delete Ractive.adaptors.foo;
 	});
 
-	QUnit.test( 'isolated components do not inherit adaptors from their parents', t => {
+	test( 'isolated components do not inherit adaptors from their parents', t => {
 		const adaptor = {
 			filter ( value ) { return typeof value === 'string'; },
 			wrap ( ractive, value ) {
@@ -425,7 +426,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'bar!baz' );
 	});
 
-	QUnit.test( 'adaptors should work with update (#2493)', t => {
+	test( 'adaptors should work with update (#2493)', t => {
 		const thing = new Foo( 'one' );
 		const r = new Ractive({
 			adapt: [ 'foo' ],
@@ -441,7 +442,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'two' );
 	});
 
-	QUnit.test( 'extra case for #2493', t => {
+	test( 'extra case for #2493', t => {
 		const thing = { thing: 'one' };
 		const adaptor = {
 			filter ( child, parent, keypath ) {
@@ -475,7 +476,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'two' );
 	});
 
-	QUnit.test( 'adaptors with deeper keypaths should also work with update (#2500)', t => {
+	test( 'adaptors with deeper keypaths should also work with update (#2500)', t => {
 		const thing = { thing: { a: 1, b: 4 } };
 		const adaptor = {
 			filter ( child, keypath, parent ) {
@@ -536,7 +537,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '2 5' );
 	});
 
-	QUnit.test( 'adaptors that adapt whilst marking should tear down old instances', t => {
+	test( 'adaptors that adapt whilst marking should tear down old instances', t => {
 		const obj = { foo: new Foo( 'one' ) };
 		const r = new Ractive({
 			adapt: [ 'foo' ],
@@ -553,7 +554,7 @@ export default function() {
 		t.ok( !foo._wrapper );
 	});
 
-	QUnit.test( 'Components made with Ractive.extend() can include adaptors', t => {
+	test( 'Components made with Ractive.extend() can include adaptors', t => {
 		Ractive.adaptors.foo = fooAdaptor;
 
 		const Widget = Ractive.extend({
@@ -575,7 +576,7 @@ export default function() {
 		delete Ractive.adaptors.foo;
 	});
 
-	QUnit.test( 'adapted values passed to expressions should be unwrapped (#2513)', t => {
+	test( 'adapted values passed to expressions should be unwrapped (#2513)', t => {
 		class Foo {
 			constructor () {
 				this.content = 'sup';
@@ -612,7 +613,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'sup hey' );
 	});
 
-	QUnit.test( 'adapted values should be unwrapped by default with get, but wrapped when unwrap === false', t => {
+	test( 'adapted values should be unwrapped by default with get, but wrapped when unwrap === false', t => {
 		class Foo {
 			constructor () {
 				this.content = 'sup';
@@ -648,7 +649,7 @@ export default function() {
 		t.ok( r.get( 'foo', { unwrap: false } ) === 'sup' );
 	});
 
-	QUnit.test( 'adaptors should not cause death during branching caused by two-way binding (#2467)', t => {
+	test( 'adaptors should not cause death during branching caused by two-way binding (#2467)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<select value="{{foo.0.bar.0}}"><option>yep</option><option value="{{42}}">answer</option></select>`,
@@ -661,7 +662,7 @@ export default function() {
 		t.equal( r.get( 'foo.0.bar.0' ), undefined );
 	});
 
-	QUnit.test( 'adapted values that are mapped should be unwrapped on the mapped side (#2513 part 2)', t => {
+	test( 'adapted values that are mapped should be unwrapped on the mapped side (#2513 part 2)', t => {
 		class Foo {
 			constructor () {
 				this.content = 'sup';
@@ -701,7 +702,7 @@ export default function() {
 		t.ok( c.get( 'it' ) instanceof Foo, 'value is unwrapped' );
 	});
 
-	QUnit.test( `updating the child of an adapted value only updates the child (#2693)`, t => {
+	test( `updating the child of an adapted value only updates the child (#2693)`, t => {
 		class Wrap {
 			constructor (obj) {
 				this.obj = obj;

--- a/tests/browser/plugins/decorators.js
+++ b/tests/browser/plugins/decorators.js
@@ -1,10 +1,11 @@
 import { hasUsableConsole, onWarn, initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'plugins/decorators.js' );
 
 
-	QUnit.test( 'Basic decorator', t => {
+	test( 'Basic decorator', t => {
 		new Ractive({
 			el: fixture,
 			template: '<div as-foo>this text will be overwritten</div>',
@@ -26,7 +27,7 @@ export default function() {
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'Missing decorator', t => {
+		test( 'Missing decorator', t => {
 			t.expect( 1 );
 
 			onWarn( msg => {
@@ -40,7 +41,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'Decorator with a static argument', t => {
+	test( 'Decorator with a static argument', t => {
 		new Ractive({
 			el: fixture,
 			template: '<div as-foo=""bar"">this text will be overwritten</div>',
@@ -61,7 +62,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>bar</div>' );
 	});
 
-	QUnit.test( 'Decorator with a dynamic argument', t => {
+	test( 'Decorator with a dynamic argument', t => {
 		new Ractive({
 			el: fixture,
 			template: '<div as-foo="foo">this text will be overwritten</div>',
@@ -85,7 +86,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>baz</div>' );
 	});
 
-	QUnit.test( 'Decorator with a dynamic argument that changes, without update() method', t => {
+	test( 'Decorator with a dynamic argument that changes, without update() method', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div as-foo="foo">this text will be overwritten</div>',
@@ -113,7 +114,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>bar</div>' );
 	});
 
-	QUnit.test( 'Decorator with a dynamic argument that changes, with update() method', t => {
+	test( 'Decorator with a dynamic argument that changes, with update() method', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div as-foo="foo">this text will be overwritten</div>',
@@ -144,7 +145,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>bar</div>' );
 	});
 
-	QUnit.test( 'Decorator without arguments can be torn down (#453)', t => {
+	test( 'Decorator without arguments can be torn down (#453)', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -162,7 +163,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'Unnecessary whitespace is trimmed (#810)', t => {
+	test( 'Unnecessary whitespace is trimmed (#810)', t => {
 		new Ractive({
 			el: fixture,
 			template: '<pre as-show=""blue is the moon""/><pre as-show="" blue is the moon   ""/>',
@@ -177,7 +178,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<pre>|blue is the moon|</pre><pre>| blue is the moon   |</pre>' );
 	});
 
-	QUnit.test( 'Rebinding causes decorators to update, if arguments are index references', t => {
+	test( 'Rebinding causes decorators to update, if arguments are index references', t => {
 		t.expect(1);
 
 		const ractive = new Ractive({
@@ -202,7 +203,7 @@ export default function() {
 		ractive.shift( 'letters' );
 	});
 
-	QUnit.test( 'Rebinding safe if decorators have no arguments', t => {
+	test( 'Rebinding safe if decorators have no arguments', t => {
 		// second time is for teardown
 		t.expect(2);
 
@@ -227,7 +228,7 @@ export default function() {
 		ractive.shift( 'letters' );
 	});
 
-	QUnit.test( 'Teardown before init should work', t => {
+	test( 'Teardown before init should work', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{# count > 0}}<span as-whatever>foo</span>{{/0}}',
@@ -251,7 +252,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'Decorator teardown should happen after outros have completed (#1481)', t => {
+	test( 'Decorator teardown should happen after outros have completed (#1481)', t => {
 		const done = t.async();
 
 		let decoratorTorndown;
@@ -300,7 +301,7 @@ export default function() {
 		t.equal( div.style.color, 'red' );
 	});
 
-	QUnit.test( 'Decorators can have their parameters change before they are rendered (#2278)', t => {
+	test( 'Decorators can have their parameters change before they are rendered (#2278)', t => {
 		t.expect( 0 );
 
 		const dec = () => ({ teardown() {} });
@@ -318,7 +319,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'basic conditional decorator', t => {
+	test( 'basic conditional decorator', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '<div {{#if foo}}as-foo{{/if}}>bar</div>',
@@ -344,7 +345,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>foo</div>' );
 	});
 
-	QUnit.test( 'conditional decorator with else', t => {
+	test( 'conditional decorator with else', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '<div {{#if foo}}as-foo{{else}}as-baz{{/if}}>bar</div>',
@@ -382,7 +383,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>baz</div>' );
 	});
 
-	QUnit.test( 'decorators can be named with as-${name}', t => {
+	test( 'decorators can be named with as-${name}', t => {
 		new Ractive({
 			el: fixture,
 			template: '<div as-foo>this text will be overwritten</div>',
@@ -403,7 +404,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>foo</div>' );
 	});
 
-	QUnit.test( 'decorators can be named with as-${name} with args', t => {
+	test( 'decorators can be named with as-${name} with args', t => {
 		new Ractive({
 			el: fixture,
 			template: `<div as-foo="bar, 'baz'">this text will be overwritten</div>`,
@@ -425,7 +426,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>foo baz</div>' );
 	});
 
-	QUnit.test( 'named decorators update with their args (#2590)', t => {
+	test( 'named decorators update with their args (#2590)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<div as-foo="bar">bar here</div>`,
@@ -452,7 +453,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>baz</div>' );
 	});
 
-	QUnit.test( 'decorators in nested elements are torn down (#2608)', t => {
+	test( 'decorators in nested elements are torn down (#2608)', t => {
 		let count = 0;
 		const r = new Ractive({
 			el: fixture,
@@ -482,7 +483,7 @@ export default function() {
 		t.equal( count, 0 );
 	});
 
-	QUnit.test( 'decorators in nested components are torn down (#2608)', t => {
+	test( 'decorators in nested components are torn down (#2608)', t => {
 		let count = 0;
 		const cmp = Ractive.extend({
 			template: '<div as-foo />',
@@ -514,7 +515,7 @@ export default function() {
 		t.equal( count, 0 );
 	});
 
-	QUnit.test( 'decorators get applied if the element rendered during onrender (#2697)', t => {
+	test( 'decorators get applied if the element rendered during onrender (#2697)', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{#if show}}<p as-foo>nope</p>{{/if}}',
@@ -532,7 +533,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>yep</p>' );
 	});
 
-	QUnit.test( 'decorators within a nested alias block are torn down appropriately (#2735)', t => {
+	test( 'decorators within a nested alias block are torn down appropriately (#2735)', t => {
 		let count = 0;
 
 		function foo () {
@@ -557,7 +558,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( `decorators that cause themselves to be torn down during their init are torn down properly (#2412)`, t => {
+	test( `decorators that cause themselves to be torn down during their init are torn down properly (#2412)`, t => {
 		let go = true;
 		let setup = 0;
 		let teardown = 0;

--- a/tests/browser/plugins/transitions.js
+++ b/tests/browser/plugins/transitions.js
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, hasUsableConsole, onWarn, initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	let Ractive_original;
@@ -33,7 +34,7 @@ export default function() {
 
 	initModule( 'plugins/transitions.js' );
 
-	QUnit.test( 'Animated style', t => {
+	test( 'Animated style', t => {
 		t.expect( 2 );
 
 		const done = t.async();
@@ -65,7 +66,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Elements containing components with outroing elements do not detach until transitions are complete', t => {
+	test( 'Elements containing components with outroing elements do not detach until transitions are complete', t => {
 		const done = t.async();
 
 		let shouldHaveCompleted;
@@ -96,7 +97,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'noIntro option prevents intro transition', t => {
+	test( 'noIntro option prevents intro transition', t => {
 		const done = t.async();
 
 		t.expect( 1 );
@@ -117,7 +118,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'noOutro option prevents outro transition', t => {
+	test( 'noOutro option prevents outro transition', t => {
 		const done = t.async();
 
 		t.expect( 1 );
@@ -139,7 +140,7 @@ export default function() {
 		r.teardown();
 	});
 
-	QUnit.test( 'noIntro option prevents intro transition when el is initially undefined', t => {
+	test( 'noIntro option prevents intro transition when el is initially undefined', t => {
 		t.expect( 1 );
 
 		const done = t.async();
@@ -161,7 +162,7 @@ export default function() {
 		ractive.render( fixture );
 	});
 
-	QUnit.test( 'noIntro on a rendering parent instance prevents intro transition on component', t => {
+	test( 'noIntro on a rendering parent instance prevents intro transition on component', t => {
 		t.expect( 1 );
 		const done = t.async();
 
@@ -187,7 +188,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( `noIntro on already rendered parent instance doesn't affect components`, t => {
+	test( `noIntro on already rendered parent instance doesn't affect components`, t => {
 		t.expect( 2 );
 		const done = t.async();
 
@@ -214,7 +215,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( `noOutro on still rendered parent instance doesn't affect components`, t => {
+	test( `noOutro on still rendered parent instance doesn't affect components`, t => {
 		t.expect( 2 );
 		const done = t.async();
 
@@ -241,7 +242,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'ractive.transitionsEnabled false prevents all transitions', t => {
+	test( 'ractive.transitionsEnabled false prevents all transitions', t => {
 		t.expect( 1 );
 
 		const done = t.async();
@@ -272,7 +273,7 @@ export default function() {
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'Missing transition functions do not cause errors, but do console.warn', t => {
+		test( 'Missing transition functions do not cause errors, but do console.warn', t => {
 			t.expect( 1 );
 
 			const done = t.async();
@@ -291,7 +292,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'Transitions work the first time (#916)', t => {
+	test( 'Transitions work the first time (#916)', t => {
 		// we're using line height for testing because it's a numerical CSS property that IE8 supports
 		const done = t.async();
 
@@ -322,7 +323,7 @@ export default function() {
 		t.equal( div.style.lineHeight, 0 );
 	});
 
-	QUnit.test( 'Nodes are detached synchronously if there are no outro transitions (#856)', t => {
+	test( 'Nodes are detached synchronously if there are no outro transitions (#856)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#if foo}}<div test-in>intro</div>{{else}}<div class="target">no outro</div>{{/if}}'
@@ -335,7 +336,7 @@ export default function() {
 		t.ok( !fixture.contains( target ) );
 	});
 
-	QUnit.test( 'Regression test for #1157', t => {
+	test( 'Regression test for #1157', t => {
 		const done = t.async();
 
 		new Ractive({
@@ -350,7 +351,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Parameter objects are not polluted (#1239)', t => {
+	test( 'Parameter objects are not polluted (#1239)', t => {
 		const done = t.async();
 
 		t.expect(3);
@@ -381,7 +382,7 @@ export default function() {
 		t.notEqual( objects[0], objects[1] );
 	});
 
-	QUnit.test( 'processParams extends correctly if no default provided (#2446)', t => {
+	test( 'processParams extends correctly if no default provided (#2446)', t => {
 		new Ractive({
 			el: fixture,
 			template: '<p foo-in="{ duration: 1000 }"></p>',
@@ -396,7 +397,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'An intro will be aborted if a corresponding outro begins before it completes', t => {
+	test( 'An intro will be aborted if a corresponding outro begins before it completes', t => {
 		let tooLate;
 
 		const done = t.async();
@@ -427,7 +428,7 @@ export default function() {
 		}, 200 );
 	});
 
-	QUnit.test( 'processParams extends correctly if no default provided (#2446)', t => {
+	test( 'processParams extends correctly if no default provided (#2446)', t => {
 		new Ractive({
 			el: fixture,
 			template: '<p foo-in="{ duration: 1000 }"></p>',
@@ -442,7 +443,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Conditional sections that become truthy are not rendered if a parent simultaneously becomes falsy (#1483)', t => {
+	test( 'Conditional sections that become truthy are not rendered if a parent simultaneously becomes falsy (#1483)', t => {
 		let transitionRan = false;
 		const done = t.async();
 		t.expect(1);
@@ -474,7 +475,7 @@ export default function() {
 		t.ok( !transitionRan );
 	});
 
-	QUnit.test( 'Nodes that are affected by deferred observers should actually get dettached (#2310)', t => {
+	test( 'Nodes that are affected by deferred observers should actually get dettached (#2310)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#if bar}}<span>baz</span>{{/if}}`,
@@ -491,7 +492,7 @@ export default function() {
 	});
 
 	if ( !/phantom/i.test( navigator.userAgent ) ) {
-		QUnit.test( 'Nodes not affected by a transition should be immediately handled (#2027)', t => {
+		test( 'Nodes not affected by a transition should be immediately handled (#2027)', t => {
 			const done = t.async();
 			t.expect( 3 );
 
@@ -512,7 +513,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'Context of transition function is current instance', t => {
+	test( 'Context of transition function is current instance', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -530,7 +531,7 @@ export default function() {
 		ractive.set( 'visible', true );
 	});
 
-	QUnit.test( 'intro transitions can be conditional', t => {
+	test( 'intro transitions can be conditional', t => {
 		let count = 0;
 		const r = new Ractive({
 			el: fixture,
@@ -553,7 +554,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( 'outro transitions can be conditional', t => {
+	test( 'outro transitions can be conditional', t => {
 		let count = 0;
 		const r = new Ractive({
 			el: fixture,
@@ -579,7 +580,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( 'intro-outro transitions can be conditional', t => {
+	test( 'intro-outro transitions can be conditional', t => {
 		let count = 0;
 		const r = new Ractive({
 			el: fixture,
@@ -605,7 +606,7 @@ export default function() {
 		t.equal( count, 4 );
 	});
 
-	QUnit.test( 'intros can be named attributes', t => {
+	test( 'intros can be named attributes', t => {
 		let count = 0;
 		const r = new Ractive({
 			el: fixture,
@@ -625,7 +626,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( 'outros can be named attributes', t => {
+	test( 'outros can be named attributes', t => {
 		let count = 0;
 		const r = new Ractive({
 			el: fixture,
@@ -646,7 +647,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( 'intro-outros can be named attributes', t => {
+	test( 'intro-outros can be named attributes', t => {
 		let count = 0;
 		const r = new Ractive({
 			el: fixture,
@@ -670,7 +671,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'named attribute transitions can have normal expression args', t => {
+	test( 'named attribute transitions can have normal expression args', t => {
 		let count = 0;
 		new Ractive({
 			el: fixture,
@@ -689,7 +690,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( `transitions have a timeout safety net (#2463)`, t => {
+	test( `transitions have a timeout safety net (#2463)`, t => {
 		const done = t.async();
 		t.expect( 1 );
 
@@ -724,7 +725,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( `transition safety net doesn't break with manual render/unrender`, t => {
+	test( `transition safety net doesn't break with manual render/unrender`, t => {
 		const done = t.async();
 		let count = 0;
 		let r;
@@ -772,7 +773,7 @@ export default function() {
 		}, 400);
 	});
 
-	QUnit.test( `transition args can change (#2818)`, t => {
+	test( `transition args can change (#2818)`, t => {
 		let count = 0;
 		function go ( trans ) {
 			count++;
@@ -793,7 +794,7 @@ export default function() {
 		t.equal( count, 2 );
 	});
 
-	QUnit.test( `intro transitions don't leave styles hanging around`, t => {
+	test( `intro transitions don't leave styles hanging around`, t => {
 		const done = t.async();
 
 		function go ( trans ) {
@@ -821,7 +822,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( `transitions that are nested: false and at root fire`, t => {
+	test( `transitions that are nested: false and at root fire`, t => {
 		const done = t.async();
 		let count = 0;
 
@@ -841,7 +842,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( `transitions that are nested: false don't fire when they aren't the root`, t => {
+	test( `transitions that are nested: false don't fire when they aren't the root`, t => {
 		const done = t.async();
 		let count = 0;
 
@@ -861,7 +862,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( `transitions can be defaulted to nested: false at the instance level with nestedTransitions`, t => {
+	test( `transitions can be defaulted to nested: false at the instance level with nestedTransitions`, t => {
 		const done = t.async();
 		let count = 0;
 
@@ -882,7 +883,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( `transitions that are nested: true override their instance nestedTransitions setting`, t => {
+	test( `transitions that are nested: true override their instance nestedTransitions setting`, t => {
 		const done = t.async();
 		let count = 0;
 
@@ -903,7 +904,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( `transitions look to the nearest set nested setting if neither they nor their instance have an explicit setting`, t => {
+	test( `transitions look to the nearest set nested setting if neither they nor their instance have an explicit setting`, t => {
 		const done = t.async();
 		let count = 0;
 
@@ -929,7 +930,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( `transition params normalization`, t => {
+	test( `transition params normalization`, t => {
 		const done = t.async();
 		const r = new Ractive({
 			template: '<div go-in />',
@@ -954,7 +955,7 @@ export default function() {
 		r.render( fixture ).then( done );
 	});
 
-	QUnit.test( `outro transitions isOutro === false (#2852)`, t => {
+	test( `outro transitions isOutro === false (#2852)`, t => {
 		const done = t.async();
 		t.expect( 2 );
 
@@ -973,7 +974,7 @@ export default function() {
 		r.toggle( 'foo' ).then( done );
 	});
 
-	QUnit.test( `conditional transitions find their parent element (#2815)`, t => {
+	test( `conditional transitions find their parent element (#2815)`, t => {
 		const done = t.async();
 
 		let count = 0;
@@ -1023,7 +1024,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( `js timing functions can be used with css transitionable properties (#2152)`, t => {
+	test( `js timing functions can be used with css transitionable properties (#2152)`, t => {
 		const done = t.async();
 
 		let called = false;

--- a/tests/browser/rebind.js
+++ b/tests/browser/rebind.js
@@ -1,9 +1,10 @@
 import { onWarn, initModule } from '../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'rebind.js' );
 
-	QUnit.test('Section with item that has expression only called once when created', t => {
+	test('Section with item that has expression only called once when created', t => {
 		let called = 0;
 
 		const ractive = new Ractive({
@@ -21,7 +22,7 @@ export default function() {
 		t.equal( called, 1 );
 	});
 
-	QUnit.test( 'Section with item index ref expression changes correctly', t => {
+	test( 'Section with item index ref expression changes correctly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items:i}}{{format(.,i)}},{{/items}}',
@@ -41,7 +42,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '1,11,6,8,');
 	});
 
-	QUnit.test( 'Section updates child keypath expression', t => {
+	test( 'Section updates child keypath expression', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#each items:i}}{{foo[bar]}},{{/each}}',
@@ -61,7 +62,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'bob,jill,');
 	});
 
-	QUnit.test('Section with nested sections and inner context does splice()', t => {
+	test('Section with nested sections and inner context does splice()', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -83,7 +84,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>1,2</p><p>3,4</p>');
 	});
 
-	QUnit.test( 'Components in a list can be rebound', ( t ) => {
+	test( 'Components in a list can be rebound', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items}}<widget letter="{{.}}"/>{{/items}}',
@@ -105,7 +106,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>d</p><p>e</p>' );
 	});
 
-	QUnit.test( 'Index references can be used as key attributes on components, and rebinding works', ( t ) => {
+	test( 'Index references can be used as key attributes on components, and rebinding works', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items:i}}<widget index="{{i}}" letter="{{.}}"/>{{/items}}',
@@ -123,7 +124,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>0: a</p><p>1: c</p>' );
 	});
 
-	QUnit.test('Section with partials that use indexRef update correctly', t => {
+	test('Section with partials that use indexRef update correctly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items:i}}{{>partial}},{{/items}}',
@@ -140,7 +141,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '0,1,2,3,');
 	});
 
-	QUnit.test( 'Expressions with unresolved references can be rebound (#630)', ( t ) => {
+	test( 'Expressions with unresolved references can be rebound (#630)', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#list}}{{#check > length}}true{{/test}}{{/list}}',
@@ -151,7 +152,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'Regression test for #697', ( t ) => {
+	test( 'Regression test for #697', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#model}}{{#thing}}{{# foo && bar }}<p>works</p>{{/inner}}{{/thing}}{{/model}}',
@@ -171,7 +172,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'Regression test for #715', ( t ) => {
+	test( 'Regression test for #715', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items}}{{#test}}{{# .entries > 1 }}{{{ foo }}}{{/ .entries }}{{/test}}{{/items}}',
@@ -189,7 +190,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'Items are not unrendered and rerendered unnecessarily in cases like #715', ( t ) => {
+	test( 'Items are not unrendered and rerendered unnecessarily in cases like #715', ( t ) => {
 		let renderCount = 0;
 		let unrenderCount = 0;
 
@@ -221,7 +222,7 @@ export default function() {
 		t.equal( unrenderCount, 0 );
 	});
 
-	QUnit.test( 'Regression test for #729 (part one) - rebinding silently-created elements', ( t ) => {
+	test( 'Regression test for #729 (part one) - rebinding silently-created elements', ( t ) => {
 		const items = [{test: { bool: false }}];
 
 		const ractive = new Ractive({
@@ -236,7 +237,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'Regression test for #729 (part two) - inserting before silently-created elements', ( t ) => {
+	test( 'Regression test for #729 (part two) - inserting before silently-created elements', ( t ) => {
 		const items = [];
 
 		const ractive = new Ractive({
@@ -252,7 +253,7 @@ export default function() {
 		t.ok( true );
 	});
 
-	QUnit.test( 'Regression test for #756 - fragment contexts are not rebound to undefined', ( t ) => {
+	test( 'Regression test for #756 - fragment contexts are not rebound to undefined', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -277,7 +278,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div class></div><div class>[ Z ]</div>' );
 	});
 
-	QUnit.test( '@index rebinds correctly', ( t ) => {
+	test( '@index rebinds correctly', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#each items}}<p>{{@index}}:{{this}}</p>{{/each}}',
@@ -288,7 +289,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>0:a</p><p>1:b</p><p>2:c</p><p>3:d</p>' );
 	});
 
-	QUnit.test( 'index rebinds do not go past new index providers (#1457)', ( t ) => {
+	test( 'index rebinds do not go past new index providers (#1457)', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#each foo}}{{@index}}{{#each .bar}}{{@index}}{{/each}}<br/>{{/each}}',
@@ -308,7 +309,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '001<br/>10123<br/>' );
 	});
 
-	QUnit.test( 'index rebinds get passed through conditional sections correctly', t => {
+	test( 'index rebinds get passed through conditional sections correctly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#each foo}}{{@index}}{{#.bar}}{{@index}}{{/}}<br/>{{/each}}',
@@ -329,7 +330,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '00<br/>1<br/>22<br/>' );
 	});
 
-	QUnit.test( 'Computations are not triggered prematurely on rebind (#2259)', t => {
+	test( 'Computations are not triggered prematurely on rebind (#2259)', t => {
 		t.expect( 0 );
 
 		onWarn( () => {
@@ -350,7 +351,7 @@ export default function() {
 		ractive.splice( 'items', 0, 1 );
 	});
 
-	QUnit.test( 'rebinds of IF sections do not add new context (#2454)', ( t ) => {
+	test( 'rebinds of IF sections do not add new context (#2454)', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -375,7 +376,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'rebinds of if/else sections do not add new context (#2454)', ( t ) => {
+	test( 'rebinds of if/else sections do not add new context (#2454)', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -402,7 +403,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'rebinds of UNLESS sections do not add new context (#2454)', ( t ) => {
+	test( 'rebinds of UNLESS sections do not add new context (#2454)', ( t ) => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `

--- a/tests/browser/references.js
+++ b/tests/browser/references.js
@@ -1,10 +1,11 @@
 import { initModule, onWarn } from '../helpers/test-config';
 import { fire } from 'simulant';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'references.js' );
 
-	QUnit.test( '@index special ref finds the nearest index', t => {
+	test( '@index special ref finds the nearest index', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{#each outer}}{{#each .list}}{{@index}}{{/each}}{{/each}}',
@@ -16,7 +17,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '012' );
 	});
 
-	QUnit.test( '@key special ref finds the nearest key', t => {
+	test( '@key special ref finds the nearest key', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{#each outer}}{{#each .list}}{{@key}}{{/each}}{{/each}}',
@@ -28,7 +29,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'abc' );
 	});
 
-	QUnit.test( 'component @keypath references should be relative to the component', t => {
+	test( 'component @keypath references should be relative to the component', t => {
 		const cmp = Ractive.extend({
 			template: '{{#with foo.bar}}{{@keypath}}{{/with}}'
 		});
@@ -45,7 +46,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo.bar' );
 	});
 
-	QUnit.test( 'nested component @keypath references should be relative to the nested component', t => {
+	test( 'nested component @keypath references should be relative to the nested component', t => {
 		const cmp1 = Ractive.extend({
 			template: '{{#with foo.bar}}{{@keypath}}{{/with}}'
 		});
@@ -66,7 +67,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo.bar' );
 	});
 
-	QUnit.test( 'component @rootpath references should be relative to the root', t => {
+	test( 'component @rootpath references should be relative to the root', t => {
 		const cmp = Ractive.extend({
 			template: '{{#with foo.bar}}{{@rootpath}}{{/with}}'
 		});
@@ -83,7 +84,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'baz.bat.bar' );
 	});
 
-	QUnit.test( '@global special ref gives access to the vm global object', t => {
+	test( '@global special ref gives access to the vm global object', t => {
 		/* global global, window */
 		const target = typeof global !== 'undefined' ? global : window;
 		const r = new Ractive({
@@ -109,7 +110,7 @@ export default function() {
 		t.equal( target.foo.bar, 10 );
 	});
 
-	QUnit.test( 'instance property shortcut @.foo === @this.foo', t => {
+	test( 'instance property shortcut @.foo === @this.foo', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{@.foo}} {{@.bar.baz}}',
@@ -120,7 +121,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo baz' );
 	});
 
-	QUnit.test( 'instance shortcut in event handlers', t => {
+	test( 'instance shortcut in event handlers', t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `<button on-click="@.set('foo', 'yep')">click me</button>`
@@ -131,7 +132,7 @@ export default function() {
 		t.equal( r.get( 'foo' ), 'yep' );
 	});
 
-	QUnit.test( 'calling set with an instance property shortcut', t => {
+	test( 'calling set with an instance property shortcut', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{@.foo}} {{@.bar.baz}}',
@@ -146,7 +147,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo baz' );
 	});
 
-	QUnit.test( `can't set with one of the reserved read-only special refs`, t => {
+	test( `can't set with one of the reserved read-only special refs`, t => {
 		const r = new Ractive({});
 		t.throws( () => r.set( '@index', true ), /invalid keypath/ );
 		t.throws( () => r.set( '@key', true ), /invalid keypath/ );
@@ -154,7 +155,7 @@ export default function() {
 		t.throws( () => r.set( '@rootpath', true ), /invalid keypath/ );
 	});
 
-	QUnit.test( 'context popping with ^^/', t => {
+	test( 'context popping with ^^/', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{#with some.path}}{{#with ~/other}}{{^^/foo}}{{#with .foo}}{{" " + ^^/^^/foo}}{{/with}}{{/with}}{{/with}}',
@@ -171,7 +172,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep yep' );
 	});
 
-	QUnit.test( 'context popping with path popping ^^/../', t => {
+	test( 'context popping with path popping ^^/../', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{#with some.path}}{{#with ~/other}}{{^^/../up.foo}}{{#with .foo}}{{" " + ^^/^^/../up.foo}}{{/with}}{{/with}}{{/with}}',
@@ -189,7 +190,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yep yep' );
 	});
 
-	QUnit.test( 'direct ancestor reference to a context', t => {
+	test( 'direct ancestor reference to a context', t => {
 		const bar = { baz: 'yep' };
 		new Ractive({
 			el: fixture,
@@ -200,7 +201,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, JSON.stringify( bar ) );
 	});
 
-	QUnit.test( 'direct context pop reference to a context', t => {
+	test( 'direct context pop reference to a context', t => {
 		const bar = { baz: 'yep' };
 		new Ractive({
 			el: fixture,
@@ -211,7 +212,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, JSON.stringify( bar ) );
 	});
 
-	QUnit.test( 'direct context pop and ancestor reference to a context', t => {
+	test( 'direct context pop and ancestor reference to a context', t => {
 		const bar = { baz: 'yep' };
 		new Ractive({
 			el: fixture,
@@ -222,7 +223,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, JSON.stringify( bar ) );
 	});
 
-	QUnit.test( '@shared special refers to ractive-only global state', t => {
+	test( '@shared special refers to ractive-only global state', t => {
 		const r1 = new Ractive({
 			target: fixture,
 			template: `{{#with @shared.foo}}{{@keypath}} {{.}}{{/with}}`
@@ -235,7 +236,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '@shared.foo bar' );
 	});
 
-	QUnit.test( 'by default instance members resolve after ambiguous context', t => {
+	test( 'by default instance members resolve after ambiguous context', t => {
 		new Ractive({
 			target: fixture,
 			template: '{{foo}} {{#with 1 as foo}}{{foo}}{{/with}} {{#with bar}}{{#with ~/other}}{{foo}}{{/with}}{{/with}}',
@@ -249,7 +250,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'hey 1 yep' );
 	});
 
-	QUnit.test( 'instance members are not resolved if resolveInstanceMembers is false', t => {
+	test( 'instance members are not resolved if resolveInstanceMembers is false', t => {
 		new Ractive({
 			target: fixture,
 			template: '{{foo}}?',
@@ -260,7 +261,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '?' );
 	});
 
-	QUnit.test( 'if asked, ractive will issue warnings about ambiguous references', t => {
+	test( 'if asked, ractive will issue warnings about ambiguous references', t => {
 		t.expect( 4 );
 
 		onWarn( w => {
@@ -293,7 +294,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yepyep' );
 	});
 
-	QUnit.test( 'component tree root data can be accessed with @.root.data (#2432)', t => {
+	test( 'component tree root data can be accessed with @.root.data (#2432)', t => {
 		const cmp = Ractive.extend({
 			template: '{{#with some.path}}{{~/foo}} {{@.root.data.foo}}{{/with}}',
 			data: {
@@ -314,7 +315,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'cmp root' );
 	});
 
-	QUnit.test( 'root model will deal with ~/ references (#2432)', t => {
+	test( 'root model will deal with ~/ references (#2432)', t => {
 		const cmp = Ractive.extend({
 			data: { foo: { bar: 'cmp' } }
 		});
@@ -331,7 +332,7 @@ export default function() {
 		t.equal( c.get( '@.root.data.foo.bar' ), 'root' );
 	});
 
-	QUnit.test( `trying to set a relative keypath from instance set warns and doesn't do unexpected things`, t => {
+	test( `trying to set a relative keypath from instance set warns and doesn't do unexpected things`, t => {
 		onWarn( w => {
 			t.ok( /relative keypath.*non-relative.*getNodeInfo.*event object/.test( w ) );
 		});
@@ -343,7 +344,7 @@ export default function() {
 		t.ok( !( '' in r.get() ) );
 	});
 
-	QUnit.test( `instance methods are bound properly when used with resolveInstanceMembers (#2757)`, t => {
+	test( `instance methods are bound properly when used with resolveInstanceMembers (#2757)`, t => {
 		const r = new Ractive({
 			target: fixture,
 			template: `<button on-click="set('foo', 'bar')">click me</button>`
@@ -354,7 +355,7 @@ export default function() {
 		t.equal( r.get( 'foo' ), 'bar' );
 	});
 
-	QUnit.test( `context takes precedent over instance methods`, t => {
+	test( `context takes precedent over instance methods`, t => {
 		new Ractive({
 			target: fixture,
 			template: '{{foo()}}',
@@ -367,7 +368,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo' );
 	});
 
-	QUnit.test( `instance methods aren't resolved if resolveInstanceMembers is false`, t => {
+	test( `instance methods aren't resolved if resolveInstanceMembers is false`, t => {
 		new Ractive({
 			target: fixture,
 			template: '{{foo()}}',
@@ -378,7 +379,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( `children of references that become non-objects behave correctly (#2817)`, t => {
+	test( `children of references that become non-objects behave correctly (#2817)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foo[bar]}}{{.baz.bat}}{{/with}}`,
@@ -390,19 +391,19 @@ export default function() {
 		t.equal( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( `@event cannot be used outside of an event directive`, t => {
+	test( `@event cannot be used outside of an event directive`, t => {
 		t.throws( () => {
 			Ractive.parse( '{{@event}}' );
 		}, /are only valid references within an event directive/ );
 	});
 
-	QUnit.test( `@node cannot be used outside of an event directive`, t => {
+	test( `@node cannot be used outside of an event directive`, t => {
 		t.throws( () => {
 			Ractive.parse( '{{@node}}' );
 		}, /are only valid references within an event directive/ );
 	});
 
-	QUnit.test( `@context expression can be used to get reference to any template context`, t => {
+	test( `@context expression can be used to get reference to any template context`, t => {
 		t.expect( 3 );
 
 		new Ractive({

--- a/tests/browser/render/components.js
+++ b/tests/browser/render/components.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'render/components.js' );
 
-	QUnit.test( 'Components are rendered in the correct place', t => {
+	test( 'Components are rendered in the correct place', t => {
 		const Component = Ractive.extend({
 			template: '<p>this is a component!</p>'
 		});
@@ -17,7 +18,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<h2>Here is a component:</h2><p>this is a component!</p><p>(that was a component)</p>' );
 	});
 
-	QUnit.test( 'Top-level sections in components are updated correctly', t => {
+	test( 'Top-level sections in components are updated correctly', t => {
 		const Component = Ractive.extend({
 			template: '{{#foo}}foo is truthy{{/foo}}{{^foo}}foo is falsy{{/foo}}'
 		});
@@ -34,7 +35,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo is truthy' );
 	});
 
-	QUnit.test( 'Element order is maintained correctly with components with multiple top-level elements', t => {
+	test( 'Element order is maintained correctly with components with multiple top-level elements', t => {
 		const Test = Ractive.extend({
 			template: '{{#bool}}TRUE{{/bool}}{{^bool}}FALSE{{/bool}}'
 		});
@@ -54,7 +55,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>before</p> FALSE <p>after</p>' );
 	});
 
-	QUnit.test( 'Top-level list sections in components do not cause elements to be out of order (#412 regression)', t => {
+	test( 'Top-level list sections in components do not cause elements to be out of order (#412 regression)', t => {
 		const Widget = Ractive.extend({
 			template: '{{#numbers:o}}<p>{{.}}</p>{{/numbers}}'
 		});
@@ -72,7 +73,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<h1>Names</h1><p>one</p><p>two</p><p>three</p><p>four</p>' );
 	});
 
-	QUnit.test( 'An unless section in a component should still work with an ambiguous condition should still update (#2165)', t => {
+	test( 'An unless section in a component should still work with an ambiguous condition should still update (#2165)', t => {
 		const cmp = Ractive.extend({
 			template: '{{#unless nope}}{{foo}}{{/unless}}'
 		});
@@ -88,7 +89,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'still' );
 	});
 
-	QUnit.test( 'components should be able to resolve @index refs from their context', t => {
+	test( 'components should be able to resolve @index refs from their context', t => {
 		const cmp = Ractive.extend({
 			template: '{{@index}}'
 		});
@@ -104,7 +105,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '012' );
 	});
 
-	QUnit.test( 'resetting a nested component should find the correct anchor when rendering (#2695)', t => {
+	test( 'resetting a nested component should find the correct anchor when rendering (#2695)', t => {
 		const cmp1 = Ractive.extend({
 			template: '<cmp/>',
 			components: {
@@ -127,7 +128,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'the second place' );
 	});
 
-	QUnit.test( `decorators, transitions, and binding flags are ignored on components`, t => {
+	test( `decorators, transitions, and binding flags are ignored on components`, t => {
 		const cmp = Ractive.extend({
 			template: 'yep'
 		});

--- a/tests/browser/render/css.js
+++ b/tests/browser/render/css.js
@@ -1,4 +1,5 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'render/css.js' );
@@ -33,7 +34,7 @@ export default function() {
 		return hex.toUpperCase();
 	}
 
-	QUnit.test( 'CSS is applied to components', t => {
+	test( 'CSS is applied to components', t => {
 		const Widget = Ractive.extend({
 			template: '<p>foo</p>',
 			css: 'p { color: red; }'
@@ -46,7 +47,7 @@ export default function() {
 		t.equal( getHexColor( ractive.find( 'p' ) ), hexCodes.red );
 	});
 
-	QUnit.test( 'CSS is encapsulated', t => {
+	test( 'CSS is encapsulated', t => {
 		const Widget = Ractive.extend({
 			template: '<p>red</p>',
 			css: 'p { color: red; }'
@@ -64,7 +65,7 @@ export default function() {
 		t.equal( getHexColor( paragraphs[1] ), hexCodes.red );
 	});
 
-	QUnit.test( 'CSS encapsulation transformation is optional', t => {
+	test( 'CSS encapsulation transformation is optional', t => {
 		const done = t.async();
 
 		const Widget = Ractive.extend({
@@ -88,7 +89,7 @@ export default function() {
 		ractive.teardown().then( done );
 	});
 
-	QUnit.test( 'Comments do not break transformed CSS', t => {
+	test( 'Comments do not break transformed CSS', t => {
 		const Widget = Ractive.extend({
 			template: '<p>foo</p>',
 			css: '/*p { color: red; }*/ p { color: blue; }'
@@ -101,7 +102,7 @@ export default function() {
 		t.equal( getHexColor( ractive.find( 'p' ) ), hexCodes.blue );
 	});
 
-	QUnit.test( 'Multiple pseudo-selectors work', t => {
+	test( 'Multiple pseudo-selectors work', t => {
 		const Widget = Ractive.extend({
 			template: '<div><p>blue</p><p>black</p></div>',
 			css: 'p:first-child:nth-child(1) { color: blue; }'
@@ -121,7 +122,7 @@ export default function() {
 		t.equal( getHexColor( paragraphs[3] ), hexCodes.black );
 	});
 
-	QUnit.test( 'Combinators work', t => {
+	test( 'Combinators work', t => {
 		const Widget = Ractive.extend({
 			template: '<div><p>black</p><p>green</p></div>',
 			css: 'p + p { color: green; }'
@@ -141,7 +142,7 @@ export default function() {
 		t.equal( getHexColor( paragraphs[3] ), hexCodes.green );
 	});
 
-	QUnit.test( 'Media queries work', t => {
+	test( 'Media queries work', t => {
 		const Widget = Ractive.extend({
 			template: '<p>red</p>',
 			css: 'p { color: blue } @media screen and (max-width: 99999px) { p { color: red; } }'
@@ -159,7 +160,7 @@ export default function() {
 		t.equal( getHexColor( paragraphs[1] ), hexCodes.red );
 	});
 
-	QUnit.test( 'Multiple inheritance doesn\'t break css', t => {
+	test( 'Multiple inheritance doesn\'t break css', t => {
 		const C = Ractive.extend({
 			css: 'p { color: red; }',
 			template: '<p>Hi!</p>'
@@ -176,7 +177,7 @@ export default function() {
 		t.equal( getHexColor( paragraph ), hexCodes.red );
 	});
 
-	QUnit.test( 'nth-child selectors work', t => {
+	test( 'nth-child selectors work', t => {
 		const ZebraList = Ractive.extend({
 			css: 'li { color: green; } li:nth-child(2n+1) { color: red; }',
 			template: `
@@ -201,7 +202,7 @@ export default function() {
 		t.equal( getHexColor( lis[4] ), hexCodes.red );
 	});
 
-	QUnit.test( 'Components forward encapsulation instructions to top-level components in their own templates', t => {
+	test( 'Components forward encapsulation instructions to top-level components in their own templates', t => {
 		const Inner = Ractive.extend({
 			template: '<p>red, bold, italic</p>',
 			css: 'p { color: red; }'
@@ -231,7 +232,7 @@ export default function() {
 		t.equal( style.fontStyle, 'italic' );
 	});
 
-	QUnit.test( 'Yielded content gets encapsulated styles', t => {
+	test( 'Yielded content gets encapsulated styles', t => {
 		const Wrapper = Ractive.extend({
 			template: `<div class='blue'>{{yield}}</div>`,
 			css: '.blue { color: blue; }'
@@ -252,7 +253,7 @@ export default function() {
 		t.ok( /Comic Sans MS/.test( style.fontFamily ) );
 	});
 
-	QUnit.test( 'Components retain their encapsulated CSS until they are detached', t => {
+	test( 'Components retain their encapsulated CSS until they are detached', t => {
 		const done = t.async();
 
 		const Widget = Ractive.extend({
@@ -289,7 +290,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'data-ractive-css only gets applied to one level of elements', t => {
+	test( 'data-ractive-css only gets applied to one level of elements', t => {
 		const Widget = Ractive.extend({
 			template: '<div><p></p></div>',
 			css: 'div {}'
@@ -301,7 +302,7 @@ export default function() {
 		t.ok( !ractive.find( 'p' ).hasAttribute( 'data-ractive-css' ) );
 	});
 
-	QUnit.test( 'top-level elements inside each blocks get encapsulated styles', t => {
+	test( 'top-level elements inside each blocks get encapsulated styles', t => {
 		const Widget = Ractive.extend({
 			template: `
 				<div class='one'>a</div>
@@ -332,7 +333,7 @@ export default function() {
 		t.equal( getHexColor( two ), hexCodes.blue );
 	});
 
-	QUnit.test( 'Multiline comments are removed (#2683)', t => {
+	test( 'Multiline comments are removed (#2683)', t => {
 		const Widget = Ractive.extend({
 			template: '<p>foo</p>',
 			css: '/*p \n{ color: red; }*/ p { color: blue; }'
@@ -345,7 +346,7 @@ export default function() {
 		t.equal( getHexColor( ractive.find( 'p' ) ), hexCodes.blue );
 	});
 
-	QUnit.test( 'Attribute selectors are handled correctly (#2778)', t => {
+	test( 'Attribute selectors are handled correctly (#2778)', t => {
 		const Widget = Ractive.extend({
 			template: '<p data-foo="https://\'\']:">foo</p>',
 			css: 'p[data-foo=\'https://\\\'\\\']:\'] { color: blue; }'
@@ -358,7 +359,7 @@ export default function() {
 		t.equal( getHexColor( ractive.find( 'p' ) ), hexCodes.blue );
 	});
 
-	QUnit.test( `components should output css scoping ids with toHTML (#2709)`, t => {
+	test( `components should output css scoping ids with toHTML (#2709)`, t => {
 		const cmp = new (Ractive.extend({
 			template: '<div />',
 			cssId: 'my-nifty-cmp',
@@ -369,7 +370,7 @@ export default function() {
 		t.ok( ~cmp.toCSS().indexOf( 'my-nifty-cmp' ) );
 	});
 
-	QUnit.test( `using 'from' and 'to' in keyframe declarations works (#2854)`, t => {
+	test( `using 'from' and 'to' in keyframe declarations works (#2854)`, t => {
 		const cmp = new (Ractive.extend({
 			el: fixture,
 			template: '<p class="blue">foo</p><p class="red">bar</p>',
@@ -381,7 +382,7 @@ export default function() {
 		t.ok( ~cmp.toCSS().indexOf( 'someAnimation { from { transform: scale3d(1.5,1.5,1) rotate(0deg); } }' ) );
 	});
 
-	QUnit.test( `css can be loaded from an element, and id, or a selector too (#2511)`, t => {
+	test( `css can be loaded from an element, and id, or a selector too (#2511)`, t => {
 		const script = document.createElement( 'script' );
 		script.setAttribute( 'type', 'text/css' );
 		script.setAttribute( 'id', 'foo-css' );

--- a/tests/browser/render/elements.js
+++ b/tests/browser/render/elements.js
@@ -1,10 +1,11 @@
 /*global document, HTMLParagraphElement */
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'render/elements.js' );
 
-	QUnit.test( 'option element with custom selected logic works without error and correctly', t => {
+	test( 'option element with custom selected logic works without error and correctly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -22,7 +23,7 @@ export default function() {
 		t.equal( ractive.find('select').value , 2 );
 	});
 
-	QUnit.test( 'element inside option is an error', t => {
+	test( 'element inside option is an error', t => {
 		t.throws( () => {
 			new Ractive({
 				el: fixture,
@@ -31,7 +32,7 @@ export default function() {
 		}, /An <option> element cannot contain other elements \(encountered <blink>\)/ );
 	});
 
-	QUnit.test( 'Input with uppercase tag name binds correctly', t => {
+	test( 'Input with uppercase tag name binds correctly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `<INPUT value='{{val}}'>{{val}}`,
@@ -43,7 +44,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<input>bar' );
 	});
 
-	QUnit.test( 'Textarea is stringified correctly', t => {
+	test( 'Textarea is stringified correctly', t => {
 		const ractive = new Ractive({
 			template: '<textarea value="123<div></div>"></textarea>'
 		});
@@ -51,7 +52,7 @@ export default function() {
 		t.equal( ractive.toHTML(), '<textarea>123&lt;div&gt;&lt;/div&gt;</textarea>' );
 	});
 
-	QUnit.test( 'Wildcard proxy-events invalid on elements', t => {
+	test( 'Wildcard proxy-events invalid on elements', t => {
 		t.expect( 1 );
 
 		t.throws( () => {
@@ -64,7 +65,7 @@ export default function() {
 	});
 
 	if ( 'draggable' in document.createElement( 'div' ) ) {
-		QUnit.test( 'draggable attribute is handled correctly (#1780)', t => {
+		test( 'draggable attribute is handled correctly (#1780)', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '<div draggable="true" /><div draggable="false" /><div draggable="" /><div draggable /><div draggable="{{true}}" /><div draggable="{{false}}" /><div draggable="{{empty}}" />'
@@ -87,7 +88,7 @@ export default function() {
 	}
 
 	if ( 'registerElement' in document ) {
-		QUnit.test( '"is" attribute is handled correctly for custom elements (#2043)', t => {
+		test( '"is" attribute is handled correctly for custom elements (#2043)', t => {
 			document.registerElement( 'x-foo', {
 				prototype: Object.create( HTMLParagraphElement.prototype, {
 					testMember: { value: true }
@@ -105,7 +106,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'svg elements contributed by a component should have the correct namespace - #2621', t => {
+	test( 'svg elements contributed by a component should have the correct namespace - #2621', t => {
 		t.expect( 7 );
 		const svg = 'http://www.w3.org/2000/svg';
 		const point = Ractive.extend({

--- a/tests/browser/render/enhance.js
+++ b/tests/browser/render/enhance.js
@@ -1,9 +1,10 @@
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'render/enhance.js' );
 
-	QUnit.test( 'Cannot use append and enhance at the same time', t => {
+	test( 'Cannot use append and enhance at the same time', t => {
 		t.throws( () => {
 			new Ractive({
 				enhance: true,
@@ -12,7 +13,7 @@ export default function() {
 		}, /Cannot use append and enhance at the same time/ );
 	});
 
-	QUnit.test( 'basic progressive enhancement', t => {
+	test( 'basic progressive enhancement', t => {
 		fixture.innerHTML = '<p></p>';
 		const p = fixture.querySelector( 'p' );
 
@@ -26,7 +27,7 @@ export default function() {
 		t.strictEqual( p, ractive.find( 'p' ) );
 	});
 
-	QUnit.test( 'progressive enhancement for svg elements', t => {
+	test( 'progressive enhancement for svg elements', t => {
 		/*
 		 * list is grabbed from https://developer.mozilla.org/en-US/docs/Web/SVG/Element using the following code:
 		 *
@@ -48,7 +49,7 @@ export default function() {
 		t.strictEqual( svg, ractive.find( 'svg' ) );
 	});
 
-	QUnit.test( 'missing nodes are added', t => {
+	test( 'missing nodes are added', t => {
 		fixture.innerHTML = '<p></p>';
 		const p = fixture.querySelector( 'p' );
 
@@ -62,7 +63,7 @@ export default function() {
 		t.strictEqual( p, ractive.find( 'p' ) );
 	});
 
-	QUnit.test( 'excess nodes are removed', t => {
+	test( 'excess nodes are removed', t => {
 		fixture.innerHTML = '<p></p><p></p>';
 		const ps = fixture.querySelectorAll( 'p' );
 
@@ -77,7 +78,7 @@ export default function() {
 		t.ok( ps[1].parentNode !== fixture );
 	});
 
-	QUnit.test( 'nested elements', t => {
+	test( 'nested elements', t => {
 		const html = '<div><p><strong>it works!</strong></p></div>';
 		fixture.innerHTML = html;
 
@@ -97,7 +98,7 @@ export default function() {
 		t.strictEqual( strong, ractive.find( 'strong' ) );
 	});
 
-	QUnit.test( 'attributes are added/removed as appropriate', t => {
+	test( 'attributes are added/removed as appropriate', t => {
 		fixture.innerHTML = '<button disabled data-live="false"></button>';
 		const button = fixture.querySelector( 'button' );
 
@@ -112,7 +113,7 @@ export default function() {
 		t.ok( !button.disabled );
 	});
 
-	QUnit.test( 'attributes are removed if none exist in template', t => {
+	test( 'attributes are removed if none exist in template', t => {
 		fixture.innerHTML = `<button disabled>don't click me</button>`;
 		const button = fixture.querySelector( 'button' );
 
@@ -127,7 +128,7 @@ export default function() {
 		t.ok( !button.disabled );
 	});
 
-	QUnit.test( 'redundant classes are removed', t => {
+	test( 'redundant classes are removed', t => {
 		fixture.innerHTML = '<div class="someCls someClsToRemove">foo</div>';
 		const div = fixture.querySelector( 'div' );
 
@@ -141,7 +142,7 @@ export default function() {
 		t.strictEqual( div, ractive.find( 'div' ) );
 	});
 
-	QUnit.test( 'conditional sections inherit existing DOM', t => {
+	test( 'conditional sections inherit existing DOM', t => {
 		fixture.innerHTML = '<p></p>';
 		const p = fixture.querySelector( 'p' );
 
@@ -156,7 +157,7 @@ export default function() {
 		t.strictEqual( p, ractive.find( 'p' ) );
 	});
 
-	QUnit.test( 'list sections inherit existing DOM', t => {
+	test( 'list sections inherit existing DOM', t => {
 		fixture.innerHTML = '<ul><li>a</li><li>b</li><li>c</li></ul>';
 		const lis = fixture.querySelectorAll( 'li' );
 
@@ -175,7 +176,7 @@ export default function() {
 		t.deepEqual( ractive.findAll( 'li' ), [].slice.call( lis ) );
 	});
 
-	QUnit.test( 'interpolator in text sandwich', t => {
+	test( 'interpolator in text sandwich', t => {
 		fixture.innerHTML = '<p>before</p> hello, world! <p>after</p>';
 		const ps = fixture.querySelectorAll( 'p' );
 
@@ -190,7 +191,7 @@ export default function() {
 		t.deepEqual( ractive.findAll( 'p' ), [].slice.call( ps ) );
 	});
 
-	QUnit.test( 'mismatched interpolator in text sandwich', t => {
+	test( 'mismatched interpolator in text sandwich', t => {
 		fixture.innerHTML = '<p>before</p> hello, world! <p>after</p>';
 		const ps = fixture.querySelectorAll( 'p' );
 
@@ -205,7 +206,7 @@ export default function() {
 		t.deepEqual( ractive.findAll( 'p' ), [].slice.call( ps ) );
 	});
 
-	QUnit.test( 'partials', t => {
+	test( 'partials', t => {
 		fixture.innerHTML = '<p>I am a partial</p>';
 		const p = fixture.querySelector( 'p' );
 
@@ -222,7 +223,7 @@ export default function() {
 		t.strictEqual( ractive.find( 'p' ), p );
 	});
 
-	QUnit.test( 'components', t => {
+	test( 'components', t => {
 		fixture.innerHTML = '<ul><li>apples</li><li>oranges</li></ul>';
 		const lis = fixture.querySelectorAll( 'li' );
 
@@ -245,7 +246,7 @@ export default function() {
 		t.deepEqual( ractive.findAll( 'li' ), [].slice.call( lis ) );
 	});
 
-	QUnit.test( 'two-way binding is initialised from DOM', t => {
+	test( 'two-way binding is initialised from DOM', t => {
 		fixture.innerHTML = '<input value="it works"/>';
 		const input = fixture.querySelector( 'input' );
 
@@ -259,7 +260,7 @@ export default function() {
 		t.strictEqual( ractive.find( 'input' ), input );
 	});
 
-	QUnit.test( 'two-way binding with number input', t => {
+	test( 'two-way binding with number input', t => {
 		fixture.innerHTML = '<input type="number" value="42"/>';
 		const input = fixture.querySelector( 'input' );
 
@@ -273,7 +274,7 @@ export default function() {
 		t.strictEqual( ractive.find( 'input' ), input );
 	});
 
-	QUnit.test( 'two-way binding with range input', t => {
+	test( 'two-way binding with range input', t => {
 		fixture.innerHTML = '<input type="range" value="42"/>';
 		const input = fixture.querySelector( 'input' );
 
@@ -288,7 +289,7 @@ export default function() {
 	});
 
 	if ( !/phantomjs/i.test( navigator.userAgent ) ) { // gah
-		QUnit.test( 'two-way binding with single select', t => {
+		test( 'two-way binding with single select', t => {
 			fixture.innerHTML = `
 				<select>
 					<option>isomorphic</option>
@@ -317,7 +318,7 @@ export default function() {
 			t.equal( ractive.get( 'selected.desc' ), 'universal' );
 		});
 
-		QUnit.test( 'two-way binding with multiple select', t => {
+		test( 'two-way binding with multiple select', t => {
 			fixture.innerHTML = `
 				<select multiple>
 					<option>isomorphic</option>
@@ -350,7 +351,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'two-way binding with checkbox input', t => {
+	test( 'two-way binding with checkbox input', t => {
 		fixture.innerHTML = `
 			<input type='checkbox'>
 			<input type='checkbox' checked>`;
@@ -368,7 +369,7 @@ export default function() {
 		t.ok(  inputs[1].checked );
 	});
 
-	QUnit.test( 'two-way binding with checkbox name input', t => {
+	test( 'two-way binding with checkbox name input', t => {
 		fixture.innerHTML = `
 			<input type='checkbox' value='foo' checked>
 			<input type='checkbox' value='bar'>
@@ -391,7 +392,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'selected' ), [ 'foo', 'baz' ]);
 	});
 
-	QUnit.test( 'two-way binding with radio inputs', t => {
+	test( 'two-way binding with radio inputs', t => {
 		fixture.innerHTML = `
 			<input type='radio'>
 			<input type='radio' checked>
@@ -412,7 +413,7 @@ export default function() {
 		t.ok( !ractive.get( 'c' ) );
 	});
 
-	QUnit.test( 'two-way binding with radio name inputs', t => {
+	test( 'two-way binding with radio name inputs', t => {
 		fixture.innerHTML = `
 			<input type='radio' value='isomorphic'>
 			<input type='radio' value='universal' checked>
@@ -431,7 +432,7 @@ export default function() {
 		t.equal( ractive.get( 'selected' ), 'universal' );
 	});
 
-	QUnit.test( 'two-way binding with contenteditable', t => {
+	test( 'two-way binding with contenteditable', t => {
 		fixture.innerHTML = `<div contenteditable='true'><p>hello</p></div>`;
 
 		const ractive = new Ractive({
@@ -443,7 +444,7 @@ export default function() {
 		t.equal( ractive.get( 'value' ), '<p>hello</p>' );
 	});
 
-	QUnit.test( 'standard namespaced attributes without namespace declaration (#2623)', t => {
+	test( 'standard namespaced attributes without namespace declaration (#2623)', t => {
 		fixture.innerHTML = '<svg><use xlink:href="#foo" /></svg>';
 		const svg = fixture.querySelector( 'svg' );
 		const use = fixture.querySelector( 'use' );
@@ -457,7 +458,7 @@ export default function() {
 		t.strictEqual( r.find( 'use' ), use );
 	});
 
-	QUnit.test( `enhancing sibling text nodes and interpolators`, t => {
+	test( `enhancing sibling text nodes and interpolators`, t => {
 		fixture.innerHTML = 'foo bar baz';
 		new Ractive({
 			target: fixture,
@@ -469,7 +470,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foo bar baz' );
 	});
 
-	QUnit.test( `triples reuse existing content if it matches (#2403)`, t => {
+	test( `triples reuse existing content if it matches (#2403)`, t => {
 		fixture.innerHTML = '<div>foo bar</div><span><i>guts</i></span>&amp; why not?<!-- yep -->?sure';
 		const div = fixture.childNodes[0];
 		const text = div.childNodes[0];
@@ -502,7 +503,7 @@ export default function() {
 		t.ok( comment === _comment );
 	});
 
-	QUnit.test( `triples that don't match existing content are still rendered correctly`, t => {
+	test( `triples that don't match existing content are still rendered correctly`, t => {
 		fixture.innerHTML = '<div>nope</div>sure';
 
 		new Ractive({
@@ -517,7 +518,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div>yep</div>still yep' );
 	});
 
-	QUnit.test( `enhancement works with anchors`, t => {
+	test( `enhancement works with anchors`, t => {
 		fixture.innerHTML = '<div>foo</div>';
 		const div = fixture.childNodes[0];
 		const text = div.childNodes[0];

--- a/tests/browser/render/misc.js
+++ b/tests/browser/render/misc.js
@@ -1,5 +1,6 @@
 import { svg } from '../../../src/config/environment';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 /* globals window, document */
 
@@ -7,7 +8,7 @@ export default function() {
 	initModule( 'render/misc' );
 
 	if ( svg ) {
-		QUnit.test( 'Style elements have content inserted that becomes .textContent gh #569', t => {
+		test( 'Style elements have content inserted that becomes .textContent gh #569', t => {
 			new Ractive({
 				el: fixture,
 				template: '<svg><style id="style">text { font-size: 40px }</style></svg>'
@@ -20,7 +21,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'Nested reference expression updates when array index member changes', t => {
+	test( 'Nested reference expression updates when array index member changes', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#item}}{{foo[bar]}}{{/}}',
@@ -33,7 +34,7 @@ export default function() {
 
 	});
 
-	QUnit.test( 'Conditional section with reference expression updates when keypath changes', t => {
+	test( 'Conditional section with reference expression updates when keypath changes', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#foo[bar]}}buzz{{/}}',
@@ -49,7 +50,7 @@ export default function() {
 
 	});
 
-	QUnit.test( 'Input with reference expression updates target when keypath changes', t => {
+	test( 'Input with reference expression updates target when keypath changes', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input value="{{foo[bar]}}"/>',
@@ -66,7 +67,7 @@ export default function() {
 
 	});
 
-	QUnit.test( 'List of inputs with referenceExpression name update correctly', t => {
+	test( 'List of inputs with referenceExpression name update correctly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `<input type='radio' name='{{responses[topic]}}'/>`,
@@ -82,7 +83,7 @@ export default function() {
 		t.equal( input.name, '{{responses.Color}}' );
 	});
 
-	QUnit.test( 'List of inputs with nested referenceExpression name updates correctly', t => {
+	test( 'List of inputs with nested referenceExpression name updates correctly', t => {
 		t.expect(3);
 
 		const ractive = new Ractive({
@@ -112,7 +113,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Rendering a non-append instance into an already-occupied element removes the other instance (#1430)', t => {
+	test( 'Rendering a non-append instance into an already-occupied element removes the other instance (#1430)', t => {
 		let ractive = new Ractive({
 			template: 'instance1'
 		});
@@ -128,7 +129,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'instance2' );
 	});
 
-	QUnit.test( 'Render may be called with a selector (#1430)', t => {
+	test( 'Render may be called with a selector (#1430)', t => {
 		const ractive = new Ractive({
 			template: 'foo'
 		});
@@ -140,7 +141,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div id="foo">foo</div>' );
 	});
 
-	QUnit.test( 'Value changes in object iteration should cause updates (#1476)', t => {
+	test( 'Value changes in object iteration should cause updates (#1476)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#obj[sel]:sk}}{{sk}} {{@key}} {{.}}{{/}}',
@@ -166,7 +167,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'a a a1b b b1' );
 	});
 
-	QUnit.test( 'Sections survive unrender-render (#1553)', t => {
+	test( 'Sections survive unrender-render (#1553)', t => {
 		window.renderedFragments = 0;
 
 		const ractive = new Ractive({
@@ -181,7 +182,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<p>1</p><p>2</p><p>3</p>' );
 	});
 
-	QUnit.test( 'Multi switch each block object -> array -> object -> array (#2054)', t => {
+	test( 'Multi switch each block object -> array -> object -> array (#2054)', t => {
 		const arrayData = ['a', 'b', 'c'];
 		const objectData = { a: 'a', b: 'b', c: 'c' };
 		const expected = 'abc';
@@ -203,7 +204,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, expected );
 	});
 
-	QUnit.test( 'iteration special refs outside of an iteration should not error', t => {
+	test( 'iteration special refs outside of an iteration should not error', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{@index}}{{@key}}'
@@ -212,7 +213,7 @@ export default function() {
 		t.ok( true, 'hey, it didn\'t throw' );
 	});
 
-	QUnit.test( 'static delimiters should be configurable (#2240)', t => {
+	test( 'static delimiters should be configurable (#2240)', t => {
 		new Ractive({
 			el: fixture,
 			template: '{{one}} {{{two}}} [[three]] [[[four]]]',
@@ -225,7 +226,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '{{one}} {{{two}}} [[three]] [[[four]]]');
 	});
 
-	QUnit.test( 'a repeated section should skip empty iterations when looking for a next node for insertion (#2234)', t => {
+	test( 'a repeated section should skip empty iterations when looking for a next node for insertion (#2234)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#each items}}{{#if .bool}}{{.val}}{{/if}}{{/each}}',
@@ -242,7 +243,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '13' );
 	});
 
-	QUnit.test( 'fragment should skip non-rendered items when searching for its next node (#2317)', t => {
+	test( 'fragment should skip non-rendered items when searching for its next node (#2317)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#if step === 3}}3{{/if}}{{#if step === 1}}1{{/if}}{{#if step === 2}}2{{/if}}text',
@@ -256,7 +257,7 @@ export default function() {
 	});
 
 	if ( typeof Object.create === 'function' ) {
-		QUnit.test( 'data of type Object.create(null) (#1825)', t => {
+		test( 'data of type Object.create(null) (#1825)', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '<hr class="{{ noproto }}">{{ noproto }}',
@@ -270,7 +271,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'unresolveds that go out of scope should be unregistered', t => {
+	test( 'unresolveds that go out of scope should be unregistered', t => {
 		t.expect( 0 );
 
 		const r = new Ractive({
@@ -283,7 +284,7 @@ export default function() {
 		r.set( 'foo', 2 );
 	});
 
-	QUnit.test( 'instances that are made dirty while updating should not get stuck (#2554)', t => {
+	test( 'instances that are made dirty while updating should not get stuck (#2554)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<span>{{bar}}</span>{{#if foo}}<input type="checkbox" checked="{{baf}}" />{{bar}}{{/if}}`,
@@ -311,7 +312,7 @@ export default function() {
 		t.htmlEqual( span.innerHTML, 'y' );
 	});
 
-	QUnit.test( 'space entity refs should not be consumed during trimming (#2327)', t => {
+	test( 'space entity refs should not be consumed during trimming (#2327)', t => {
 		new Ractive({
 			el: fixture,
 			template: '\n  {{#if check}}\n    &nbsp;\n    {{first}}\n    &nbsp;\n    {{second}}\n    &nbsp;\n  {{/if}}\n',
@@ -321,7 +322,7 @@ export default function() {
 		t.equal( fixture.innerHTML, '&nbsp; 1 &nbsp; 2 &nbsp;' );
 	});
 
-	QUnit.test( `rendering a textOnlyMode template renders text only`, t => {
+	test( `rendering a textOnlyMode template renders text only`, t => {
 		const r = new Ractive({
 			template: Ractive.parse( `no <elements or="attributes" /> or &amp; & entities <{{any}} foo="bar"> {{just}} text, [[refs]], and {{#if foo}}sections{{/if}}`, { textOnlyMode: true } ),
 			data: {

--- a/tests/browser/render/mustache-compliance/all.js
+++ b/tests/browser/render/mustache-compliance/all.js
@@ -1,4 +1,5 @@
 import { onWarn, initModule } from '../../../helpers/test-config';
+import { test } from 'qunit';
 
 // MUSTACHE SPEC COMPLIANCE TESTS
 // ==============================
@@ -1193,7 +1194,7 @@ export default function() {
 		theModule.tests.forEach( theTest => {
 			if ( theTest.unpassable || ( isOldIe && theTest.oldIe ) ) return;
 
-			QUnit.test( `[${theModule.name}] ${theTest.name}`, t => {
+			test( `[${theModule.name}] ${theTest.name}`, t => {
 				onWarn( msg => {
 					t.ok( /Could not find template/.test( msg ) ); // only warning that should appear
 				});

--- a/tests/browser/render/namespaceURI.js
+++ b/tests/browser/render/namespaceURI.js
@@ -1,5 +1,6 @@
 import { svg } from '../../../src/config/environment';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'render/namespaceURI.js' );
@@ -8,7 +9,7 @@ export default function() {
 		const html = 'http://www.w3.org/1999/xhtml';
 		const svg = 'http://www.w3.org/2000/svg';
 
-		QUnit.test( 'Top-level elements have html namespace by default', t => {
+		test( 'Top-level elements have html namespace by default', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: `<p>html</p>`
@@ -17,7 +18,7 @@ export default function() {
 			t.equal( ractive.find( 'p' ).namespaceURI, html );
 		});
 
-		QUnit.test( 'SVG elements have svg namespace', t => {
+		test( 'SVG elements have svg namespace', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: `<svg><text>svg</text></svg>`
@@ -27,7 +28,7 @@ export default function() {
 			t.equal( ractive.find( 'text' ).namespaceURI, svg );
 		});
 
-		QUnit.test( 'Top-level elements inherit SVG namespaceURI where appropriate', t => {
+		test( 'Top-level elements inherit SVG namespaceURI where appropriate', t => {
 			const ractive = new Ractive({
 				el: document.createElementNS( svg, 'svg' ),
 				template: '<text>svg</text>'
@@ -36,7 +37,7 @@ export default function() {
 			t.equal( ractive.find( 'text' ).namespaceURI, svg );
 		});
 
-		QUnit.test( 'Triples inside SVG elements result in correct namespaceURI', t => {
+		test( 'Triples inside SVG elements result in correct namespaceURI', t => {
 			const ractive = new Ractive({
 				el: document.createElementNS( svg, 'svg' ),
 				template: '{{{code}}}',
@@ -50,7 +51,7 @@ export default function() {
 			t.equal( text.namespaceURI, svg );
 		});
 
-		QUnit.test( 'Children of foreignObject elements default to html namespace (#713)', t => {
+		test( 'Children of foreignObject elements default to html namespace (#713)', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '<svg><foreignObject><p>foo</p></foreignObject></svg>'
@@ -62,7 +63,7 @@ export default function() {
 			t.equal( ractive.find( 'p' ).namespaceURI, html );
 		});
 
-		QUnit.test( 'Top-level elements in components have the correct namespace (#953)', t => {
+		test( 'Top-level elements in components have the correct namespace (#953)', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '<svg><widget message="yup"/></svg>',
@@ -77,7 +78,7 @@ export default function() {
 			t.htmlEqual( fixture.innerHTML, '<svg><text>yup</text></svg>' );
 		});
 
-		QUnit.test( 'Custom namespaces are supported (#2038)', t => {
+		test( 'Custom namespaces are supported (#2038)', t => {
 			new Ractive({
 				el: fixture,
 				template: `
@@ -90,7 +91,7 @@ export default function() {
 			t.equal( documentProperties.namespaceURI, 'http://www.w3.org/2000/svg' );
 		});
 
-		QUnit.test( 'Namespaced attributes are set correctly', t => {
+		test( 'Namespaced attributes are set correctly', t => {
 			const ractive = new Ractive({
 				template: '<svg><use xlink:href="#yup" /></svg>'
 			});

--- a/tests/browser/render/output.js
+++ b/tests/browser/render/output.js
@@ -1,6 +1,7 @@
 import { svg } from '../../../src/config/environment';
 import tests from '../../helpers/samples/render';
 import { onWarn, initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'render/output.js' );
@@ -13,7 +14,7 @@ export default function() {
 		if ( !svg && theTest.svg ) return;
 		if ( theTest.nodeOnly ) return;
 
-		QUnit.test( theTest.name, t => {
+		test( theTest.name, t => {
 
 			// suppress warnings about non-POJOs and failed computations
 			onWarn( msg => t.ok( /plain JavaScript object|Failed to compute/.test( msg ) ) );

--- a/tests/browser/select.js
+++ b/tests/browser/select.js
@@ -1,9 +1,10 @@
 import { initModule } from '../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'select.js' );
 
-	QUnit.test( 'Use as a string to compare', t => {
+	test( 'Use as a string to compare', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			comparatorFn( option, value ) {
@@ -26,7 +27,7 @@ export default function() {
 		t.equal( ractive.find( 'select' ).value, { id: 2 } );
 	});
 
-	QUnit.test( 'Use as a function to compare', t => {
+	test( 'Use as a function to compare', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			comparatorFn( option, value ) {
@@ -49,7 +50,7 @@ export default function() {
 		t.equal( ractive.find( 'select' ).value, { id: 2 } );
 	});
 
-	QUnit.test( 'If a select\'s value attribute is updated at the same time as the available options, the correct option will be selected', t => {
+	test( 'If a select\'s value attribute is updated at the same time as the available options, the correct option will be selected', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -71,7 +72,7 @@ export default function() {
 		t.equal( ractive.find( '#select' ).value, 'c' );
 	});
 
-	QUnit.test( 'If a select value with two-way binding has a selected option at render time, the model updates accordingly', t => {
+	test( 'If a select value with two-way binding has a selected option at render time, the model updates accordingly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -88,7 +89,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<select><option value="red">red</option><option value="blue">blue</option><option value="green">green</option></select> <p>selected green</p>' );
 	});
 
-	QUnit.test( 'If a select value with two-way binding has no selected option at render time, the model defaults to the top value', t => {
+	test( 'If a select value with two-way binding has no selected option at render time, the model defaults to the top value', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -105,7 +106,7 @@ export default function() {
 	});
 
 
-	QUnit.test( 'If the value of a select is specified in the model, it overrides the markup', t => {
+	test( 'If the value of a select is specified in the model, it overrides the markup', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -122,7 +123,7 @@ export default function() {
 		t.ok( !ractive.find( '#green' ).selected );
 	});
 
-	QUnit.test( 'A select value with static options with numeric values will show the one determined by the model, whether a string or a number is used', t => {
+	test( 'A select value with static options with numeric values will show the one determined by the model, whether a string or a number is used', t => {
 		let ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -154,7 +155,7 @@ export default function() {
 		t.ok(  ractive.find( '#_3' ).selected );
 	});
 	/*
-QUnit.test( 'Setting the value of a select works with options added via a triple', t => {
+test( 'Setting the value of a select works with options added via a triple', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<select value="{{value}}">{{{triple}}}</select>',
@@ -172,7 +173,7 @@ QUnit.test( 'Setting the value of a select works with options added via a triple
 		t.equal( ractive.get( 'value' ), 1 );
 	});
 	*/
-	QUnit.test( 'A two-way select updates to the actual value of its selected option, not the stringified value', t => {
+	test( 'A two-way select updates to the actual value of its selected option, not the stringified value', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -202,7 +203,7 @@ QUnit.test( 'Setting the value of a select works with options added via a triple
 	});
 
 	/*
-QUnit.test( 'If a multiple select value with two-way binding has a selected option at render time, the model updates accordingly', t => {
+test( 'If a multiple select value with two-way binding has a selected option at render time, the model updates accordingly', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<select value="{{colors}}" multiple><option value="red">red</option><option value="blue" selected>blue</option><option value="green" selected>green</option></select>'
@@ -212,7 +213,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 	});
 	*/
 
-	QUnit.test( 'If a multiple select value with two-way binding has no selected option at render time, the model defaults to an empty array', t => {
+	test( 'If a multiple select value with two-way binding has no selected option at render time, the model defaults to an empty array', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -226,7 +227,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.deepEqual( ractive.get( 'colors' ), [] );
 	});
 
-	QUnit.test( 'If the value of a multiple select is specified in the model, it overrides the markup', t => {
+	test( 'If the value of a multiple select is specified in the model, it overrides the markup', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -244,7 +245,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.ok( ractive.find( '#green' ).selected );
 	});
 
-	QUnit.test( 'updateModel correctly updates the value of a multiple select', t => {
+	test( 'updateModel correctly updates the value of a multiple select', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -263,7 +264,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.deepEqual( ractive.get( 'selected' ), [ 'red', 'blue' ] );
 	});
 
-	QUnit.test( 'Options added to a select after the initial render will be selected if the value matches', t => {
+	test( 'Options added to a select after the initial render will be selected if the value matches', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -292,7 +293,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.ok( options[1].selected );
 	});
 
-	QUnit.test( 'If an empty select with a binding has options added to it, the model should update', t => {
+	test( 'If an empty select with a binding has options added to it, the model should update', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -309,7 +310,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.htmlEqual( fixture.innerHTML, '<select><option value="1">one</option><option value="2">two</option></select><strong>Selected: 1</strong>' );
 	});
 
-	QUnit.test( 'Regression test for #339', t => {
+	test( 'Regression test for #339', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -333,7 +334,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.deepEqual( ractive.get(), { items: [ {color: 'red'}, {color: 'red'} ] } );
 	});
 
-	QUnit.test( 'Regression test for #351', t => {
+	test( 'Regression test for #351', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -349,7 +350,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.htmlEqual( fixture.innerHTML, '<select multiple><option value="1">one</option><option value="2">two</option></select>' );
 	});
 
-	QUnit.test( '<option>{{foo}}</option> behaves the same as <option value="{{foo}}">{{foo}}</option>', t => {
+	test( '<option>{{foo}}</option> behaves the same as <option value="{{foo}}">{{foo}}</option>', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -380,7 +381,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.equal( ractive.get( 'test2' ), 'c' );
 	});
 
-	QUnit.test( 'A select whose options are re-rendered will update its binding', t => {
+	test( 'A select whose options are re-rendered will update its binding', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -403,7 +404,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.htmlEqual( fixture.innerHTML, '<select><option value="d">d</option><option value="e">e</option><option value="f">f</option></select><p>selected: d</p>' );
 	});
 
-	QUnit.test( 'Options can be inside a partial (#707)', t => {
+	test( 'Options can be inside a partial (#707)', t => {
 		new Ractive({
 			el: fixture,
 			template: `
@@ -417,7 +418,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.htmlEqual( fixture.innerHTML, '<select><option value="a">a</option><option value="b">b</option></select>' );
 	});
 
-	QUnit.test( 'Disabled options have no implicit value (#786)', t => {
+	test( 'Disabled options have no implicit value (#786)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -437,7 +438,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.htmlEqual( fixture.innerHTML, '<p></p><select><option disabled>Select a letter</option><option value="a">a</option><option value="b">b</option><option value="c">c</option></select>' );
 	});
 
-	QUnit.test( 'Uninitialised <select> elements will use the first *non-disabled* option', t => {
+	test( 'Uninitialised <select> elements will use the first *non-disabled* option', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -458,7 +459,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.equal( ractive.find( 'select' ).value, 'a' );
 	});
 
-	QUnit.test( 'Removing selected options from a list causes the select element\'s binding to update (#776)', t => {
+	test( 'Removing selected options from a list causes the select element\'s binding to update (#776)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -480,7 +481,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.equal( ractive.get( 'value' ), '999' );
 	});
 
-	QUnit.test( 'Select bindings work even if there is only a disabled option', t => {
+	test( 'Select bindings work even if there is only a disabled option', t => {
 		t.expect( 0 );
 
 		new Ractive({
@@ -492,7 +493,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		});
 	});
 
-	QUnit.test( 'Model -> view binding works with <select multiple> (#1009)', t => {
+	test( 'Model -> view binding works with <select multiple> (#1009)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -515,7 +516,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.ok( options[3].selected );
 	});
 
-	QUnit.test( 'A multiple select uses non-strict comparison', t => {
+	test( 'A multiple select uses non-strict comparison', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -538,7 +539,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.ok(  ractive.find( '#_3' ).selected );
 	});
 
-	QUnit.test( 'safe to render options into select outside of ractive', t => {
+	test( 'safe to render options into select outside of ractive', t => {
 		const select = document.createElement( 'SELECT' );
 		fixture.appendChild( select );
 
@@ -556,7 +557,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.htmlEqual( select.innerHTML, '<option>a</option>' );
 	});
 
-	QUnit.test( `select options fragment should update correctly (#2428)`, t => {
+	test( `select options fragment should update correctly (#2428)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `
@@ -574,7 +575,7 @@ QUnit.test( 'If a multiple select value with two-way binding has a selected opti
 		t.equal( r.findAll( 'option' ).length, 2 );
 	});
 
-	QUnit.test( `check to see if a multiselect value is an array before looking for options (#2825)`, t => {
+	test( `check to see if a multiselect value is an array before looking for options (#2825)`, t => {
 		t.expect( 0 );
 
 		new Ractive({

--- a/tests/browser/shuffling.js
+++ b/tests/browser/shuffling.js
@@ -1,10 +1,11 @@
 import { fire } from 'simulant';
 import { initModule } from '../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'shuffling.js' );
 
-	QUnit.test( 'Pattern observers on arrays fire correctly after mutations (mirror of test in observe.js)', t => {
+	test( 'Pattern observers on arrays fire correctly after mutations (mirror of test in observe.js)', t => {
 		const ractive = new Ractive({
 			data: {
 				items: [ 'a', 'b', 'c' ]
@@ -39,7 +40,7 @@ export default function() {
 		t.ok( observedLengthChange );
 	});
 
-	QUnit.test( '#if sections only render once when arrays are mutated', t => {
+	test( '#if sections only render once when arrays are mutated', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#if list}}yes{{else}}no{{/if}}',
@@ -57,7 +58,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'yes' );
 	});
 
-	QUnit.test( 'an appropriate error is thrown when shuffling a non-array keypath', t => {
+	test( 'an appropriate error is thrown when shuffling a non-array keypath', t => {
 		const r = new Ractive({
 			data: { foo: null }
 		});
@@ -67,7 +68,7 @@ export default function() {
 		}, /.*push.*non-array.*foo.*/i);
 	});
 
-	QUnit.test( 'conditional attributes shuffle correctly', t => {
+	test( 'conditional attributes shuffle correctly', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#each items}}<div {{#if .cond}}foo="{{.bar}}"{{/if}}>yep</div>{{/each}}',
@@ -81,7 +82,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div foo="bat">yep</div><div foo="baz">yep</div>' );
 	});
 
-	QUnit.test( 'yielders shuffle correctly', t => {
+	test( 'yielders shuffle correctly', t => {
 		const cmp = Ractive.extend({
 			template: '{{yield}}'
 		});
@@ -100,7 +101,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'batbaz' );
 	});
 
-	QUnit.test( 'event directives should shuffle correctly', t => {
+	test( 'event directives should shuffle correctly', t => {
 		t.expect( 5 );
 
 		const r = new Ractive({
@@ -134,7 +135,7 @@ export default function() {
 		fire( r.find( '#div1' ), 'click' );
 	});
 
-	QUnit.test( 'method event directives should shuffle correctly', t => {
+	test( 'method event directives should shuffle correctly', t => {
 		t.expect( 9 );
 
 		let group = 0;
@@ -177,7 +178,7 @@ export default function() {
 		fire( r.find( '#div1' ), 'click' );
 	});
 
-	QUnit.test( 'method event directives with no args should shuffle without throwing', t => {
+	test( 'method event directives with no args should shuffle without throwing', t => {
 		t.expect( 0 );
 
 		const r = new Ractive({
@@ -189,7 +190,7 @@ export default function() {
 		r.unshift( 'items', 2 );
 	});
 
-	QUnit.test( 'shuffling around a computation with an index ref', t => {
+	test( 'shuffling around a computation with an index ref', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items.slice(1)}}{{2 * @index}} {{@index * .}}|{{/each}}`,
@@ -205,7 +206,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '0 0|2 2|' );
 	});
 
-	QUnit.test( 'shuffling a computation should not cause the computation to shuffle (#2267 #2269)', t => {
+	test( 'shuffling a computation should not cause the computation to shuffle (#2267 #2269)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each items.slice(1)}}{{.}}{{/each}}`,
@@ -219,7 +220,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( 'shuffled sections that unrender at the same time should not leave orphans (#2277)', t => {
+	test( 'shuffled sections that unrender at the same time should not leave orphans (#2277)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#if items.length}}{{#each items}}{{.}}{{/each}}{{/if}}`,
@@ -233,7 +234,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '' );
 	});
 
-	QUnit.test( `shuffled elements with attributes depending on template context (@index, etc) should have appropriately updated attributes (#2422)`, t => {
+	test( `shuffled elements with attributes depending on template context (@index, etc) should have appropriately updated attributes (#2422)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each foo}}<span data-wat="{{50 * @index}}">{{50 * @index}}</span>{{/each}}`,
@@ -253,7 +254,7 @@ export default function() {
 		for ( let i = 0; i < spans.length; i++ ) t.equal( spans[i].getAttribute( 'data-wat' ), spans[i].innerHTML );
 	});
 
-	QUnit.test( 'computations with reference expressions that resolve to an array length should be marked on shuffle (#2541)', t => {
+	test( 'computations with reference expressions that resolve to an array length should be marked on shuffle (#2541)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{foo[v].length + 1}}',
@@ -268,7 +269,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '4' );
 	});
 
-	QUnit.test( 'shuffled computations are updated with their shuffled member', t => {
+	test( 'shuffled computations are updated with their shuffled member', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each list as item:i}}{{item + i}}{{/each}}`,
@@ -284,7 +285,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '211' );
 	});
 
-	QUnit.test( 'children of shuffled reference expressions survive the shuffle', t => {
+	test( 'children of shuffled reference expressions survive the shuffle', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#each lists[name]}}{{.foo}}{{/each}}',
@@ -303,7 +304,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'foobaz' );
 	});
 
-	QUnit.test( 'reference expression members shuffle safely', t => {
+	test( 'reference expression members shuffle safely', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#each lists[name.0]}}{{.foo}}{{/each}}',
@@ -324,7 +325,7 @@ export default function() {
 	});
 
 	// TODO reinstate this in some form. Commented out for purposes of #1740
-	//QUnit.test( `Array shuffling only adjusts context and doesn't tear stuff down to rebuild it`, t => {
+	//test( `Array shuffling only adjusts context and doesn't tear stuff down to rebuild it`, t => {
 	// 	let ractive = new Ractive({
 	// 		el: fixture,
 	// 		template: '{{#each items}}{{.name}}{{.name + "_expr"}}{{.[~/name]}}<span {{#.name}}ok{{/}} class="{{.name}}">{{.name}}</span>{{/each}}',
@@ -357,7 +358,7 @@ export default function() {
 	// });
 
 	function removedElementsTest ( action, fn ) {
-		QUnit.test( `Array elements removed via ${action} do not trigger updates in removed sections`, t => {
+		test( `Array elements removed via ${action} do not trigger updates in removed sections`, t => {
 			let observed = false;
 			let errored = false;
 
@@ -394,7 +395,7 @@ export default function() {
 	removedElementsTest( 'splice', ractive => ractive.splice( 'options', 1, 1 ) );
 	removedElementsTest( 'merge', ractive => ractive.set( 'options', [ 'a', 'c' ], { shuffle: true } ) );
 
-	QUnit.test( `mapped unresolved computations should shuffle correctly (#2602)`, t => {
+	test( `mapped unresolved computations should shuffle correctly (#2602)`, t => {
 		const cmp = Ractive.extend({
 			template: '{{foo.baz || 1}}-{{foo.bar}}|'
 		});
@@ -413,7 +414,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '1-3|10-1|1-2|' );
 	});
 
-	QUnit.test( 'pattern observers should shuffle correctly (#2601)', t => {
+	test( 'pattern observers should shuffle correctly (#2601)', t => {
 		let count = 0;
 		const cmp = Ractive.extend({
 			template: '{{foo.bar}}',
@@ -446,7 +447,7 @@ export default function() {
 		t.equal( count, 1 );
 	});
 
-	QUnit.test( 'components that are spliced out should not fire observers - #2604', t => {
+	test( 'components that are spliced out should not fire observers - #2604', t => {
 		const cmp = Ractive.extend({
 			template: '<div />',
 			onconfig () {
@@ -470,7 +471,7 @@ export default function() {
 		t.equal( r.findAll( 'div' ).length, 3 );
 	});
 
-	QUnit.test( 'components that are spliced out should not fire pattern observers - #2604', t => {
+	test( 'components that are spliced out should not fire pattern observers - #2604', t => {
 		let count = 0;
 		const cmp = Ractive.extend({
 			template: '<div />',
@@ -496,7 +497,7 @@ export default function() {
 		t.equal( count, 4 );
 	});
 
-	QUnit.test( 'shuffling around nested lists', t => {
+	test( 'shuffling around nested lists', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#each outer}}{{#each inner}}{{.foo}}{{../0.foo}}{{~/outer.0.inner.0.foo}}{{/each}}{{.inner.0.foo}}{{/each}}',
@@ -515,7 +516,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '999559911921913394393' );
 	});
 
-	QUnit.test( 'observers shuffle correctly', t => {
+	test( 'observers shuffle correctly', t => {
 		let val;
 		const r = new Ractive({
 			el: fixture,
@@ -534,7 +535,7 @@ export default function() {
 		t.equal( val, 4 );
 	});
 
-	QUnit.test( 'pattern observers shuffle correctly', t => {
+	test( 'pattern observers shuffle correctly', t => {
 		let val;
 		const r = new Ractive({
 			el: fixture,
@@ -553,7 +554,7 @@ export default function() {
 		t.equal( val, 4 );
 	});
 
-	QUnit.test( 'mapped observers shuffle correctly', t => {
+	test( 'mapped observers shuffle correctly', t => {
 		let rel;
 		let stat;
 		let relKey;
@@ -594,7 +595,7 @@ export default function() {
 		t.equal( stat, 4 );
 	});
 
-	QUnit.test( 'mapped pattern observers shuffle correctly', t => {
+	test( 'mapped pattern observers shuffle correctly', t => {
 		let rel;
 		let stat;
 		let relKey;
@@ -643,7 +644,7 @@ export default function() {
 		t.equal( stat, 4 );
 	});
 
-	QUnit.test( 'decorators shuffle correctly', t => {
+	test( 'decorators shuffle correctly', t => {
 		let inits = 0;
 		let upds = 0;
 		let tears = 0;
@@ -678,7 +679,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<span>7</span><span>3</span>' );
 	});
 
-	QUnit.test( 'transitions shuffle correctly', t => {
+	test( 'transitions shuffle correctly', t => {
 		const map = { 1: 0, 2: 0, undefined: 0 };
 		const r = new Ractive({
 			el: fixture,

--- a/tests/browser/twoway.js
+++ b/tests/browser/twoway.js
@@ -1,11 +1,12 @@
 /* global document */
 import { fire } from 'simulant';
 import { hasUsableConsole, onWarn, initModule } from '../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'twoway.js' );
 
-	QUnit.test( 'Two-way bindings work with index references', t => {
+	test( 'Two-way bindings work with index references', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items:i}}<label><input value="{{items[i].name}}"> {{name}}</label>{{/items}}',
@@ -20,7 +21,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<label><input> baz</label><label><input> bar</label>' );
 	});
 
-	QUnit.test( 'Two-way bindings work with foo["bar"] type notation', t => {
+	test( 'Two-way bindings work with foo["bar"] type notation', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<label><input value={{foo["bar"]["baz"]}}> {{foo.bar.baz}}</label>',
@@ -36,7 +37,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<label><input> 2</label>' );
 	});
 
-	QUnit.test( 'Two-way bindings work with arbitrary expressions that resolve to keypaths', t => {
+	test( 'Two-way bindings work with arbitrary expressions that resolve to keypaths', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<label><input value={{foo["bar"][ a+1 ].baz[ b ][ 1 ] }}> {{ foo.bar[1].baz.qux[1] }}</label>',
@@ -61,7 +62,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<label><input> it works</label>' );
 	});
 
-	QUnit.test( 'An input whose value is updated programmatically will update the model on blur (#644)', t => {
+	test( 'An input whose value is updated programmatically will update the model on blur (#644)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input value="{{foo}}">',
@@ -78,7 +79,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'Model is validated on blur, and the view reflects the validate model (#644)', t => {
+	test( 'Model is validated on blur, and the view reflects the validate model (#644)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input value="{{foo}}">',
@@ -99,7 +100,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'Two-way data binding is not attempted on elements with no mustache binding', t => {
+	test( 'Two-way data binding is not attempted on elements with no mustache binding', t => {
 		t.expect( 0 );
 
 		// This will throw an error if the binding is attempted (Issue #750)
@@ -109,7 +110,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Uninitialised values should be initialised with whatever the \'empty\' value is (#775)', t => {
+	test( 'Uninitialised values should be initialised with whatever the \'empty\' value is (#775)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input value="{{foo}}">'
@@ -118,7 +119,7 @@ export default function() {
 		t.equal( ractive.get( 'foo' ), '' );
 	});
 
-	QUnit.test( 'Contenteditable elements can be bound via the value attribute', t => {
+	test( 'Contenteditable elements can be bound via the value attribute', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div contenteditable="true" value="{{content}}"><strong>some content</strong></div>'
@@ -134,7 +135,7 @@ export default function() {
 	try {
 		fire( document.createElement( 'div' ), 'change' );
 
-		QUnit.test( 'Contenteditable elements can be bound with a bindable contenteditable attribute.', ( t ) => {
+		test( 'Contenteditable elements can be bound with a bindable contenteditable attribute.', ( t ) => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '<div contenteditable="{{editable}}" value="{{content}}"><strong>some content</strong></div>',
@@ -152,7 +153,7 @@ export default function() {
 		// do nothing
 	}
 
-	QUnit.test( 'Existing model data overrides contents of contenteditable elements', t => {
+	test( 'Existing model data overrides contents of contenteditable elements', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div contenteditable="true" value="{{content}}"><strong>some content</strong></div>',
@@ -163,7 +164,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<div contenteditable="true">overridden</div>' );
 	});
 
-	QUnit.test( 'The order of attributes does not affect contenteditable (#1134)', t => {
+	test( 'The order of attributes does not affect contenteditable (#1134)', t => {
 		new Ractive({
 			el: fixture,
 			template: `
@@ -179,7 +180,7 @@ export default function() {
 	});
 
 	[ 'number', 'range' ].forEach( ( type ) => {
-		QUnit.test( 'input type=' + type + ' values are coerced', t => {
+		test( 'input type=' + type + ' values are coerced', t => {
 			const ractive = new Ractive({
 				el: fixture,
 				template: '<input value="{{a}}" type="' + type + '"><input value="{{b}}" type="' + type + '">{{a}}+{{b}}={{a+b}}'
@@ -196,7 +197,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'The model updates to reflect which checkbox inputs are checked at render time', t => {
+	test( 'The model updates to reflect which checkbox inputs are checked at render time', t => {
 		let ractive = new Ractive({
 			el: fixture,
 			template: '<input id="red" type="checkbox" name="{{colors}}" value="red"><input id="green" type="checkbox" name="{{colors}}" value="blue" checked><input id="blue" type="checkbox" name="{{colors}}" value="green" checked>'
@@ -218,7 +219,7 @@ export default function() {
 		t.ok( !ractive.find( '#green' ).checked );
 	});
 
-	QUnit.test( 'Checkbox Name bindings use property attributes to determined if checked or not', t => {
+	test( 'Checkbox Name bindings use property attributes to determined if checked or not', t => {
 		let ractive = new Ractive({
 			el: fixture,
 			data: {
@@ -284,7 +285,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'selected' ), [ { id: 'blue', name: 'Blue' }, { id: 'green', name: 'Green'} ] );
 	});
 
-	QUnit.test( 'Radio Name bindings use value-comparator to determined if checked or not', t => {
+	test( 'Radio Name bindings use value-comparator to determined if checked or not', t => {
 		let ractive = new Ractive({
 			el: fixture,
 			data: {
@@ -337,7 +338,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'selected' ), { id: 'green', name: 'Green'} );
 	});
 
-	QUnit.test( 'The model overrides which checkbox inputs are checked at render time', t => {
+	test( 'The model overrides which checkbox inputs are checked at render time', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -353,7 +354,7 @@ export default function() {
 		t.ok( !ractive.find( '#green' ).checked );
 	});
 
-	QUnit.test( 'Named checkbox bindings are kept in sync with data changes (#1610)', t => {
+	test( 'Named checkbox bindings are kept in sync with data changes (#1610)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -370,7 +371,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'colors' ), [ 'green', 'red' ]);
 	});
 
-	QUnit.test( 'The model updates to reflect which radio input is checked at render time', t => {
+	test( 'The model updates to reflect which radio input is checked at render time', t => {
 		let ractive = new Ractive({
 			el: fixture,
 			template: '<input type="radio" name="{{color}}" value="red"><input type="radio" name="{{color}}" value="blue" checked><input type="radio" name="{{color}}" value="green">'
@@ -386,7 +387,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'color' ), undefined );
 	});
 
-	QUnit.test( 'The model overrides which radio input is checked at render time', t => {
+	test( 'The model overrides which radio input is checked at render time', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input id="red" type="radio" name="{{color}}" value="red"><input id="blue" type="radio" name="{{color}}" value="blue" checked><input id="green" type="radio" name="{{color}}" value="green">',
@@ -399,7 +400,7 @@ export default function() {
 		t.ok( ractive.find( '#green' ).checked );
 	});
 
-	QUnit.test( 'updateModel correctly updates the value of a text input', t => {
+	test( 'updateModel correctly updates the value of a text input', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input value="{{name}}">',
@@ -412,7 +413,7 @@ export default function() {
 		t.equal( ractive.get( 'name' ), 'Jim' );
 	});
 
-	QUnit.test( 'updateModel correctly updates the value of a select', t => {
+	test( 'updateModel correctly updates the value of a select', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<select value="{{selected}}"><option selected value="red">red</option><option value="blue">blue</option><option value="green">green</option></select>'
@@ -426,7 +427,7 @@ export default function() {
 		t.equal( ractive.get( 'selected' ), 'blue' );
 	});
 
-	QUnit.test( 'updateModel correctly updates the value of a textarea', t => {
+	test( 'updateModel correctly updates the value of a textarea', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<textarea value="{{name}}"></textarea>',
@@ -439,7 +440,7 @@ export default function() {
 		t.equal( ractive.get( 'name' ), 'Jim' );
 	});
 
-	QUnit.test( 'updateModel correctly updates the value of a checkbox', t => {
+	test( 'updateModel correctly updates the value of a checkbox', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input type="checkbox" checked="{{active}}">',
@@ -452,7 +453,7 @@ export default function() {
 		t.equal( ractive.get( 'active' ), false );
 	});
 
-	QUnit.test( 'updateModel correctly updates the value of a radio', t => {
+	test( 'updateModel correctly updates the value of a radio', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input type="radio" checked="{{active}}">',
@@ -465,7 +466,7 @@ export default function() {
 		t.equal( ractive.get( 'active' ), false );
 	});
 
-	QUnit.test( 'updateModel correctly updates the value of an indirect (name-value) checkbox', t => {
+	test( 'updateModel correctly updates the value of an indirect (name-value) checkbox', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input type="checkbox" name="{{colour}}" value="red"><input type="checkbox" name="{{colour}}" value="blue" checked><input type="checkbox" name="{{colour}}" value="green">'
@@ -479,7 +480,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'colour' ), [ 'blue', 'green' ] );
 	});
 
-	QUnit.test( 'updateModel correctly updates the value of an indirect (name-value) radio', t => {
+	test( 'updateModel correctly updates the value of an indirect (name-value) radio', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input type="radio" name="{{colour}}" value="red"><input type="radio" name="{{colour}}" value="blue" checked><input type="radio" name="{{colour}}" value="green">'
@@ -493,7 +494,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'colour' ), 'green' );
 	});
 
-	QUnit.test( 'Radio inputs will update the model if another input in their group is checked', t => {
+	test( 'Radio inputs will update the model if another input in their group is checked', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items}}<input type="radio" name="plan" checked="{{ checked }}"/>{{/items}}',
@@ -515,7 +516,7 @@ export default function() {
 		t.equal( ractive.get( 'items[1].checked' ), true );
 	});
 
-	QUnit.test( "Radio name inputs don't get stuck after one pass on each value (#2638)", t => {
+	test( "Radio name inputs don't get stuck after one pass on each value (#2638)", t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '{{#items}}<input type="radio" name="{{~/color}}" value="{{.}}" />{{/items}}',
@@ -545,7 +546,7 @@ export default function() {
 		t.equal( r.get( 'color' ), 'red' );
 	});
 
-	QUnit.test( 'Radio name inputs respond to model changes (regression, see #783)', t => {
+	test( 'Radio name inputs respond to model changes (regression, see #783)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items}}<input type="radio" name="{{foo}}" value="{{this}}"/>{{/items}}',
@@ -568,7 +569,7 @@ export default function() {
 	});
 
 
-	QUnit.test(`bindings that trigger their own immediate update via computation should not get stuck (#2427)`, t => {
+	test(`bindings that trigger their own immediate update via computation should not get stuck (#2427)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			data: {
@@ -592,7 +593,7 @@ export default function() {
 		t.equal( inputs[3].value, 'z' );
 	});
 
-	QUnit.test( 'Post-blur validation works (#771)', t => {
+	test( 'Post-blur validation works (#771)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input value="{{foo}}">{{foo}}'
@@ -622,7 +623,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'Reference expression radio bindings rebind correctly inside reference expression sections (#904)', t => {
+	test( 'Reference expression radio bindings rebind correctly inside reference expression sections (#904)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#with steps[current] }}<input type="radio" name="{{~/selected[name]}}" value="{{value}}">{{/with}}',
@@ -642,7 +643,7 @@ export default function() {
 		t.deepEqual( ractive.get( 'selected' ), { one: 'a', two: 'b' });
 	});
 
-	QUnit.test( 'Static bindings can only be one-way (#1149)', t => {
+	test( 'Static bindings can only be one-way (#1149)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input value="[[foo]]">{{foo}}',
@@ -657,7 +658,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<input>static' );
 	});
 
-	QUnit.test( 'input[type="checkbox"] with bound checked and name attributes, updates as expected (#1749)', t => {
+	test( 'input[type="checkbox"] with bound checked and name attributes, updates as expected (#1749)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input type="checkbox" name="{{name}}" checked="{{on}}">',
@@ -686,7 +687,7 @@ export default function() {
 		t.equal( checkbox.name, 'bar' );
 	});
 
-	QUnit.test( 'input[type="checkbox"] with bound name updates as expected (#1305)', t => {
+	test( 'input[type="checkbox"] with bound name updates as expected (#1305)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input type="checkbox" name="{{ch}}" value="foo">',
@@ -697,7 +698,7 @@ export default function() {
 		t.ok( ractive.find( 'input' ).checked );
 	});
 
-	QUnit.test( 'input[type="checkbox"] with bound name updates as expected, with array mutations (#1305)', t => {
+	test( 'input[type="checkbox"] with bound name updates as expected, with array mutations (#1305)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -726,7 +727,7 @@ export default function() {
 		t.ok( checkboxes[1].checked );
 	});
 
-	QUnit.test( 'input[type="checkbox"] works with array of numeric values (#1305)', t => {
+	test( 'input[type="checkbox"] works with array of numeric values (#1305)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -750,7 +751,7 @@ export default function() {
 		t.ok( checkboxes[2].checked );
 	});
 
-	QUnit.test( 'input[type="checkbox"] works with array mutated on init (#1305)', t => {
+	test( 'input[type="checkbox"] works with array mutated on init (#1305)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `
@@ -772,7 +773,7 @@ export default function() {
 		t.ok( checkboxes[2].checked );
 	});
 
-	QUnit.test( 'Downstream expression objects in two-way bindings do not trigger a warning (#1421)', t => {
+	test( 'Downstream expression objects in two-way bindings do not trigger a warning (#1421)', t => {
 		// TODO what exactly is being tested here...?
 		onWarn( () => {} ); // suppress
 
@@ -785,7 +786,7 @@ export default function() {
 		t.equal( ractive.find('input').value, 'bar' );
 	});
 
-	QUnit.test( 'Changes made in oninit are reflected on render (#1390)', t => {
+	test( 'Changes made in oninit are reflected on render (#1390)', t => {
 		let inputs;
 
 		new Ractive({
@@ -809,7 +810,7 @@ export default function() {
 		t.ok( !inputs[2].checked );
 	});
 
-	QUnit.test( 'Changes made after render to unresolved', t => {
+	test( 'Changes made after render to unresolved', t => {
 
 		const ractive = new Ractive({
 			el: fixture,
@@ -830,7 +831,7 @@ export default function() {
 		t.ok( !inputs[2].checked );
 	});
 
-	QUnit.test( 'If there happen to be unresolved references next to binding resolved references, the unresolveds should not be evicted by mistake (#1608)', t => {
+	test( 'If there happen to be unresolved references next to binding resolved references, the unresolveds should not be evicted by mistake (#1608)', t => {
 		onWarn( () => {} ); // suppress
 
 		const ractive = new Ractive({
@@ -854,7 +855,7 @@ export default function() {
 		t.htmlEqual( div.innerHTML, 'true: true' );
 	});
 
-	QUnit.test( 'Change events propagate after the model has been updated (#1371)', t => {
+	test( 'Change events propagate after the model has been updated (#1371)', t => {
 		t.expect( 1 );
 
 		const ractive = new Ractive({
@@ -874,7 +875,7 @@ export default function() {
 	});
 
 	if ( hasUsableConsole ) {
-		QUnit.test( 'Using expressions in two-way bindings triggers a warning (#1399)', t => {
+		test( 'Using expressions in two-way bindings triggers a warning (#1399)', t => {
 			onWarn( message => {
 				t.ok( ~message.indexOf( 'Cannot use two-way binding on <input> element: foo() is read-only' ) );
 			});
@@ -886,7 +887,7 @@ export default function() {
 			});
 		});
 
-		QUnit.test( 'Using expressions with keypath in two-way bindings triggers a warning (#1399/#1421)', t => {
+		test( 'Using expressions with keypath in two-way bindings triggers a warning (#1399/#1421)', t => {
 			onWarn( () => {
 				t.ok( true );
 			});
@@ -898,7 +899,7 @@ export default function() {
 			});
 		});
 
-		QUnit.test( '@key cannot be used for two-way binding', t => {
+		test( '@key cannot be used for two-way binding', t => {
 			t.expect( 3 );
 
 			onWarn( msg => {
@@ -915,7 +916,7 @@ export default function() {
 		});
 	}
 
-	QUnit.test( 'Radio input can have name/checked attributes without two-way binding (#783)', t => {
+	test( 'Radio input can have name/checked attributes without two-way binding (#783)', t => {
 		t.expect( 0 );
 
 		new Ractive({
@@ -924,7 +925,7 @@ export default function() {
 		});
 	});
 
-	QUnit.test( 'Two-way binding can be set up against expressions that resolve to regular keypaths', t => {
+	test( 'Two-way binding can be set up against expressions that resolve to regular keypaths', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '{{#items:i}}<label><input value="{{ proxies[i].name }}"> name: {{ proxies[i].name }}</label>{{/items}}',
@@ -942,7 +943,7 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, '<label><input> name: foo</label>' );
 	});
 
-	QUnit.test( 'Contenteditable works with lazy: true (#1933)', t => {
+	test( 'Contenteditable works with lazy: true (#1933)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<div contenteditable="true" value="{{value}}"></div>',
@@ -960,7 +961,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'select with no matching value option selects none (#2494)', t => {
+	test( 'select with no matching value option selects none (#2494)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '<select value="{{foo}}">{{#if opt1}}<option>1</option>{{/if}}<option>2</option></select>',
@@ -979,7 +980,7 @@ export default function() {
 		t.equal( r.find( 'select' ).selectedIndex, 0 );
 	});
 
-	QUnit.test( 'type attribute does not have to be first (#1968)', t => {
+	test( 'type attribute does not have to be first (#1968)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input id="red" name="{{selectedColors}}" value="red" type="checkbox">'
@@ -990,7 +991,7 @@ export default function() {
 		t.ok( ractive.find( '#red' ).checked );
 	});
 
-	QUnit.test( 'input type=number binds (#2082)', t => {
+	test( 'input type=number binds (#2082)', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: `{{number}} <input type="number" value="{{number}}">`,
@@ -1003,7 +1004,7 @@ export default function() {
 		t.equal( ractive.get( 'number' ), 20 );
 	});
 
-	QUnit.test( 'twoway may be overridden on a per-element basis', t => {
+	test( 'twoway may be overridden on a per-element basis', t => {
 		let ractive = new Ractive({
 			el: fixture,
 			template: '<input value="{{foo}}" twoway="true" />',
@@ -1029,7 +1030,7 @@ export default function() {
 		t.equal( ractive.get( 'foo' ), 'test' );
 	});
 
-	QUnit.test( 'Presence of lazy or twoway without value is considered true', t => {
+	test( 'Presence of lazy or twoway without value is considered true', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input value="{{foo}}" twoway lazy/>',
@@ -1049,7 +1050,7 @@ export default function() {
 		t.equal( ractive.get( 'foo' ), 'changed' );
 	});
 
-	QUnit.test( '`lazy=0` is not mistaken for `lazy`', t => {
+	test( '`lazy=0` is not mistaken for `lazy`', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input value="{{foo}}" lazy="0"/>'
@@ -1064,7 +1065,7 @@ export default function() {
 		t.equal( ractive.get( 'foo' ), 'changed' );
 	});
 
-	QUnit.test( '`twoway=0` is not mistaken for `twoway`', t => {
+	test( '`twoway=0` is not mistaken for `twoway`', t => {
 		const ractive = new Ractive({
 			el: fixture,
 			template: '<input value="{{foo}}" twoway="0"/>'
@@ -1081,7 +1082,7 @@ export default function() {
 		t.equal( ractive.get( 'foo' ), undefined );
 	});
 
-	QUnit.test( 'checkbox name binding with the same value on multiple boxes still works (#2163)', t => {
+	test( 'checkbox name binding with the same value on multiple boxes still works (#2163)', t => {
 		const common = {};
 		const r = new Ractive({
 			el: fixture,
@@ -1102,7 +1103,7 @@ export default function() {
 		t.ok( inputs[0].checked && inputs[1].checked && inputs[2].checked );
 	});
 
-	QUnit.test( 'checkbox name bindings work across component boundaries (#2163)', t => {
+	test( 'checkbox name bindings work across component boundaries (#2163)', t => {
 		const things = [
 			{id: 1, color: '#cc8'},
 			{id: 2, color: '#c88'},
@@ -1145,7 +1146,7 @@ export default function() {
 		t.deepEqual( checked(), [ true, false, true, false ]);
 	});
 
-	QUnit.test( 'textarea with a single interpolator as content should set up a twoway binding (#2197)', t => {
+	test( 'textarea with a single interpolator as content should set up a twoway binding (#2197)', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '<textarea>{{foo}}</textarea>',
@@ -1160,7 +1161,7 @@ export default function() {
 		t.equal( r.get( 'foo' ), 'bop' );
 	});
 
-	QUnit.test( 'conditional twoway should apply/unapply correctly', t => {
+	test( 'conditional twoway should apply/unapply correctly', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<input value="{{foo}}" {{#if twoway}}twoway{{/if}} /><span>{{foo}}</span>`,
@@ -1183,7 +1184,7 @@ export default function() {
 		t.equal( span.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'bound twoway should apply/unapply correctly', t => {
+	test( 'bound twoway should apply/unapply correctly', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<input value="{{foo}}" twoway="{{#if twoway}}true{{else}}false{{/if}}" /><span>{{foo}}</span>`,
@@ -1206,7 +1207,7 @@ export default function() {
 		t.equal( span.innerHTML, 'bar' );
 	});
 
-	QUnit.test( 'conditional lazy should apply/unapply correctly', t => {
+	test( 'conditional lazy should apply/unapply correctly', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<input value="{{foo}}" {{#if lazy}}lazy{{/if}} /><span>{{foo}}</span>`,
@@ -1236,7 +1237,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'bound lazy should apply/unapply correctly', t => {
+	test( 'bound lazy should apply/unapply correctly', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `<input value="{{foo}}" lazy="{{#if lazy}}true{{else}}false{{/if}}" /><span>{{foo}}</span>`,
@@ -1266,7 +1267,7 @@ export default function() {
 		}
 	});
 
-	QUnit.test( 'textarea with a single static interpolator as content should not set up a twoway binding', t => {
+	test( 'textarea with a single static interpolator as content should not set up a twoway binding', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '<textarea>[[foo]]</textarea>',
@@ -1281,7 +1282,7 @@ export default function() {
 		t.equal( r.get( 'foo' ), 'baz' );
 	});
 
-	QUnit.test( 'ComputationChild will allow bindings if requested', t => {
+	test( 'ComputationChild will allow bindings if requested', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each some.expr()}}<div>{{.val}}</div><input value="{{.val}}" />{{/each}}`,
@@ -1301,7 +1302,7 @@ export default function() {
 		t.equal( label.innerHTML, 'test1' );
 	});
 
-	QUnit.test( 'ComputationChild bindings also notify other interested parties when changed', t => {
+	test( 'ComputationChild bindings also notify other interested parties when changed', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#each some.expr()}}<input value="{{.val}}" />{{/each}}<div>{{'yep' + JSON.stringify(some.expr())}}</div>`,
@@ -1321,7 +1322,7 @@ export default function() {
 		t.equal( label.innerHTML, 'yep[{"val":"test1"}]' );
 	});
 
-	QUnit.test( 'ComputationChild name bindings work for checkboxes', t => {
+	test( 'ComputationChild name bindings work for checkboxes', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foos()}}<input type="checkbox" name="{{.array}}" value="{{+1}}" /><input type="checkbox" name="{{.array}}" value="{{+2}}" />{{/with}}`,
@@ -1350,7 +1351,7 @@ export default function() {
 		t.equal( r.get( 'foo.array.1' ), 2 );
 	});
 
-	QUnit.test( 'ComputationChild name bindings work for radio buttons', t => {
+	test( 'ComputationChild name bindings work for radio buttons', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: `{{#with foos()}}<input type="radio" name="{{.value}}" value="{{+1}}" /><input type="radio" name="{{.value}}" value="{{+2}}" />{{/with}}`,
@@ -1378,7 +1379,7 @@ export default function() {
 		t.equal( r.get( 'foo.value' ), 2 );
 	});
 
-	QUnit.test( 'textareas with non-model context should still bind correctly (#2099)', t => {
+	test( 'textareas with non-model context should still bind correctly (#2099)', t => {
 		onWarn( () => {} ); // suppress
 
 		const r = new Ractive({
@@ -1391,7 +1392,7 @@ export default function() {
 		t.equal( r.find( 'textarea' ).value, 'baz' );
 	});
 
-	QUnit.test( 'binding to an reference proxy does not cause out-of-syncitude with the actual model', t => {
+	test( 'binding to an reference proxy does not cause out-of-syncitude with the actual model', t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '<span>{{foo.bar.baz}}</span>{{#with foo[what]}}<input value="{{.baz}}" />{{/with}}',
@@ -1420,7 +1421,7 @@ export default function() {
 		t.equal( input.value, 'also yep' );
 	});
 
-	QUnit.test( `binding to a valid reference expression doesn't warn about unresolved paths`, t => {
+	test( `binding to a valid reference expression doesn't warn about unresolved paths`, t => {
 		t.expect( 1 );
 		onWarn( () => t.ok( false, 'should not warn' ) );
 		const r = new Ractive({
@@ -1436,7 +1437,7 @@ export default function() {
 		t.equal( r.get( 'randomFoo132123.bar' ), 'yep' );
 	});
 
-	QUnit.test( `binding a select with mismatched option values shouldn't break section rendering (#2424)`, t => {
+	test( `binding a select with mismatched option values shouldn't break section rendering (#2424)`, t => {
 		const cmp = Ractive.extend({ template: `<div>{{yield}}</div>` });
 		const r = new Ractive({
 			el: fixture,
@@ -1460,7 +1461,7 @@ export default function() {
 		t.equal( fixture.querySelectorAll( 'div' ).length, 3 );
 	});
 
-	QUnit.test( 'bindings stay up to date when updated from the model (#2643)', t => {
+	test( 'bindings stay up to date when updated from the model (#2643)', t => {
 		t.expect( 5 );
 
 		const r = new Ractive({
@@ -1483,7 +1484,7 @@ export default function() {
 		t.ok( input.checked, 'input checked by click' );
 	});
 
-	QUnit.test( `numeric bindings update correctly if set to undefined from initial value (#2761)`, t => {
+	test( `numeric bindings update correctly if set to undefined from initial value (#2761)`, t => {
 		const r = new Ractive({
 			el: fixture,
 			template: '<input type="number" value="{{x}}" />',
@@ -1500,7 +1501,7 @@ export default function() {
 		t.ok( hit );
 	});
 
-	QUnit.test( `options that exist across a component boundary register with their parent select correctly`, t => {
+	test( `options that exist across a component boundary register with their parent select correctly`, t => {
 		const cmp = Ractive.extend({ template: '<select value="{{foo}}">{{yield}}</select>' });
 		const r = new Ractive({
 			el: fixture,
@@ -1511,7 +1512,7 @@ export default function() {
 		t.equal( r.get( 'foo' ), 'a' );
 	});
 
-	QUnit.test( `multi select binding`, t => {
+	test( `multi select binding`, t => {
 		fixture.innerHTML = '<select multiple><option value="1">one</option><option value="2">two</option><option value="3">three</option></select>';
 		const r = new Ractive({
 			target: fixture,

--- a/tests/browser/utils/normalise.js
+++ b/tests/browser/utils/normalise.js
@@ -1,14 +1,15 @@
 import { normalise } from '../../../src/shared/keypaths';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'utils/normalise.js' );
 
-	QUnit.test( 'Regular keypath', ( t ) => {
+	test( 'Regular keypath', ( t ) => {
 		t.equal( normalise( 'foo.bar' ), 'foo.bar' );
 	});
 
-	QUnit.test( 'Keypath with array notation', ( t ) => {
+	test( 'Keypath with array notation', ( t ) => {
 		t.equal( normalise( 'foo[1]' ), 'foo.1' );
 	});
 }

--- a/tests/browser/utils/parseJSON.js
+++ b/tests/browser/utils/parseJSON.js
@@ -1,65 +1,66 @@
 import parseJSON from '../../../src/utils/parseJSON';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'utils/parseJSON.ks' );
 
-	QUnit.test( 'Unquoted string', t => {
+	test( 'Unquoted string', t => {
 		const parsed = parseJSON( 'foo' );
 		t.ok( !parsed );
 	});
 
-	QUnit.test( 'Single-quoted string', t => {
+	test( 'Single-quoted string', t => {
 		const parsed = parseJSON( `'foo'` );
 		t.equal( parsed.value, 'foo' );
 	});
 
-	QUnit.test( 'Double-quoted string', t => {
+	test( 'Double-quoted string', t => {
 		const parsed = parseJSON( '"foo"' );
 		t.equal( parsed.value, 'foo' );
 	});
 
-	QUnit.test( 'Number', t => {
+	test( 'Number', t => {
 		const parsed = parseJSON( '42' );
 		t.equal( parsed.value, 42 );
 	});
 
-	QUnit.test( 'Array', t => {
+	test( 'Array', t => {
 		const parsed = parseJSON( '["a","b"]' );
 		t.deepEqual( parsed.value, ['a','b'] );
 	});
 
-	QUnit.test( 'Interpolated value', t => {
+	test( 'Interpolated value', t => {
 		const parsed = parseJSON( '${answer}', { answer: 42 } );
 		t.equal( parsed.value, 42);
 	});
 
-	QUnit.test( 'Array of interpolated values', t => {
+	test( 'Array of interpolated values', t => {
 		const parsed = parseJSON( '[${a},${b},${c}]', { a: 1, b: 2, c: 3 } );
 		t.deepEqual( parsed.value, [1,2,3]);
 	});
 
-	QUnit.test( 'Array of interpolated values with funky whitespace', t => {
+	test( 'Array of interpolated values with funky whitespace', t => {
 		const parsed = parseJSON( '[  ${a} , ${b} , ${c}  ]', { a: 1, b: 2, c: 3 } );
 		t.deepEqual( parsed.value, [1,2,3]);
 	});
 
-	QUnit.test( 'Interpolated falsy values (#621)', t => {
+	test( 'Interpolated falsy values (#621)', t => {
 		const parsed = parseJSON( '"${a}"', { a: 0 });
 		t.equal( parsed.value, '0' );
 	});
 
-	QUnit.test( 'Empty array (#810)', t => {
+	test( 'Empty array (#810)', t => {
 		const parsed = parseJSON( '[]' );
 		t.deepEqual( parsed.value, [] );
 	});
 
-	QUnit.test( 'Empty object (#810)', t => {
+	test( 'Empty object (#810)', t => {
 		const parsed = parseJSON( '{}' );
 		t.deepEqual( parsed.value, {} );
 	});
 
-	QUnit.test( 'Object with leading whitespace (#1157)', t => {
+	test( 'Object with leading whitespace (#1157)', t => {
 		const parsed = parseJSON( ' { foo: "bar" }' );
 		t.deepEqual( parsed.value, { foo: 'bar' });
 	});

--- a/tests/browser/utils/wrapPrototypeMethod.js
+++ b/tests/browser/utils/wrapPrototypeMethod.js
@@ -1,12 +1,13 @@
 import wrap from '../../../src/Ractive/config/wrapPrototypeMethod';
 import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
 
 export default function() {
 	initModule( 'utils/wrapPrototypeMethod.js' );
 
 	function callSuper () { this._super(); }
 
-	QUnit.test( 'can call _super on parent', t => {
+	test( 'can call _super on parent', t => {
 		t.expect(1);
 
 		const parent = { talk: () => t.ok( true ) };
@@ -17,7 +18,7 @@ export default function() {
 		instance.talk();
 	});
 
-	QUnit.test( '"this" in methods refers to correct instance', t => {
+	test( '"this" in methods refers to correct instance', t => {
 		t.expect(2);
 
 		const parent = {
@@ -36,7 +37,7 @@ export default function() {
 		instance.talk();
 	});
 
-	QUnit.test( 'can find _super in prototype chain', t => {
+	test( 'can find _super in prototype chain', t => {
 		t.expect(1);
 
 		const grandparent = { talk: () => t.ok( true ) };
@@ -47,7 +48,7 @@ export default function() {
 		instance.talk();
 	});
 
-	QUnit.test( 'safe to use _super with no parent', t => {
+	test( 'safe to use _super with no parent', t => {
 		t.expect( 1 );
 
 		const parent = {};
@@ -61,7 +62,7 @@ export default function() {
 		instance.talk();
 	});
 
-	QUnit.test( 'parent _super can be added later', t => {
+	test( 'parent _super can be added later', t => {
 		t.expect( 1 );
 
 		const parent = {};
@@ -73,7 +74,7 @@ export default function() {
 		instance.talk();
 	});
 
-	QUnit.test( 'only wraps when this._super used in method', t => {
+	test( 'only wraps when this._super used in method', t => {
 		t.expect( 1 );
 
 		const parent = { talk: () => t.ok( true ) };
@@ -82,7 +83,7 @@ export default function() {
 		t.equal( wrap( parent, 'talk', method ), method );
 	});
 
-	QUnit.test( 'if this._super is non-function, returns as value', t => {
+	test( 'if this._super is non-function, returns as value', t => {
 		t.expect( 1 );
 
 		const data = { foo: 'bar' };
@@ -95,7 +96,7 @@ export default function() {
 		t.equal( instance.talk() , data );
 	});
 
-	QUnit.test( 'parent instance can be changed', t => {
+	test( 'parent instance can be changed', t => {
 		t.expect( 2 );
 
 		const parent = { talk: () => false };
@@ -109,7 +110,7 @@ export default function() {
 		instance.talk();
 	});
 
-	QUnit.test( 'can access original via _method', t => {
+	test( 'can access original via _method', t => {
 		const method = wrap( parent, 'talk', callSuper );
 		t.equal( method._method, callSuper );
 	});

--- a/tests/node/basic.js
+++ b/tests/node/basic.js
@@ -1,8 +1,10 @@
-export default function(){
+const { module, test } = QUnit;
 
-	QUnit.module( 'Ractive' );
+export default function () {
 
-	QUnit.test( 'should be a function', t => {
+	module( 'Ractive' );
+
+	test( 'should be a function', t => {
 		t.equal( typeof Ractive, 'function' );
 	});
 

--- a/tests/node/components.js
+++ b/tests/node/components.js
@@ -1,7 +1,9 @@
-export default function(){
-	QUnit.module( 'Components' );
+const { module, test } = QUnit;
 
-	QUnit.test( 'should render in a non-DOM environment', t => {
+export default function(){
+	module( 'Components' );
+
+	test( 'should render in a non-DOM environment', t => {
 		const Widget = Ractive.extend({
 			template: '<p>foo-{{bar}}</p>',
 			isolated: false
@@ -20,7 +22,7 @@ export default function(){
 		t.equal( ractive.toHTML(), '<p>foo-baz</p>' );
 	});
 
-	QUnit.test( 'should not fail if component has CSS', t => {
+	test( 'should not fail if component has CSS', t => {
 		const Widget = Ractive.extend({
 			template: '<p>red</p>',
 			css: 'p { color: red; }'

--- a/tests/node/getCSS.js
+++ b/tests/node/getCSS.js
@@ -1,3 +1,5 @@
+const { module, test } = QUnit;
+
 function createComponentDefinition( Ractive ) {
 
 	return Ractive.extend( {
@@ -7,9 +9,9 @@ function createComponentDefinition( Ractive ) {
 
 export default function(){
 
-	QUnit.module( 'ractive.toCSS()' );
+	module( 'ractive.toCSS()' );
 
-	QUnit.test( 'should render CSS with a single component definition', t => {
+	test( 'should render CSS with a single component definition', t => {
 
 		const Component = createComponentDefinition( Ractive );
 
@@ -19,7 +21,7 @@ export default function(){
 		t.ok( !!~css.indexOf( '.green[data-ractive-css~="{' + cssId + '}"], [data-ractive-css~="{' + cssId + '}"] .green', '.green selector for ' + cssId + ' should exist' ) );
 	} );
 
-	QUnit.test( 'should render CSS with multiple components definition', t => {
+	test( 'should render CSS with multiple components definition', t => {
 
 		const ComponentA = createComponentDefinition( Ractive );
 

--- a/tests/node/parse.js
+++ b/tests/node/parse.js
@@ -1,53 +1,54 @@
+const { module, test } = QUnit;
 import parseTests from '../helpers/samples/parse';
 
 export default function(){
 
-	QUnit.module( 'Ractive.parse()' );
+	module( 'Ractive.parse()' );
 
-	parseTests.forEach( test => {
+	parseTests.forEach( parseTest => {
 
 		// disable for tests unless explicitly specified
 		// we can just test the signatures, so set csp false
-		test.options = test.options || { csp: false };
-		if ( !test.options.hasOwnProperty( 'csp' ) ) {
-			test.options.csp = false;
+		parseTest.options = parseTest.options || { csp: false };
+		if ( !parseTest.options.hasOwnProperty( 'csp' ) ) {
+			parseTest.options.csp = false;
 		}
 
-		QUnit.test( test.name, t => {
-			if (test.error) {
+		test( parseTest.name, t => {
+			if ( parseTest.error ) {
 				t.throws( () => {
-					Ractive.parse( test.template, test.options );
+					Ractive.parse( parseTest.template, parseTest.options );
 				}, error => {
-					if (error.name !== 'ParseError') {
+					if ( error.name !== 'ParseError' ) {
 						throw error;
 					}
-					if ( test.error.test ) {
-						t.ok( test.error.test( error.message ) );
+					if ( parseTest.error.test ) {
+						t.ok( parseTest.error.test( error.message ) );
 					} else {
-						t.equal( error.message, test.error );
+						t.equal( error.message, parseTest.error );
 					}
 					return true;
 				}, 'Expected ParseError');
 			} else {
-				const parsed = Ractive.parse( test.template, test.options );
+				const parsed = Ractive.parse( parseTest.template, parseTest.options );
 
-				if (parsed.e && test.parsed.e) {
-					const expectedKeys = Object.keys(test.parsed.e);
-					const parsedKeys = Object.keys(parsed.e);
+				if ( parsed.e && parseTest.parsed.e ) {
+					const expectedKeys = Object.keys( parseTest.parsed.e) ;
+					const parsedKeys = Object.keys( parsed.e );
 
 					t.deepEqual(parsedKeys, expectedKeys);
 
 					expectedKeys.forEach(key => {
 						// normalize function whitepace for browser vs phantomjs
-						const actual = parsed.e[key].toString().replace(') \{', ')\{');
-						t.equal(actual, test.parsed.e[key]);
+						const actual = parsed.e[key].toString().replace( ') \{', ')\{' );
+						t.equal( actual, parseTest.parsed.e[key] );
 					});
 
 					delete parsed.e;
-					delete test.parsed.e;
+					delete parseTest.parsed.e;
 				}
 
-				t.deepEqual( parsed, test.parsed );
+				t.deepEqual( parsed, parseTest.parsed );
 			}
 		});
 	});

--- a/tests/node/toCSS.js
+++ b/tests/node/toCSS.js
@@ -1,8 +1,10 @@
+const { module, test } = QUnit;
+
 export default function(){
 
-	QUnit.module( 'ractive.toCSS()' );
+	module( 'ractive.toCSS()' );
 
-	QUnit.test( 'should render CSS with a single component instance', t => {
+	test( 'should render CSS with a single component instance', t => {
 
 		const Component = Ractive.extend( {
 			template: '<div></div>',
@@ -20,7 +22,7 @@ export default function(){
 		app.teardown();
 	} );
 
-	QUnit.test( 'should render CSS with nested component instances', t => {
+	test( 'should render CSS with nested component instances', t => {
 
 		const GrandChildComponent = Ractive.extend( {
 			template: '<div></div>',
@@ -60,7 +62,7 @@ export default function(){
 		app.teardown();
 	} );
 
-	QUnit.test( 'should NEVER render CSS with a Ractive instance', t => {
+	test( 'should NEVER render CSS with a Ractive instance', t => {
 
 		const app = new Ractive( {
 			template: '<div></div>',

--- a/tests/node/toHTML.js
+++ b/tests/node/toHTML.js
@@ -1,3 +1,4 @@
+const { module, test } = QUnit;
 import renderTests from '../helpers/samples/render';
 import cheerio from 'cheerio';
 
@@ -30,10 +31,10 @@ function deepClone(source) {
 }
 
 export default function () {
-	QUnit.module('ractive.toHTML()');
+	module('ractive.toHTML()');
 
 	renderTests.forEach( theTest => {
-		QUnit.test(theTest.name, t => {
+		test(theTest.name, t => {
 
 			const ractive = new Ractive({
 				template: theTest.template,
@@ -54,7 +55,7 @@ export default function () {
 		});
 	});
 
-	QUnit.test('doctype declarations handle updates (#2679)', t => {
+	test('doctype declarations handle updates (#2679)', t => {
 		// the select triggers an update during bind
 		const template = Ractive.parse('<!DOCTYPE html><html><select value="{{foo}}"><option value="bar">bar</option></select></html>');
 		const r = new Ractive({


### PR DESCRIPTION
## Description of the pull request:
This switches to using `import { test } from 'qunit'` in all of the tests so that backporting bugfixes is easier between 0.10, 0.9, and 0.8.

It also adds a runner for the node tests to the build scripts.

## Is breaking:
Nope.
