### PR TITLE
Adjust internal event handling to allow delegation for any event including bindings - #2988

### DIFF
--- a/src/shared/Context.js
+++ b/src/shared/Context.js
@@ -89,6 +89,14 @@ export default class Context {
 		return promise;
 	}
 
+	listen ( event, handler ) {
+		const el = this.element;
+		el.on( event, handler );
+		return {
+			cancel () { el.off( event, handler ); }
+		};
+	}
+
 	observe ( keypath, callback, options = {} ) {
 		if ( isObject( keypath ) ) options = callback || {};
 		options.fragment = this.fragment;
@@ -180,6 +188,10 @@ export default class Context {
 		if ( here.owner && here.owner._link ) here.owner.unlink();
 		runloop.end();
 		return promise;
+	}
+
+	unlisten ( event, handler ) {
+		this.element.off( event, handler );
 	}
 
 	unshift ( keypath, ...add ) {

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -110,7 +110,7 @@ export default class Element extends ContainerItem {
 		this.attributes.forEach( destroyed );
 		const ls = this.listeners;
 		for ( const k in ls ) {
-			if ( ls[k] && ls[k].length ) this.node.removeEventListener( event, handler );
+			if ( ls[k] && ls[k].length ) this.node.removeEventListener( k, handler );
 		}
 		if ( this.fragment ) this.fragment.destroyed();
 	}
@@ -204,8 +204,8 @@ export default class Element extends ContainerItem {
 			const add = n.addEventListener;
 			const rem = n.removeEventListener;
 
-			if ( !ref.refs || !ref.length ) {
-				add.call( n, event, handler, capture || !!ref.refs );
+			if ( !ref.length ) {
+				add.call( n, event, handler, capture );
 			} else if ( ref.length && !ref.refs && capture ) {
 				rem.call( n, event, handler, false );
 				add.call( n, event, handler, true );

--- a/src/view/items/element/ElementEvents.js
+++ b/src/view/items/element/ElementEvents.js
@@ -1,37 +1,35 @@
 import { fatal } from '../../../utils/log';
 
 class DOMEvent {
-	constructor ( name, owner, delegate ) {
+	constructor ( name, owner ) {
 		if ( name.indexOf( '*' ) !== -1 ) {
 			fatal( `Only component proxy-events may contain "*" wildcards, <${owner.name} on-${name}="..."/> is not valid` );
 		}
 
 		this.name = name;
 		this.owner = owner;
-		this.delegate = delegate;
-		this.node = null;
 		this.handler = null;
 	}
 
 	listen ( directive ) {
-		const node = this.node = this.owner.node;
+		const node = this.owner.node;
 		const name = this.name;
 
 		// this is probably a custom event fired from a decorator or manually
 		if ( !( `on${name}` in node ) ) return;
 
-		node.addEventListener( name, this.handler = function( event ) {
-			directive.fire({
+		this.owner.on( name, this.handler = ( event ) => {
+			return directive.fire({
 				node,
 				original: event,
 				event,
 				name
 			});
-		}, this.delegate );
+		});
 	}
 
 	unlisten () {
-		if ( this.handler ) this.node.removeEventListener( this.name, this.handler, false );
+		if ( this.handler ) this.owner.off( this.name, this.handler );
 	}
 }
 
@@ -52,7 +50,7 @@ class CustomEvent {
 
 			event.name = this.name;
 			event.node = event.node || node;
-			directive.fire( event );
+			return directive.fire( event );
 		});
 	}
 

--- a/src/view/items/element/binding/CheckboxBinding.js
+++ b/src/view/items/element/binding/CheckboxBinding.js
@@ -9,16 +9,16 @@ export default class CheckboxBinding extends Binding {
 	render () {
 		super.render();
 
-		this.node.addEventListener( 'change', handleDomEvent, false );
+		this.element.on( 'change', handleDomEvent );
 
 		if ( this.node.attachEvent ) {
-			this.node.addEventListener( 'click', handleDomEvent, false );
+			this.element.on( 'click', handleDomEvent );
 		}
 	}
 
 	unrender () {
-		this.node.removeEventListener( 'change', handleDomEvent, false );
-		this.node.removeEventListener( 'click', handleDomEvent, false );
+		this.element.off( 'change', handleDomEvent );
+		this.element.off( 'click', handleDomEvent );
 	}
 
 	getInitialValue () {

--- a/src/view/items/element/binding/CheckboxNameBinding.js
+++ b/src/view/items/element/binding/CheckboxNameBinding.js
@@ -91,11 +91,11 @@ export default class CheckboxNameBinding extends Binding {
 		node.name = '{{' + this.model.getKeypath() + '}}';
 		node.checked = this.isChecked;
 
-		node.addEventListener( 'change', handleDomEvent, false );
+		this.element.on( 'change', handleDomEvent );
 
 		// in case of IE emergency, bind to click event as well
-		if ( node.attachEvent ) {
-			node.addEventListener( 'click', handleDomEvent, false );
+		if ( this.node.attachEvent ) {
+			this.element.on( 'click', handleDomEvent );
 		}
 	}
 
@@ -115,10 +115,10 @@ export default class CheckboxNameBinding extends Binding {
 	}
 
 	unrender () {
-		const node = this.element.node;
+		const el = this.element;
 
-		node.removeEventListener( 'change', handleDomEvent, false );
-		node.removeEventListener( 'click', handleDomEvent, false );
+		el.off( 'change', handleDomEvent );
+		el.off( 'click', handleDomEvent );
 	}
 
 	arrayContains ( selectValue, optionValue ) {

--- a/src/view/items/element/binding/ContentEditableBinding.js
+++ b/src/view/items/element/binding/ContentEditableBinding.js
@@ -13,16 +13,16 @@ export default class ContentEditableBinding extends Binding {
 	render () {
 		super.render();
 
-		const node = this.node;
+		const el = this.element;
 
-		node.addEventListener( 'change', handleDomEvent, false );
-		node.addEventListener( 'blur', handleDomEvent, false );
+		el.on( 'change', handleDomEvent );
+		el.on( 'blur', handleDomEvent );
 
 		if ( !this.ractive.lazy ) {
-			node.addEventListener( 'input', handleDomEvent, false );
+			el.on( 'input', handleDomEvent );
 
-			if ( node.attachEvent ) {
-				node.addEventListener( 'keyup', handleDomEvent, false );
+			if ( this.node.attachEvent ) {
+				el.on( 'keyup', handleDomEvent );
 			}
 		}
 	}
@@ -32,11 +32,11 @@ export default class ContentEditableBinding extends Binding {
 	}
 
 	unrender () {
-		const node = this.node;
+		const el = this.element;
 
-		node.removeEventListener( 'blur', handleDomEvent, false );
-		node.removeEventListener( 'change', handleDomEvent, false );
-		node.removeEventListener( 'input', handleDomEvent, false );
-		node.removeEventListener( 'keyup', handleDomEvent, false );
+		el.off( 'blur', handleDomEvent );
+		el.off( 'change', handleDomEvent );
+		el.off( 'input', handleDomEvent );
+		el.off( 'keyup', handleDomEvent );
 	}
 }

--- a/src/view/items/element/binding/GenericBinding.js
+++ b/src/view/items/element/binding/GenericBinding.js
@@ -39,6 +39,7 @@ export default class GenericBinding extends Binding {
 		// if the value is a number, it's a timeout
 		let lazy = this.ractive.lazy;
 		let timeout = false;
+		const el = this.element;
 
 		if ( 'lazy' in this.element ) {
 			lazy = this.element.lazy;
@@ -53,26 +54,27 @@ export default class GenericBinding extends Binding {
 
 		const node = this.node;
 
-		node.addEventListener( 'change', handleDomEvent, false );
+		el.on( 'change', handleDomEvent );
 
 		if ( !lazy ) {
-			node.addEventListener( 'input', this.handler, false );
+			el.on( 'input', this.handler );
 
+			// IE is a special snowflake
 			if ( node.attachEvent ) {
-				node.addEventListener( 'keyup', this.handler, false );
+				el.on( 'keyup', this.handler );
 			}
 		}
 
-		node.addEventListener( 'blur', handleBlur, false );
+		el.on( 'blur', handleBlur );
 	}
 
 	unrender () {
-		const node = this.element.node;
+		const el = this.element;
 		this.rendered = false;
 
-		node.removeEventListener( 'change', handleDomEvent, false );
-		node.removeEventListener( 'input', this.handler, false );
-		node.removeEventListener( 'keyup', this.handler, false );
-		node.removeEventListener( 'blur', handleBlur, false );
+		el.off( 'change', handleDomEvent );
+		el.off( 'input', this.handler );
+		el.off( 'keyup', this.handler );
+		el.off( 'blur', handleBlur );
 	}
 }

--- a/src/view/items/element/binding/MultipleSelectBinding.js
+++ b/src/view/items/element/binding/MultipleSelectBinding.js
@@ -44,7 +44,7 @@ export default class MultipleSelectBinding extends Binding {
 	render () {
 		super.render();
 
-		this.node.addEventListener( 'change', handleDomEvent, false );
+		this.element.on( 'change', handleDomEvent );
 
 		if ( this.model.get() === undefined ) {
 			// get value from DOM, if possible
@@ -66,6 +66,6 @@ export default class MultipleSelectBinding extends Binding {
 	}
 
 	unrender () {
-		this.node.removeEventListener( 'change', handleDomEvent, false );
+		this.element.off( 'change', handleDomEvent );
 	}
 }

--- a/src/view/items/element/binding/RadioBinding.js
+++ b/src/view/items/element/binding/RadioBinding.js
@@ -34,10 +34,10 @@ export default class RadioBinding extends Binding {
 	render () {
 		super.render();
 
-		this.node.addEventListener( 'change', handleDomEvent, false );
+		this.element.on( 'change', handleDomEvent );
 
 		if ( this.node.attachEvent ) {
-			this.node.addEventListener( 'click', handleDomEvent, false );
+			this.element.on( 'click', handleDomEvent );
 		}
 	}
 
@@ -50,7 +50,7 @@ export default class RadioBinding extends Binding {
 	}
 
 	unrender () {
-		this.node.removeEventListener( 'change', handleDomEvent, false );
-		this.node.removeEventListener( 'click', handleDomEvent, false );
+		this.element.off( 'change', handleDomEvent );
+		this.element.off( 'click', handleDomEvent );
 	}
 }

--- a/src/view/items/element/binding/RadioNameBinding.js
+++ b/src/view/items/element/binding/RadioNameBinding.js
@@ -69,10 +69,10 @@ export default class RadioNameBinding extends Binding {
 		node.name = `{{${this.model.getKeypath()}}}`;
 		node.checked = this.element.compare ( this.model.get(), this.element.getAttribute( 'value' ) );
 
-		node.addEventListener( 'change', handleDomEvent, false );
+		this.element.on( 'change', handleDomEvent );
 
 		if ( node.attachEvent ) {
-			node.addEventListener( 'click', handleDomEvent, false );
+			this.element.on( 'click', handleDomEvent );
 		}
 	}
 
@@ -89,9 +89,9 @@ export default class RadioNameBinding extends Binding {
 	}
 
 	unrender () {
-		const node = this.node;
+		const el = this.element;
 
-		node.removeEventListener( 'change', handleDomEvent, false );
-		node.removeEventListener( 'click', handleDomEvent, false );
+		el.off( 'change', handleDomEvent );
+		el.off( 'click', handleDomEvent );
 	}
 }

--- a/src/view/items/element/binding/SingleSelectBinding.js
+++ b/src/view/items/element/binding/SingleSelectBinding.js
@@ -78,7 +78,7 @@ export default class SingleSelectBinding extends Binding {
 
 	render () {
 		super.render();
-		this.node.addEventListener( 'change', handleDomEvent, false );
+		this.element.on( 'change', handleDomEvent );
 	}
 
 	setFromNode ( node ) {
@@ -87,6 +87,6 @@ export default class SingleSelectBinding extends Binding {
 	}
 
 	unrender () {
-		this.node.removeEventListener( 'change', handleDomEvent, false );
+		this.element.off( 'change', handleDomEvent );
 	}
 }

--- a/src/view/items/element/specials/Form.js
+++ b/src/view/items/element/specials/Form.js
@@ -9,11 +9,11 @@ export default class Form extends Element {
 
 	render ( target, occupants ) {
 		super.render( target, occupants );
-		this.node.addEventListener( 'reset', handleReset, false );
+		this.on( 'reset', handleReset );
 	}
 
 	unrender ( shouldDestroy ) {
-		this.node.removeEventListener( 'reset', handleReset, false );
+		this.off( 'reset', handleReset );
 		super.unrender( shouldDestroy );
 	}
 }

--- a/src/view/items/shared/EventDirective.js
+++ b/src/view/items/shared/EventDirective.js
@@ -14,41 +14,6 @@ import noop from '../../../utils/noop';
 const specialPattern = /^(event|arguments|@node|@event|@context)(\..+)?$/;
 const dollarArgsPattern = /^\$(\d+)(\..+)?$/;
 
-export const DelegateProxy = {
-	fire ( event, args = [] ) {
-		if ( event && event.event ) {
-			const ev = event.event;
-
-			// TODO if IE<9 needs to be supported here, could probably walk to the element with a ractive proxy with a delegates property
-			const end = ev.currentTarget;
-			let node = ev.target;
-			const name = event.name;
-			let bubble = true;
-
-			// starting with the origin node, walk up the DOM looking for ractive nodes with a matching event listener
-			while ( bubble && node && node !== end ) {
-				const el = node._ractive && node._ractive.proxy;
-
-				if ( el ) {
-					// set up the context for the handler
-					event.node = el.node;
-					event.name = name;
-
-					el.events.forEach( ev => {
-						if ( ev.delegate && ~ev.template.n.indexOf( name ) ) {
-							bubble = ev.fire( event, args ) !== false && bubble;
-						}
-					});
-				}
-
-				node = node.parentNode;
-			}
-
-			return bubble;
-		}
-	}
-};
-
 export default class EventDirective {
 	constructor ( options ) {
 		this.owner = options.owner || options.parentFragment.owner || findElement( options.parentFragment );
@@ -56,7 +21,7 @@ export default class EventDirective {
 		this.template = options.template;
 		this.parentFragment = options.parentFragment;
 		this.ractive = options.parentFragment.ractive;
-		const delegate = this.delegate = this.ractive.delegate && options.parentFragment.delegate;
+		//const delegate = this.delegate = this.ractive.delegate && options.parentFragment.delegate;
 		this.events = [];
 
 		if ( this.element.type === COMPONENT || this.element.type === ANCHOR ) {
@@ -65,14 +30,14 @@ export default class EventDirective {
 			});
 		} else {
 			// make sure the delegate element has a storag object
-			if ( delegate && !delegate.delegates ) delegate.delegates = {};
+			//if ( delegate && !delegate.delegates ) delegate.delegates = {};
 
 			this.template.n.forEach( n => {
 				const fn = findInViewHierarchy( 'events', this.ractive, n );
 				if ( fn ) {
 					this.events.push( new CustomEvent( fn, this.element, n ) );
 				} else {
-					if ( delegate ) {
+					/*if ( delegate ) {
 						if ( !delegate.delegates[n] ) {
 							const ev = new DOMEvent( n, delegate, true );
 							delegate.delegates[n] = ev;
@@ -81,7 +46,8 @@ export default class EventDirective {
 						}
 					} else {
 						this.events.push( new DOMEvent( n, this.element ) );
-					}
+					}*/
+					this.events.push( new DOMEvent( n, this.element ) );
 				}
 			});
 		}

--- a/tests/browser/events/delegate.js
+++ b/tests/browser/events/delegate.js
@@ -31,9 +31,9 @@ export default function() {
 		Element.prototype.addEventListener = addEventListener;
 
 		const [ top, ev, other ] = r.findAll( 'div' );
-		t.ok( Object.keys( top._ractive.proxy.delegates ).length );
-		t.ok( ev._ractive.proxy.events[0].events.length === 0 );
-		t.ok( other._ractive.proxy.events[0].events.length === 0 );
+		t.ok( top._ractive.proxy.listeners.click.length === 1 && top._ractive.proxy.listeners.click.refs === 2 );
+		t.ok( ev._ractive.proxy.listeners.click.length === 1 );
+		t.ok( other._ractive.proxy.listeners.click.length === 1 );
 		fire( top, 'click' );
 		fire( ev, 'click' );
 		fire( other, 'click' );
@@ -142,9 +142,9 @@ export default function() {
 		Element.prototype.addEventListener = addEventListener;
 
 		const [ top, ev, other ] = r.findAll( 'div' );
-		t.ok( Object.keys( top._ractive.proxy.delegates ).length );
-		t.ok( ev._ractive.proxy.events[0].events.length === 0 );
-		t.ok( other._ractive.proxy.events[0].events.length === 0 );
+		t.ok( top._ractive.proxy.listeners.click.length === 1 && top._ractive.proxy.listeners.click.refs === 2 );
+		t.ok( ev._ractive.proxy.listeners.click.length === 1 );
+		t.ok( other._ractive.proxy.listeners.click.length === 1 );
 		fire( top, 'click' );
 		fire( ev, 'click' );
 		fire( other, 'click' );
@@ -169,7 +169,7 @@ export default function() {
 			data: { arr: [ 1 ] }
 		});
 
-		t.equal( count, 3 );
+		t.equal( count, 1 );
 		Element.prototype.addEventListener = addEventListener;
 
 		const [ top, outer, ev, other ] = r.findAll( 'div' );
@@ -200,12 +200,9 @@ export default function() {
 		t.equal( count, 2 );
 		Element.prototype.addEventListener = addEventListener;
 
-		const [ top, outer, , ev, other ] = r.findAll( 'div' );
-		t.ok( top._ractive.proxy.delegate === false );
-		t.ok( !top._ractive.proxy.delegates );
-		t.ok( outer._ractive.proxy.events[0].events.length === 1 );
-		t.ok( ev._ractive.proxy.events[0].events.length === 0 );
-		t.ok( other._ractive.proxy.events[0].events.length === 0 );
+		const [ top, , wrap ] = r.findAll( 'div' );
+		t.ok( !top._ractive.proxy.listeners.click );
+		t.ok( wrap._ractive.proxy.listeners.click.refs === 2 );
 	});
 
 	test( `delegated events work with non-ractive nodes (#2871)`, t => {
@@ -276,5 +273,31 @@ export default function() {
 		fire( r.find( 'button' ), 'click' );
 
 		t.equal( r.findAll( 'button' ).length, 1 );
+	});
+
+	test( `delegated bindings fire in the correct order (#2988)`, t => {
+		let selected = 1;
+		const r = new Ractive({
+			target: fixture,
+			template: `<div>{{#each items}}<select value="{{.option}}" on-change="@.check()">{{#each options}}<option value="{{.}}">{{@index + 1}}</option>{{/each}}</select>{{/each}}</div>`,
+			data: {
+				options: [ 1, 2, 3 ],
+				items: [ {} ]
+			},
+			check() {
+				t.equal( this.get( 'items.0.option' ), selected );
+			}
+		});
+
+		const select = r.find( 'select' );
+		const options = r.findAll( 'option' );
+
+		selected = 2;
+		options[1].selected = true;
+		fire( select, 'change' );
+
+		selected = 3;
+		options[2].selected = true;
+		fire( select, 'change' );
 	});
 }


### PR DESCRIPTION
## Description of the pull request:

This moves dom event handling to the element vdom item, so that delegation can be used with any subscribed events.including twoway bindings. Handlers are collected into a map on the element and only a single listener is installed for each event type, and delegation is handled as a special reference counted handler on the delegation target.

## Fixes the following issues:
#2988

## Is breaking:
Maybe.

## Reviewers:
Yep