### PR TITLE
Add support for ractive bin plugins via config file

### DIFF
--- a/bin/ractive
+++ b/bin/ractive
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 /* eslint-env node */
+/* eslint-disable no-console */
 
 const path = require( 'path' );
 const fs = require( 'fs' );
@@ -11,168 +12,209 @@ const component = require( '../lib/component' );
 const args = process.argv.slice();
 
 if ( ~args[0].indexOf( 'node' ) ) args.shift();
-const program = args.shift();
+args.shift(); // program
 const cmd = args.shift();
 
-let input = process.stdin;
-let output = process.stdout;
-// base path for resolving paths
-let base = process.cwd();
+const opts = {
+	input: process.stdin,
+	output: process.stdout,
+	base: process.cwd()
+};
 
 function readFile ( name ) {
-	return Promise.resolve( fs.readFileSync( path.resolve( base, name ), { encoding: 'utf8' } ) );
+	return Promise.resolve( fs.readFileSync( path.resolve( opts.base, name ), { encoding: 'utf8' } ) );
 }
 
 function dirIndexOrFile ( name ) {
 	const stats = util.stat( name );
 	if ( stats && stats.isDirectory() ) {
-		base = name;
+		opts.base = name;
 		if ( util.stat( path.resolve( name, './index.ractive' ) ) ) {
-			input = fs.createReadStream( path.resolve( name, './index.ractive' ) );
+			opts.input = fs.createReadStream( path.resolve( name, './index.ractive' ) );
 		} else {
-			input = fs.createReadStream( path.resolve( name, './index.html' ) );
+			opts.input = fs.createReadStream( path.resolve( name, './index.html' ) );
 		}
 	} else {
-		base = path.dirname( name );
-		input = fs.createReadStream( name );
+		opts.base = path.dirname( name );
+		opts.input = fs.createReadStream( name );
 	}
 }
 
