### PR TITLE
Add an eval option that can disable parsing of expressions

### DIFF
--- a/src/Ractive/config/defaults.js
+++ b/src/Ractive/config/defaults.js
@@ -8,6 +8,7 @@ export default {
 	template:               null,
 
 	// parse:
+	allowExpressions:       true,
 	delimiters:             [ '{{', '}}' ],
 	tripleDelimiters:       [ '{{{', '}}}' ],
 	staticDelimiters:       [ '[[', ']]' ],

--- a/src/Ractive/config/runtime-parser.js
+++ b/src/Ractive/config/runtime-parser.js
@@ -14,7 +14,9 @@ const parseOptions = [
 	'preserveWhitespace',
 	'sanitize',
 	'stripComments',
-	'contextLines'
+	'contextLines',
+	'parserTransforms',
+	'allowExpressions'
 ];
 
 const TEMPLATE_INSTRUCTIONS = `Either preparse or use a ractive runtime source that includes the parser. `;

--- a/src/parse/_parse.js
+++ b/src/parse/_parse.js
@@ -70,6 +70,7 @@ const StandardParser = Parser.extend({
 		this.includeLinePositions = options.includeLinePositions;
 		this.textOnlyMode = options.textOnlyMode;
 		this.csp = options.csp;
+		this.allowExpressions = options.allowExpressions;
 
 		this.transforms = options.transforms || options.parserTransforms;
 		if ( this.transforms ) {

--- a/src/parse/converters/readExpression.js
+++ b/src/parse/converters/readExpression.js
@@ -1,6 +1,14 @@
 import readConditional from './expressions/readConditional';
+import readReference from './expressions/primary/readReference';
 
 export default function readExpression ( parser ) {
+	// if eval is false, no expressions
+	if ( parser.allowExpressions === false ) {
+		const ref = readReference( parser );
+		parser.allowWhitespace();
+		return ref;
+	}
+
 	// The conditional operator is the lowest precedence operator (except yield,
 	// assignment operators, and commas, none of which are supported), so we
 	// start there. If it doesn't match, it 'falls through' to progressively

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -18,7 +18,9 @@ export default class ExpressionProxy extends Model {
 		this.isReadonly = true;
 		this.dirty = true;
 
-		this.fn = getFunction( template.s, template.r.length );
+		this.fn = fragment.ractive.allowExpressions === false ?
+			noop :
+			getFunction( template.s, template.r.length );
 
 		this.models = this.template.r.map( ref => {
 			return resolveReference( this.fragment, ref );

--- a/tests/browser/parser.js
+++ b/tests/browser/parser.js
@@ -130,4 +130,30 @@ export default function () {
 		Ractive.parse( '{{#[1, 2, 3]}} ... {{/who cares}}' );
 		Ractive.parse( '{{#foo.bar}}...{{/foo.bar}}' );
 	});
+
+	test( `expressions can be completely disabled by the parser`, t => {
+		t.expect( 3 );
+
+		t.ok( Ractive.parse( '{{.foo()}}' ) );
+		t.throws( () => Ractive.parse( '{{ .foo() }}', { allowExpressions: false } ), /expected closing delimiter/i );
+		t.throws( () => new Ractive({
+			template: '{{.foo()}}',
+			allowExpressions: false
+		}), /expected closing delimiter/i );
+	});
+
+	test( `expressions on a template provided to an instance with disallowed expressions are not executed`, t => {
+		t.expect( 1 );
+
+		new Ractive({
+			target: fixture,
+			template: Ractive.parse( '{{ foo() }}-{{ foo( 42, "abc" ) }}' ),
+			data: {
+				foo () { t.ok( false, 'should not run' ); }
+			},
+			allowExpressions: false
+		});
+
+		t.equal( fixture.innerHTML, '-' );
+	});
 }


### PR DESCRIPTION
## Description of the pull request:
This adds an `eval` option for instances and parsing that when set to `false` causes the parser to skip any expression parsing functions and just use the reference parsing function. The end effect is that any non-reference mustaches throw a parsing error when `eval: false`.

Per comments in ractivejs/ractivejs.github.io#68, if you have untrusted content in your templates and you're using SSR, there's not really a way to completely ensure that terrible things wouldn't happen to the server when rendering. With expressions turned off, you can at least be sure that the template has no access to the environment.

### Question
Is `eval` the best name for this option? `allowExpressions` seems a bit more descriptive of what will actually happen. For instance, you could pre-parse a template that allowed expressions, and they would still execute in an instance with `eval: false`.

## Fixes the following issues:
Security. Please, think of the children.

## Is breaking:
Only if you use an `eval` property on your instances.

## Reviewers:
@MartinKolarik @fskreuz 