### PR TITLE
Call computed setter on child update - #3006

### DIFF
--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -36,6 +36,10 @@ export default class Computation extends Model {
 		this.shuffle = undefined;
 	}
 
+	get setRoot () {
+		if ( this.signature.setter ) return this;
+	}
+
 	get ( shouldCapture ) {
 		if ( shouldCapture ) capture( this );
 

--- a/src/model/ComputationChild.js
+++ b/src/model/ComputationChild.js
@@ -10,6 +10,8 @@ export default class ComputationChild extends Model {
 		this.dirty = true;
 	}
 
+	get setRoot () { return this.parent.setRoot; }
+
 	applyValue ( value ) {
 		super.applyValue( value );
 
@@ -23,6 +25,10 @@ export default class ComputationChild extends Model {
 			if ( source ) {
 				source.dependencies.forEach( mark );
 			}
+		}
+
+		if ( this.setRoot ) {
+			this.setRoot.set( this.setRoot.value );
 		}
 	}
 

--- a/src/view/items/element/binding/Binding.js
+++ b/src/view/items/element/binding/Binding.js
@@ -14,7 +14,7 @@ export default class Binding {
 
 		const model = interpolator.model;
 
-		if ( model.isReadonly ) {
+		if ( model.isReadonly && !model.setRoot ) {
 			const keypath = model.getKeypath().replace( /^@/, '' );
 			warnOnceIfDebug( `Cannot use two-way binding on <${element.name}> element: ${keypath} is read-only. To suppress this warning use <${element.name} twoway='false'...>`, { ractive: this.ractive });
 			return false;

--- a/tests/browser/computations.js
+++ b/tests/browser/computations.js
@@ -1099,6 +1099,36 @@ export default function() {
 		r.set( 'baz', 999 );
 	});
 
+	test( `computeds with setters should call the set when updated (#3006)`, t => {
+		t.expect( 7 );
+
+		const obj = { foo: false };
+		let count = 0;
+
+		const r = new Ractive({
+			computed: {
+				foo: {
+					get () {
+						count++;
+						return obj;
+					},
+					set ( val ) {
+						t.ok( val === obj );
+						return;
+					}
+				}
+			}
+		});
+
+		t.equal( r.get( 'foo.foo' ), false );
+		t.equal( count, 1 );
+		t.equal( r.get( 'foo.foo' ), false );
+		t.equal( count, 1 );
+		r.set( 'foo.foo', true );
+		t.equal( r.get( 'foo.foo' ), true );
+		t.equal( count, 2 );
+	});
+
 	// phantom just doesn't execute this test... no error, just nothing
 	// even >>> log messages don't come out. passes chrome and ff, though
 	if ( !/phantom/i.test( navigator.userAgent ) ) {


### PR DESCRIPTION
## Description of the pull request:
This adds tracking for computed children that have a parent computed with a setter. When such children have an update applied, the parent computation setter is called with the current value that has the change applied to the downstream path.

This allows computeds to be used in bindings as long as they have a `set` method.

## Fixes the following issues:
#3006

## Is breaking:
Nope.

## Reviewers:
Sure.