### PR TITLE
Allow components to request additional mappings during construct

### DIFF
--- a/src/Ractive/config/runtime-parser.js
+++ b/src/Ractive/config/runtime-parser.js
@@ -16,7 +16,8 @@ const parseOptions = [
 	'stripComments',
 	'contextLines',
 	'parserTransforms',
-	'allowExpressions'
+	'allowExpressions',
+	'attributes'
 ];
 
 const TEMPLATE_INSTRUCTIONS = `Either preparse or use a ractive runtime source that includes the parser. `;

--- a/src/parse/_parse.js
+++ b/src/parse/_parse.js
@@ -72,6 +72,8 @@ const StandardParser = Parser.extend({
 		this.csp = options.csp;
 		this.allowExpressions = options.allowExpressions;
 
+		if ( options.attributes ) this.inTag = true;
+
 		this.transforms = options.transforms || options.parserTransforms;
 		if ( this.transforms ) {
 			this.transforms = this.transforms.concat( shared.defaults.parserTransforms );

--- a/tests/browser/components/data-and-mappings.js
+++ b/tests/browser/components/data-and-mappings.js
@@ -1662,4 +1662,39 @@ export default function() {
 
 		t.htmlEqual( fixture.innerHTML, '0 dave<button>rm</button>' );
 	});
+
+	test( `components can request additional mappings to be made during construction`, t => {
+		const cmp1 = Ractive.extend({
+			template: '{{foo}}{{#with scope}}{{.foo}}{{/with}}',
+			on: {
+				construct () {
+					if ( this.component ) this.component.mappings = [{ t: 13, n: 'scope', f: [{ t: 2, r: '.' }] }];
+				}
+			},
+			data () { return { foo: 'cmp1' }; }
+		});
+
+		const cmp2 = Ractive.extend({
+			template: '{{foo}}{{#with scope}}{{.foo}}{{/with}}',
+			on: {
+				construct () {
+					if ( this.component ) this.component.mappings = 'bind-scope=.';
+				}
+			},
+			data () { return { foo: 'cmp2' }; }
+		});
+
+		const r = new Ractive({
+			target: fixture,
+			template: '<cmp1 /><cmp2 />',
+			data: { foo: ' outer ' },
+			components: { cmp1, cmp2 }
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'cmp1 outer cmp2 outer' );
+
+		r.set( 'foo', ' foo ' );
+
+		t.htmlEqual( fixture.innerHTML, 'cmp1 foo cmp2 foo' );
+	});
 }

--- a/tests/helpers/samples/parse.js
+++ b/tests/helpers/samples/parse.js
@@ -830,6 +830,14 @@ const parseTests = [
 		parsed: {v:4,t:['<!-- comment -->']}
 	},
 	{
+		name: 'attributes mode',
+		template: 'foo=bar baz="{{bat}}" {{#if wat}}on-click="@.foo()"{{/if}} class-bip',
+		options: {
+			attributes: true
+		},
+		parsed: {v:4,t:[{n:'foo',f:'bar',t:13},{n:'baz',f:[{t:2,r:'bat'}],t:13},{t:4,f:[{n:['click'],t:70,f:{r:['@this'],s:'[_0.foo()]'}}],n:50,r:'wat'},{n:'class-bip',t:13}]}
+	},
+	{
 		name: 'unclosed element',
 		template: '<ul><li>',
 		error: `Missing end tags (</li></ul>) at line 1 character 9:


### PR DESCRIPTION
## Description:

This adds an extra step during component setup that checks for `this.mappings`, which is accessible from `this.component.mappings` in the `construct` event, and if present and an array or a string, will install additional mappings before the init of the component. That _sounds_ pretty janky and like a violation of encapsulation, and it is the latter, but it's quite useful when you're processing the component template to split out partials and related attributes for use in the main component template. For instance, in a tab component that allows you to specify a `disabled` attribute that can be a mapping on a particular tab:

```html
<tabs>
  <tab title="tab 1" disabled="{{tab1disabled}}">tab1 content</tab>
  <tab title="tab 2">tab2 content</tab>
</tabs>
```

The template is processed such that during init, the two tabs are turned into an array with inline partials for the content and properties for attributes. In the case of the `title`s, they're static strings, so there's no need to do any mapping or yielding (in the actual component, the titles are _also_ turned into partials and yielded, but that's not relevant to this PR). The `disabled` attribute needs to be used in a conditional though, but there's no way to do so without trying to reverse engineer the reference passed in the interpolator, which is possible with a simple reference but gets very difficult if it happens to be an expression or reference expression. It's also not possible to use a yielded partial as a value, as that doesn't really make sense, so `{{#each tabs}}...{{#if yield .disabled}}...` can't happen.

Creating an additional specifically named mapping can solve this by taking the interpolator passed to the `disabled` attribute, giving it a generated name, requesting that the component create a mapping with the name and interpolator, storing the name on the tab item, and referencing _that_ in the component template using a reference expression e.g. `{{#each tabs}}...{{#if ~/_generated[.disabled]}}...`. The parent instance still controls the expression inside the interpolator, and the child component can use it in its own template.

This also has other uses, such as in #3067, where the event generated inside a component around a yield is trying to also exist within the yielded context. Simply creating a mapping for the scope and wrapping the component template in a `{{#with scope}}` resolves the mismatch of expectations. There's a hacky way to achieve that now that assumes you're familiar with the internals of how components work, but it seems like it would be a useful thing to expose in a slightly less foot-gun-prone way.

I have dogfooded the hacky way quite a bit, and it definitely makes components _much_ more used friendly from the template side. It also helps avoid whole nested component-within-component weirdness that is typically recommended for things like tab components in ractive. I'll hopefully be able to start polishing up and publishing some of these components soon.

### Usage

```js
Ractive.components.aaa = Ractive.extend({
  template: '{{#with scope}}<span on-click="click">{{yield}}</span>{{/with}}',
  on: {
    construct() {
      if (this.component) this.component.mappings = [{ t: 13, n: 'scope', f: [{ t: 2, r: '.' }] }];
    }
  }
});
```

which is the replacement for the example from #3067:

```js
Ractive.components.aaa = Ractive.extend({
	template: '{{#with scope}}<span on-click="click">{{yield}}</span>{{/with}}',
	on: {
		construct() { // this has to be in construct because at config, the mappings are alread in place
			const cmp = this.component; // reference to the component item containing this instance
			if (!cmp) return; // can't mangle the outer template for mappings if not a component
			const tpl = cmp.template.f; // the fragment array for the component template
			const attrs = cmp.template.m ? cmp.template.m.slice() : []; // copy the attrs array so we can safely mangle it
			cmp.template = {
				e: cmp.template.e, // copy the component name
				f: tpl, // copy the fragment
				t: cmp.template.t, // copy the vdom type
				m: attrs // swap in our own attrs array
			} // the shallow copy prevents future renders of the template from being pre-mangled
			
			// create a new mapping on the template
			attrs.push({
				t: 13, // it's an attribute
				n: 'scope', // named scope
				f: [{ // and the content is an interpolator {{.}}
					t: 2,
					r: '.'
				}]});
				
				// now there is effectively a new attr on the component 'scope="{{.}}"'
		}
	}
});
```

If you don't mind parsing at runtime, there's also:

```js
Ractive.components.aaa = Ractive.extend({
  template: '{{#with scope}}<span on-click="click">{{yield}}</span>{{/with}}',
  on: {
    construct() {
      if (this.component) this.component.mappings = 'bind-scope="."';
    }
  }
});
```

## Fixes the following issues:

#3067 

## Is breaking:

No.
