### PR TITLE
Computation children should adapt too - fixes #3130

### DIFF
--- a/src/model/ComputationChild.js
+++ b/src/model/ComputationChild.js
@@ -40,6 +40,8 @@ export default class ComputationChild extends Model {
 			this.dirty = false;
 			const parentValue = this.parent.get();
 			this.value = parentValue ? parentValue[ this.key ] : undefined;
+			if ( this.wrapper ) this.newWrapperValue = this.value;
+			this.adapt();
 		}
 
 		return this.value;

--- a/tests/browser/plugins/adaptors/basic.js
+++ b/tests/browser/plugins/adaptors/basic.js
@@ -903,4 +903,37 @@ export default function() {
 
 	});
 
+	test( `children of computations are also adapted (#3130)`, t => {
+		const arr = [ 'hello' ];
+		let count = 0;
+
+		const Adaptor = {
+			filter ( v ) { return typeof v === 'string'; },
+			wrap ( ractive, v ) {
+				return {
+					get () { return v + ' adapted'; },
+					teardown () { count++; }
+				};
+			}
+		};
+
+		const r = new Ractive({
+			target: fixture,
+			template: '{{#each list}}{{.}}{{/each}}',
+			adapt: [ Adaptor ],
+			computed: {
+				list: {
+					get () { return arr; },
+				}
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'hello adapted' );
+
+		arr[0] = 'still';
+		r.update( 'list' );
+
+		t.htmlEqual( fixture.innerHTML, 'still adapted' );
+		t.equal( count, 1 );
+	});
 }


### PR DESCRIPTION
## Description:
This puts the adapt step back into refreshing a computation child value, as it probably got lost somewhere in the massive model shuffle between 0.7 and 0.8.

@fskreuz I _think_ this is the correct way to handle this, but it's been a while since I've spelunked that part of the code.

## Fixes the following issues:
#3130

## Is breaking:
Shouldn't be.