### PR TITLE
handle fire with context as plain object - fixes #3033

### DIFF
--- a/src/Ractive/prototype/fire.js
+++ b/src/Ractive/prototype/fire.js
@@ -8,6 +8,16 @@ export default function Ractive$fire ( eventName, ...args ) {
 		const ctx = Object.create( proto );
 		Object.assign( ctx, proto );
 		return fireEvent( this, eventName, ctx, args );
+	} else if ( args[0] && typeof args[0] === 'object' && args[0].constructor === Object ) {
+		if ( Object.keys(args[0]).length ) { // if first param is a plain object use it as context object
+			const proto = args.shift();
+			const ctx = Object.create( proto );
+			Object.assign( ctx, proto );
+			return fireEvent( this, eventName, ctx, args );
+		} else { // if object has no key that means that event handler will be called without scope
+			args.shift();
+			return fireEvent( this, eventName, null, args );
+		}
 	} else {
 		return fireEvent( this, eventName, Context.forRactive( this ), args );
 	}

--- a/src/events/fireEvent.js
+++ b/src/events/fireEvent.js
@@ -47,8 +47,10 @@ function variants ( name, initial ) {
 export default function fireEvent ( ractive, eventName, context, args = [] ) {
 	if ( !eventName ) { return; }
 
-	context.name = eventName;
-	args.unshift( context );
+	if (context) {
+		context.name = eventName;
+		args.unshift( context );
+	}
 
 	const eventNames = ractive._nsSubs ? variants( eventName, true ) : [ '*', eventName ];
 

--- a/tests/browser/events/method-calls.js
+++ b/tests/browser/events/method-calls.js
@@ -152,7 +152,7 @@ export default function() {
 
 		const component = ractive.findComponent( 'Component' );
 		fire( component.find( '#test' ), 'click' );
-		component.fire( 'bar', 'bar' );
+		component.fire( 'bar', {}, 'bar' );
 	});
 
 	test( 'component "on-" with ...arguments', t => {
@@ -307,5 +307,27 @@ export default function() {
 
 		fire( ractive.find( '#return_zero' ), 'click' );
 		t.ok( !preventedDefault && !stoppedPropagation );
+	});
+
+	test( 'Extend a context event', t => {
+		let customContext = false;
+
+		const ractive = new Ractive({
+			el: fixture,
+			template: `<button on-click='@this.fire("customContextEvent", { customContext: true }, 1)'>{{foo}}</button>`,
+			data: { foo: 0 },
+			on: {
+				customContextEvent: (context, value) => {
+					ractive.set({ foo: value });
+					if (context && context.customContext === true) {
+						customContext = true;
+					}
+				},
+			}
+		});
+
+		fire( ractive.find( 'button' ), 'click' );
+		t.equal( ractive.get( 'foo' ), 1 );
+		t.ok(customContext);
 	});
 }


### PR DESCRIPTION
## Description:
[Fire docs](https://ractive.js.org/api/#ractivefire) says that if context param is an object it should be used as a new context. Or if is an empty object no context param should be passed to event handler.

## Fixes the following issues:
#3033

## Is breaking:
No.

## Additional information
I've modified "method-calls" test on events test suite. I've also added another test which controls that context can be changed in another object.