### PR TITLE
Attempt to keep class attribute order and duplicates intact - #2903

### DIFF
--- a/src/view/items/element/attribute/getUpdateDelegate.js
+++ b/src/view/items/element/attribute/getUpdateDelegate.js
@@ -250,22 +250,7 @@ function updateClassName ( reset ) {
 	const attr = readClass( this.node.className );
 	const prev = this.previous || attr.slice( 0 );
 
-	let i = 0;
-	while ( i < value.length ) {
-		if ( !~attr.indexOf( value[i] ) ) attr.push( value[i] );
-		i++;
-	}
-
-	// remove now-missing classes
-	i = prev.length;
-	while ( i-- ) {
-		if ( !~value.indexOf( prev[i] ) ) {
-			const idx = attr.indexOf( prev[i] );
-			if ( ~idx ) attr.splice( idx, 1 );
-		}
-	}
-
-	const className = attr.join( ' ' );
+	const className = value.concat( attr.filter( c => !~prev.indexOf( c ) ) ).join( ' ' );
 
 	if ( className !== this.node.className ) {
 		this.node.className = className;

--- a/tests/browser/attributes.js
+++ b/tests/browser/attributes.js
@@ -16,7 +16,7 @@ export default function () {
 		span.className += ' yep';
 		r.set( 'classes', 'foo baz' );
 
-		t.equal( span.className, 'foo yep baz' );
+		t.equal( span.className, 'foo baz yep' );
 	});
 
 	test( `style attributes only update the styles in their content`, t => {
@@ -147,7 +147,7 @@ export default function () {
 		r.toggle( 'foo' );
 		t.equal( span.className, 'bar baz' );
 		r.toggle( 'foo' );
-		t.equal( span.className, 'bar baz foo' );
+		t.equal( span.className, 'bar foo baz' );
 	});
 
 	test( `class attributes don't override class directives at render (#2565)`, t => {
@@ -241,5 +241,32 @@ export default function () {
 
 		t.equal( span.innerHTML, 'sure' );
 		t.equal( input.value, 'yep' );
+	});
+
+	test( `class attributes try to update in original order where possible (#2903)`, t => {
+		const r = new Ractive({
+			el: fixture,
+			template: `<div class="{{classes.join(' ')}}" />`,
+			data: {
+				classes: [ 'a', 'b', 'c' ]
+			}
+		});
+
+		const div = r.find( 'div' );
+
+		r.push( 'classes', 'd', 'e' );
+		t.equal( div.className, 'a b c d e' );
+
+		r.splice( 'classes', 2, 0, 'bb' );
+		t.equal( div.className, 'a b bb c d e' );
+
+		r.set( 'classes', [] );
+		t.equal( div.className, '' );
+
+		r.set( 'classes', [ 'z', 'c', 'b' ] );
+		t.equal( div.className, 'z c b' );
+
+		r.set( 'classes', [ 'a', 'b', 'c' ] );
+		t.equal( div.className, 'a b c' );
 	});
 }

--- a/tests/browser/partials.js
+++ b/tests/browser/partials.js
@@ -533,7 +533,7 @@ export default function() {
 
 		t.htmlEqual( fixture.innerHTML, '<div class="wrapped foo around" id="foo"></div>' );
 		ractive.resetPartial( 'foo', 'nfoo' );
-		t.htmlEqual( fixture.innerHTML, '<div class="wrapped around nfoo" id="nfoo"></div>' );
+		t.htmlEqual( fixture.innerHTML, '<div class="wrapped nfoo around" id="nfoo"></div>' );
 	});
 
 	test( 'Partials in attribute blocks can be changed with resetPartial', t => {


### PR DESCRIPTION
## Description of the pull request:
As of 0.8, ractive no longer just dumps whatever it has into the class attribute of an element, but instead does some diffing on the class list to merge with any externally added classes. This causes issues with things that expect the classes to show up in a certain order or for duplicate class names to exist e.g. `class="foo foo foo"` and css `.foo.foo.foo { /* why? */ }`.

This adjusts the class handling to simply remove the last know values from the current element class attribute and pop whatever's left over onto the current target value for the class attribute. that keeps the class attribute in question in the proper order for ractive. Externally managed classes will be shuffled to the end, but they will otherwise stay in whatever order they had when added.

## Fixes the following issues:
#2903

## Is breaking:
No? Unless you have stuff that is sensitive to class order or dupes, but that seems to be pretty rare.

## Reviewers:
Yep.