### PR TITLE
Fix memory leaks in ReferenceExpressionProxy

### DIFF
--- a/src/view/resolvers/ReferenceExpressionProxy.js
+++ b/src/view/resolvers/ReferenceExpressionProxy.js
@@ -222,12 +222,20 @@ export default class ReferenceExpressionProxy extends Model {
 	}
 
 	teardown () {
+		if ( this.base ) {
+			this.base.unregister( this.intermediary );
+		}
 		if ( this.model ) {
 			this.model.unregister( this );
 			this.model.unregisterTwowayBinding( this );
 		}
 		if ( this.members ) {
-			this.members.forEach( m => m && m.unregister && m.unregister( this ) );
+			this.members.forEach( m => {
+				if ( m && m.unregister ) {
+					m.unregister( this );
+					m.unregister( this.intermediary );
+				}
+			} );
 		}
 	}
 


### PR DESCRIPTION
## Description:

It appears [the intermediary](https://github.com/ractivejs/ractive/blob/ca46df714c0b67729bd3bb9edcd0cc7466fcdf04/src/view/resolvers/ReferenceExpressionProxy.js#L81), which is registered as a dependency [here](https://github.com/ractivejs/ractive/blob/ca46df714c0b67729bd3bb9edcd0cc7466fcdf04/src/view/resolvers/ReferenceExpressionProxy.js#L117) and [here](https://github.com/ractivejs/ractive/blob/ca46df714c0b67729bd3bb9edcd0cc7466fcdf04/src/view/resolvers/ReferenceExpressionProxy.js#L127) never gets unregistered, which causes the related Models to stick around and results in a significant memory leak.

This PR fixes the problem and doesn't break any tests, but it's been a while since I worked with this part of the codebase so please review before merging.

Note: It seems there are some other leaks too but this is the only one I was able to identify so far.

## Is breaking:
Hopefully not.