-let arg;
-const opts = {};
-
-switch ( cmd ) {
-	case 'parse':
-		while ( arg = args.shift() ) {
-			switch ( arg ) {
-				case '-i':
-				case '--input':
-					input = fs.createReadStream( args.shift() );
-					break;
-
-				case '-o':
-				case '--output':
-					output = fs.createWriteStream( args.shift() );
-					break;
-
-				case '-t':
-				case '--text-only':
+const commands = {
+	parse: {
+		run ( opts ) {
+			util.readToString( opts.input ).then( string => {
+				return parse.parse( string, opts ).
+					then( string => util.writeToStream( opts.output, string ) );
+			}, err => {
+				console.error( err.message );
+				process.exit( 1 );
+			});
+		},
+		help: parse.help,
+		args ( list, opts ) {
+			for ( let i = 0; i < args.length; i++ ) {
+				if ( args[i] === '-t' || args[i] === '--text-only' ) {
 					opts.textOnlyMode = true;
-					break;
-
-				case '-x':
-				case '--nocsp':
-					opts.csp = false;
-					break;
-
-				case '-d':
-				case '--delimiters':
-					opts.delimiters = [ args.shift(), args.shift() ];
-					break;
-
-				case '-s':
-				case '--static':
-					opts.staticDelimiters = [ args.shift(), args.shift() ];
-					break;
-
-				case '-r':
-				case '--triple':
-					opts.tripleDelimiters = [ args.shift(), args.shift() ];
-					break;
-
-				case '-p':
-				case '--static-triple':
-					opts.staticTripleDelimiters = [ args.shift(), args.shift() ];
-					break;
-
-				case '-u':
-				case '--escape-unicode':
-					opts.escapeUnicode = true;
-					break;
-
-				default:
-					if ( !args.length && util.stat( arg ) ) { // last may be the input file
-						input = fs.createReadStream( arg );
-					} else {
-						console.error( '??? ', arg );
-					}
-					break;
+					args.splice( i--, 1 );
+				}
 			}
 		}
-		util.readToString( input ).then( string => {
-			return parse.parse( string, opts ).
-				then( string => util.writeToStream( output, string ) );
-		}, err => {
-			console.error( err.message );
-			process.exit( 1 );
-		});
-		break;
+	},
+	component: {
+		run ( opts ) {
+			util.readToString( opts.input ).then( string => {
+				return component.build( string, opts, readFile ).
+					then( string => util.writeToStream( opts.output, string ) );
+			}).then( null, err => {
+				console.error( err && typeof err === 'object' ? err.stack : err );
+				process.exit( 1 );
+			});
+		},
+		help: component.help
+	}
+};
 
-	case 'component':
-		while ( arg = args.shift() ) {
-			switch ( arg ) {
-				case '-i':
-				case '--input':
-					const file = args.shift();
-					dirIndexOrFile( file );
-					break;
+const config = {
+	addCommand( name, obj ) {
+		if ( !obj.help ) console.warn( `Command ${name} does not provide any help.` );
+		commands[name] = obj;
+	},
+	addStyleProcessor( fn ) {
+		const list = opts.styleProcessors || ( opts.styleProcessors = [] );
+		list.push( fn );
+	},
+	addTemplateProcessor( fn ) {
+		const list = opts.templateProcessors || ( opts.templateProcessors = [] );
+		list.push( fn );
+	},
+	addPartialProcessor( fn ) {
+		const list = opts.partialProcessors || ( opts.partialProcessors = [] );
+		list.push( fn );
+	},
+	addScriptProcessor( fn ) {
+		const list = opts.scriptProcessors || ( opts.scriptProcessors = [] );
+		list.push( fn );
+	},
+	Ractive: util.Ractive,
+	util,
+	parse,
+	component
+};
 
-				case '-o':
-				case '--output':
-					output = fs.createWriteStream( args.shift() );
-					break;
-
-				case '-x':
-				case '--nocsp':
-					opts.csp = false;
-					break;
-
-				case '-d':
-				case '--delimiters':
-					opts.delimiters = [ args.shift(), args.shift() ];
-					break;
-
-				case '-s':
-				case '--static':
-					opts.staticDelimiters = [ args.shift(), args.shift() ];
-					break;
-
-				case '-r':
-				case '--triple':
-					opts.tripleDelimiters = [ args.shift(), args.shift() ];
-					break;
-
-				case '-p':
-				case '--static-triple':
-					opts.staticTripleDelimiters = [ args.shift(), args.shift() ];
-					break;
-
-				case '-u':
-				case '--escape-unicode':
-					opts.escapeUnicode = true;
-					break;
-
-				default:
-					if ( !args.length && util.stat( arg ) ) { // last may be the input file
-						dirIndexOrFile( arg );
-					} else {
-						console.error( '??? ', arg );
-					}
-					break;
+function loadConfig () {
+	let dir = process.cwd();
+	let prev;
+	while ( dir !== prev ) {
+		const file = path.join( dir, '.ractive.config.js' );
+		if ( util.stat( file ) ) {
+			try {
+				const fn = require( file );
+				fn.call( config, config, util.Ractive );
+			} catch ( e ) {
+				console.error( `Error while trying to read Ractive config file at ${dir}:` );
+				console.error( e );
+				process.exit( 2 );
 			}
-		}
-		util.readToString( input ).then( string => {
-			return component.build( string, opts, readFile ).
-				then( string => util.writeToStream( output, string ) );
-		}).then( null, err => {
-			console.error( err.stack );
-			process.exit( 1 );
-		});
-		break;
 
-	default:
-		console.error( `Usage: ractive [command] [options] [file]\n  Commands:` );
-		console.error( parse.help );
-		console.error( component.help );
-		process.exit( 1 );
+			break;
+		} else {
+			prev = dir;
+			dir = path.join( dir, '..' );
+		}
+	}
 }
+// try to find a config file
+loadConfig();
+
+if ( cmd === 'help' ) {
+	console.error( `Usage: ractive [command] [options] [file]
+
+  Available commands: ${Object.keys(commands).sort().join(', ')}
+  ${Object.keys(commands).filter(c => commands[c].help).map(c => commands[c].help).join('')}`);
+
+	process.exit( 1 );
+}
+
+if ( args[0] === 'help' || !cmd || !commands[cmd] ) {
+	console.error( `Usage: ractive [command] [options] [file]
+
+  Available commands: ${Object.keys(commands).sort().join(', ')}`);
+
+	if ( !cmd ) console.error( `\n  Find out more about a particular command with ractive [command] help` );
+
+	if ( cmd && !commands[cmd] ) console.error( `\n  Unknown command: ${cmd}` );
+
+	if ( commands[cmd] && commands[cmd].help ) console.error( commands[cmd].help );
+
+	process.exit( 1 );
+}
+
+// let the command process the args if it wants to
+if ( typeof commands[cmd].preArgs === 'function' ) commands[cmd].preArgs( args, opts );
+
+// process out common args
+for ( let i = 0; i < args.length; i++ ) {
+	const arg = args[i];
+
+	switch ( arg ) {
+		case '-i':
+		case '--input':
+			opts.input = dirIndexOrFile( args[ i + 1 ] );
+			args.splice( i--, 2 );
+			i--;
+			break;
+
+		case '-o':
+		case '--output':
+			opts.output = fs.createWriteStream( args[ i + 1 ] );
+			args.splice( i--, 2 );
+			break;
+
+		case '-x':
+		case '--nocsp':
+			opts.csp = false;
+			args.splice( i--, 1 );
+			break;
+
+		case '-d':
+		case '--delimiters':
+			opts.delimiters = [ args[ i + 1 ], args[ i + 1 ] ];
+			args.splice( i--, 3 );
+			break;
+
+		case '-s':
+		case '--static':
+			opts.staticDelimiters = [ args[ i + 1 ], args[ i + 1 ] ];
+			args.splice( i--, 3 );
+			break;
+
+		case '-r':
+		case '--triple':
+			opts.tripleDelimiters = [ args[ i + 1 ], args[ i + 1 ] ];
+			args.splice( i--, 3 );
+			break;
+
+		case '-p':
+		case '--static-triple':
+			opts.staticTripleDelimiters = [ args[ i + 1 ], args[ i + 1 ] ];
+			args.splice( i--, 3 );
+			break;
+
+		case '-u':
+		case '--escape-unicode':
+			opts.escapeUnicode = true;
+			args.splice( i--, 1 );
+			break;
+	}
+}
+
+if ( typeof commands[cmd].args === 'function' ) commands[cmd].args( args, opts );
+
+if ( args.length === 1 && util.stat( args[0] ) ) { // last arg may be the input file
+	opts.input = fs.createReadStream( args[0] );
+} else if ( args.length ) {
+	console.error( `Unknown arguments: ${args.join(' ')}` );
+}
+
+commands[cmd].run( opts );

--- a/lib/component.js
+++ b/lib/component.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
-const Ractive = require( './util' ).Ractive;
+const { reducePromiseFunctions, Ractive } = require( './util' );
 
 const stringify = require( './parse' ).stringify;
 
@@ -46,7 +46,7 @@ function build ( string, opts, readFile ) {
 	const tpl = Ractive.parse( string, rootOpts );
 	const partials = {};
 	let script = [];
-	let style = [];
+	const style = [];
 
 	const promises = [];
 
@@ -105,7 +105,6 @@ function build ( string, opts, readFile ) {
 
 	return Promise.all( promises ).then( () => {
 		script = dedent( script.join( '' ) );
-		style = JSON.stringify( style.join( '' ).replace( /\s+/g, ' ' ) );
 
 		for ( const k in partials ) {
 			if ( !tpl.p ) tpl.p = {};
@@ -131,11 +130,17 @@ function build ( string, opts, readFile ) {
 			tpl.p[k] = t.t;
 		}
 
-		script = script.replace( /\$TEMPLATE/g, stringify( tpl, opts ) );
-		script = script.replace( /\$CSS/g, style );
-		script = script.replace( /\$PARTIALS/g, stringify( partials, opts ) );
+		return Promise.all([
+			reducePromiseFunctions( opts.styleProcessors, style.join( '' ) ).then( css => css.replace( /\s+/g, ' ' ) ),
+			reducePromiseFunctions( opts.partialProcessors, partials ),
+			reducePromiseFunctions( opts.templateProcessors, tpl )
+		]).then( list => {
+			script = script.replace( /\$TEMPLATE/g, stringify( list[2], opts ) );
+			script = script.replace( /\$CSS/g, JSON.stringify( list[0] ) );
+			script = script.replace( /\$PARTIALS/g, stringify( list[1], opts ) );
 
-		return script;
+			return reducePromiseFunctions( opts.scriptProcessors, script );
+		});
 	});
 }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
-const Ractive = require( './util' ).Ractive;
+const { reducePromiseFunctions, Ractive } = require( './util' ).Ractive;
 
 const help = `
     parse
@@ -21,7 +21,10 @@ const help = `
 
 function parse ( string, opts ) {
 	const tpl = Ractive.parse( string, opts );
-	return Promise.resolve( stringify( tpl, opts ) );
+	if ( opts.templateProcessors ) return reducePromiseFunctions( opts.templateProcessors, tpl ).then( tpl => {
+		stringify( tpl, opts );
+	});
+	else return Promise.resolve( stringify( tpl, opts ) );
 }
 
 // https://gist.github.com/mathiasbynens/1243213
@@ -74,6 +77,7 @@ function toString ( thing, opts ) {
 		let str = '{';
 		let trail = false;
 		for ( const k in thing ) {
+			if ( thing[k] === undefined ) continue;
 			if ( trail ) str += ',';
 			str += k + ':' + stringify( thing[k], opts );
 			trail = true;

--- a/lib/util.js
+++ b/lib/util.js
@@ -16,9 +16,29 @@ function readToString ( stream ) {
 	});
 }
 
+function reducePromiseFunctions ( fnList, init ) {
+	if ( !fnList || !fnList.length ) return Promise.resolve( init );
+	const fns = fnList.slice();
+	let res = init;
+
+	return new Promise(( done, fail ) => {
+		function step () {
+			const fn = fns.shift();
+			if ( !fn ) done( res );
+			else {
+				Promise.resolve( Promise.resolve( fn( res ) ).then( r => {
+					res = r;
+					step();
+				}, fail ) );
+			}
+		}
+		step();
+	});
+}
+
 // find Ractive
 const basePath = path.resolve( path.dirname( fs.realpathSync( __filename ) ) );
-const devFile = path.resolve( basePath, '../build/ractive.js' );
+const devFile = path.resolve( basePath, '../.build/ractive.js' );
 const modFile = path.resolve( basePath, '../ractive.js' );
 const Ractive = require( stat( modFile ) ? modFile : devFile );
 
@@ -29,4 +49,4 @@ function writeToStream ( stream, string ) {
 	});
 }
 
-module.exports = { Ractive, stat, readToString, writeToStream };
+module.exports = { Ractive, stat, readToString, writeToStream, reducePromiseFunctions };

--- a/src/Ractive/config/defaults.js
+++ b/src/Ractive/config/defaults.js
@@ -18,6 +18,7 @@ export default {
 	sanitize:               false,
 	stripComments:          true,
 	contextLines:           0,
+	parserTransforms:       [],
 
 	// data & binding:
 	data:                   {},

--- a/src/parse/_parse.js
+++ b/src/parse/_parse.js
@@ -71,7 +71,12 @@ const StandardParser = Parser.extend({
 		this.textOnlyMode = options.textOnlyMode;
 		this.csp = options.csp;
 
-		this.transforms = options.transforms || options.parserTransforms || shared.defaults.parserTransforms;
+		this.transforms = options.transforms || options.parserTransforms;
+		if ( this.transforms ) {
+			this.transforms = this.transforms.concat( shared.defaults.parserTransforms );
+		} else {
+			this.transforms = shared.defaults.parserTransforms;
+		}
 	},
 
 	postProcess ( result ) {
@@ -87,7 +92,7 @@ const StandardParser = Parser.extend({
 		cleanup( result[0].t, this.stripComments, this.preserveWhitespace, !this.preserveWhitespace, !this.preserveWhitespace );
 
 		const transforms = this.transforms;
-		if ( transforms && transforms.length ) {
+		if ( transforms.length ) {
 			const tlen = transforms.length;
 			const walk = function ( fragment ) {
 				let len = fragment.length;
@@ -108,10 +113,11 @@ const StandardParser = Parser.extend({
 								if ( Array.isArray( res.replace ) ) {
 									fragment.splice( i--, 1, ...res.replace );
 									len += res.replace.length - 1;
-									break;
 								} else {
-									fragment[i] = node = res.replace;
+									fragment[i--] = node = res.replace;
 								}
+
+								break;
 							}
 						}
 					}

--- a/src/parse/_parse.js
+++ b/src/parse/_parse.js
@@ -120,12 +120,24 @@ const StandardParser = Parser.extend({
 								break;
 							}
 						}
+
+						// watch for partials
+						if ( node.p ) {
+							for ( const k in node.p ) walk( node.p[k] );
+						}
 					}
 
 					if ( node.f ) walk( node.f );
 				}
 			};
+
+			// process the root fragment
 			walk( result[0].t );
+
+			// watch for root partials
+			if ( result[0].p ) {
+				for ( const k in result[0].p ) walk( result[0].p[k] );
+			}
 		}
 
 		if ( this.csp !== false ) {

--- a/tests/browser/parser.js
+++ b/tests/browser/parser.js
@@ -73,4 +73,30 @@ export default function () {
 		t.deepEqual( parsed.t, [{ t: 7, e: 'div', m: [{ t: 13, f: [{ t: 2, x: { s: `""+_0`, r: ['replaced'] } }], n: 'id' }], f: [ 'yep' ] }] );
 		t.ok( typeof parsed.e[`""+_0`] === 'function' );
 	});
+
+	test( `parser transforms may be global`, t => {
+		Ractive.defaults.parserTransforms.push(
+			function ( n ) { return n.e === 'bar' ? { replace: this.parse( `<div id="replaced">yep</div>` ).t[0] } : undefined; }
+		);
+
+		const parsed = Ractive.parse( `<bar />` );
+		t.deepEqual( parsed, { v: 4, t: [{ t: 7, e: 'div', m: [{ t: 13, f: 'replaced', n: 'id' }], f: [ 'yep' ] }] } );
+
+		Ractive.defaults.parserTransforms.pop();
+	});
+
+	test( `parser transforms include local and global options`, t => {
+		Ractive.defaults.parserTransforms.push(
+			function ( n ) { console.log('global', n);return n.e === 'bar' ? { replace: this.parse( `<baz id="replaced">yep</baz>` ).t[0] } : undefined; }
+		);
+
+		const parsed = Ractive.parse( `<bar />`, {
+			transforms: [
+				function ( n ) { console.log('local', n); if ( n.e === 'baz' ) n.e = 'div'; }
+			]
+		});
+		t.deepEqual( parsed, { v: 4, t: [{ t: 7, e: 'div', m: [{ t: 13, f: 'replaced', n: 'id' }], f: [ 'yep' ] }] } );
+
+		Ractive.defaults.parserTransforms.pop();
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
This adds support for additional commands and template, style, partial, and script processors to the ractive binary. When the binary kicks off, it will process standard options, then look from cwd to root for a `.ractive.config.js` file that exports a function taking a config object as a param, and run the first one found.

The config object has methods to add commands and various post-processors that would allow things like transpilation, supporting stylus/less/sass, and installing transforms prior to parsing. Supporting plugins allows ractive to transfer the responsibility for updating deps to the user rather than getting on the constant devDependencies treadmill. Things that would make useful command plugins would be a lazy component loader and an AOT pre-renderer.

If we wanted to add easier support for non-JS transpilation, it would probably make sense to add a script preprocessor stage that fires before the other variables get substituted in the script. I'll punt on that for now though.

This also touches up a few more cases with parser transforms, notably that a single replaced node will be run through the transforms again, that local and global transforms are all applied, and that inline partials have transforms applied.

## Is breaking:
Nope.
