### PR TITLE
fixes #2945 - oncomplete won't fire if instance is torndown

### DIFF
--- a/src/Ractive/render.js
+++ b/src/Ractive/render.js
@@ -47,5 +47,9 @@ export default function render ( ractive, target, anchor, occupants ) {
 	runloop.end();
 	ractive.rendering = false;
 
-	return promise.then( () => completeHook.fire( ractive ) );
+	return promise.then( () => {
+		if (ractive.torndown) return;
+
+		completeHook.fire( ractive );
+	});
 }

--- a/tests/browser/init/hooks/order.js
+++ b/tests/browser/init/hooks/order.js
@@ -143,20 +143,23 @@ export default function() {
 
 		t.equal( fixture.innerHTML, simpsons.join( '' ) );
 
-		ractive.teardown().then( () => {
-			function testHooks( name, order ) {
-				Object.keys( order ).forEach( hook => {
-					if ( hook === 'complete' ) {
-						t.equal( order.complete.length, simpsons.length );
-					} else {
-						t.deepEqual( order[ hook ], simpsons, `${hook} ${name} order` );
-					}
-				});
-			}
+		setTimeout( () => {
 
-			testHooks( 'method', method );
-			testHooks( 'event', event );
-			done();
+			ractive.teardown().then( () => {
+				function testHooks( name, order ) {
+					Object.keys( order ).forEach( hook => {
+						if ( hook === 'complete' ) {
+							t.equal( order.complete.length, simpsons.length );
+						} else {
+							t.deepEqual( order[ hook ], simpsons, `${hook} ${name} order` );
+						}
+					});
+				}
+
+				testHooks( 'method', method );
+				testHooks( 'event', event );
+				done();
+			});
 		});
 	});
 
@@ -193,9 +196,11 @@ export default function() {
 			const grandchild = ractive.findComponent( 'GrandChild' );
 			grandchild.set( 'foo', 'fizz' );
 
-			ractive.teardown().then( () => {
-				t.deepEqual( fired, expected );
-				done();
+			setTimeout( () => {
+				ractive.teardown().then( () => {
+					t.deepEqual( fired, expected );
+					done();
+				});
 			});
 		});
 	}


### PR DESCRIPTION
## Description of the pull request:
This PR adds a check to only fire oncomplete if the instance is not already torndown. Some of the oncomplete lifecycle tests failed where we  create a Ractive instance followed immediately by a teardown. Because the oncomplete hook is fired asynchronously the teardown call is made before oncomplete is invoked.

As a workaround I call the teardown in the next tick by wrapping it in a setTimeout,

## Fixes the following issues:
#2945 

Is breaking:
Perhaps in tests, where creating a Ractive instance is immediately followed by a teardown call, and one expects the oncomplete hook to still fire.

Reviewers:
Yes