### PR TITLE
Ensure we bind functions using `Function.prototype.bind`

### DIFF
--- a/src/utils/bind.js
+++ b/src/utils/bind.js
@@ -1,7 +1,9 @@
+const fnBind = Function.prototype.bind;
+
 export default function bind ( fn, context ) {
 	if ( !/this/.test( fn.toString() ) ) return fn;
 
-	const bound = fn.bind( context );
+	const bound = fnBind.call( fn, context );
 	for ( const prop in fn ) bound[ prop ] = fn[ prop ];
 
 	return bound;

--- a/tests/browser/misc.js
+++ b/tests/browser/misc.js
@@ -1062,6 +1062,37 @@ export default function() {
 		t.htmlEqual( fixture.innerHTML, 'FOO' );
 	});
 
+	test( 'Regression test for #2915', t => {
+		// This is how Underscore defines `_`:
+		// https://github.com/jashkenas/underscore/blob/8fc7032295d60aff3620ef85d4aa6549a55688a0/underscore.js#L42
+		// It is important to the purposes of this test, as distinct from the one
+		// above, that `_` be a function that uses `this`.
+		const _ = function (obj) {
+			if (obj instanceof _) return obj;
+			if (!(this instanceof _)) return new _(obj);
+			this._wrapped = obj;
+		};
+
+		_.bind = function () {
+			// do nothing
+		};
+		
+		_.uppercase = function ( str ) {
+			return str.toUpperCase();
+		};
+
+		new Ractive({
+			el: fixture,
+			template: '{{_.uppercase(str)}}',
+			data: {
+				_,
+				str: 'foo'
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'FOO' );
+	});
+
 	test( 'Interpolation of script/style contents can be disabled (#1050)', t => {
 		new Ractive({
 			el: fixture,


### PR DESCRIPTION
## Description of the pull request:

The function itself may have overridden `bind`, for instance if it
is Underscore: https://github.com/jashkenas/underscore/blob/8fc7032295d60aff3620ef85d4aa6549a55688a0/underscore.js#L765

## Fixes the following issues:

Fixes #2915.

A similar fix was put in place in 6ce7082f67c963ec078c4e7b6f561c2cbbd5300c
to fix #1055, but that was lost somewhere along the way. This defeated the
regression test for #1055 because `src/utils/bind.js` only calls `bind` on
_functions_ that _used `this`_ and the regression test for #1055 simulated
Underscore using a POJO.

## Is breaking:

No (at least all previous tests continue to pass, this is my first PR against Ractive so there may be something I'm missing :).