### PR TITLE
Event handler proxy adjustment - #2922

### DIFF
--- a/src/Ractive/prototype/off.js
+++ b/src/Ractive/prototype/off.js
@@ -14,11 +14,13 @@ export default function Ractive$off ( eventName, callback ) {
 			const subs = this._subs[ event ];
 			// if given a specific callback to remove, remove only it
 			if ( subs && callback ) {
-				// flag this callback as off so that any in-flight firings don't call
-				// a cancelled handler - this is _slightly_ hacky
-				( callback._proxy || callback ).off = true;
-				removeFromArray( subs, callback._proxy || callback );
-				if ( event.indexOf( '.' ) ) this._nsSubs--;
+				const entry = subs.find( s => s.callback === callback );
+				if ( entry ) {
+					removeFromArray( subs, entry );
+					entry.off = true;
+
+					if ( event.indexOf( '.' ) ) this._nsSubs--;
+				}
 			}
 
 			// otherwise, remove all listeners for this event

--- a/src/Ractive/prototype/on.js
+++ b/src/Ractive/prototype/on.js
@@ -15,20 +15,23 @@ export default function Ractive$on ( eventName, callback ) {
 		const caller = function ( ...args ) {
 			if ( !silent ) return callback.apply( this, args );
 		};
-		callback._proxy = caller;
+		const entry = {
+			callback,
+			handler: caller
+		};
 
 		if ( map.hasOwnProperty( k ) ) {
 			const names = k.split( ' ' ).map( trim ).filter( notEmptyString );
 			names.forEach( n => {
-				( this._subs[ n ] || ( this._subs[ n ] = [] ) ).push( caller );
+				( this._subs[ n ] || ( this._subs[ n ] = [] ) ).push( entry );
 				if ( n.indexOf( '.' ) ) this._nsSubs++;
-				events.push( [ n, caller ] );
+				events.push( [ n, entry ] );
 			});
 		}
 	}
 
 	return {
-		cancel: () => events.forEach( e => this.off( e[0], e[1] ) ),
+		cancel: () => events.forEach( e => this.off( e[0], e[1].callback ) ),
 		isSilenced: () => silent,
 		silence: () => silent = true,
 		resume: () => silent = false

--- a/src/events/fireEvent.js
+++ b/src/events/fireEvent.js
@@ -96,7 +96,7 @@ function notifySubscribers ( ractive, subscribers, context, args ) {
 	subscribers = subscribers.slice();
 
 	for ( let i = 0, len = subscribers.length; i < len; i += 1 ) {
-		if ( !subscribers[ i ].off && subscribers[ i ].apply( ractive, args ) === false ) {
+		if ( !subscribers[ i ].off && subscribers[ i ].handler.apply( ractive, args ) === false ) {
 			stopEvent = true;
 		}
 	}

--- a/tests/browser/events/basic.js
+++ b/tests/browser/events/basic.js
@@ -267,4 +267,48 @@ export default function() {
 		r.fire( 'bar' );
 		t.equal( count, 5 );
 	});
+
+	test( `using the same event callback function for different events or multiple times doesn't break (#2922)`, t => {
+		let count = 0;
+		function handler() {
+			count++;
+		}
+
+		const r = new Ractive();
+
+		const foo = r.on( 'foo', handler );
+		r.on( 'bar', handler );
+		const multi = r.on( 'baz bat bip.bop', handler );
+
+		r.fire( 'foo' );
+		r.fire( 'bar' );
+		r.fire( 'baz' );
+		r.fire( 'bat' );
+		r.fire( 'bip.bop' );
+
+		t.equal( count, 5 );
+
+		foo.cancel();
+		r.off( 'bar', handler );
+
+		r.fire( 'foo' );
+		r.fire( 'bar' );
+		r.fire( 'baz' );
+		r.fire( 'bat' );
+		r.fire( 'bip.bop' );
+
+		t.equal( count, 8 );
+
+		multi.cancel();
+		r.on( 'foo', handler );
+		r.on( 'bar', handler );
+
+		r.fire( 'foo' );
+		r.fire( 'bar' );
+		r.fire( 'baz' );
+		r.fire( 'bat' );
+		r.fire( 'bip.bop' );
+
+		t.equal( count, 10 );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
To avoid the pitfalls of flagging an event handler fn directly (see #2922), this introduces an intermediate object to hold the `off` flag, a reference to the original handler, and the intermediate handler used for `silence`ing a listener handle. When a handler is removed, its intermediate object gets flagged as off, which stops the handler from being called during event firing while avoiding future firing issues using the same handler function.

## Fixes the following issues:
#2922

## Is breaking:
Nope.

## Reviewers:
Yep.