### PR TITLE
Manage unclosed tag in if-elseif-else section

### DIFF
--- a/tests/helpers/samples/render.js
+++ b/tests/helpers/samples/render.js
@@ -317,6 +317,22 @@ const renderTests = [
 		new_result: '<ul><li>d</li><li>e</li><li>f</li></ul>'
 	},
 	{
+		name: 'Element without close tag inside if-elseif-else section',
+		template: '{{#if who == 1}}<div>1{{elseif who === 2}}<div>2{{else}}<div>else{{/if}}',
+		data:  { who: 1 },
+		result: '<div>1</div>',
+		steps: [
+			{
+				data:  { who: 2 },
+				result: '<div>2</div>'
+			},
+			{
+				data: { who: 3 },
+				result: '<div>else</div>'
+			}
+		]
+	},
+	{
 		name: 'Whitespace is stripped from start and end of templates',
 		template: '     <p>{{content}}</p>      ',
 		data: { content: 'test' },


### PR DESCRIPTION
## Description:
When user leaves _element_ or _component_ tag opened add `elseif` and `else` to implicit closing section tag logic to avoid wrong template render.

At the beginning I was intended to thrown an error for this scenario, however I have found that  a logic for not closed tag is already in place so I've added _elseif_ and _else_ readers to avoid breaking change.

## Fixes the following issues:
#3051

## Is breaking:
No.