### PR TITLE
Move viewmodel teardown to after destruct - #3131

### DIFF
--- a/src/Ractive/prototype/teardown.js
+++ b/src/Ractive/prototype/teardown.js
@@ -21,7 +21,6 @@ export default function Ractive$teardown () {
 
 export function teardown ( instance, getPromise ) {
 	instance.torndown = true;
-	instance.viewmodel.teardown();
 	instance.fragment.unbind();
 	instance._observers.slice().forEach( cancel );
 
@@ -32,7 +31,11 @@ export function teardown ( instance, getPromise ) {
 	const promise = getPromise();
 
 	teardownHook.fire( instance );
-	promise.then( () => destructHook.fire( instance ) );
+
+	promise.then( () => {
+		destructHook.fire( instance );
+		instance.viewmodel.teardown();
+	});
 
 	return promise;
 }

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -284,7 +284,10 @@ export default class Model extends ModelBase {
 	source () { return this; }
 
 	teardown () {
-		if ( this._link ) this._link.teardown();
+		if ( this._link ) {
+			this._link.teardown();
+			this._link = null;
+		}
 		this.children.forEach( teardown );
 		if ( this.wrapper ) this.wrapper.teardown();
 		if ( this.keypathModel ) this.keypathModel.teardown();

--- a/tests/browser/plugins/adaptors/basic.js
+++ b/tests/browser/plugins/adaptors/basic.js
@@ -152,6 +152,8 @@ export default function() {
 	});
 
 	test( 'Adaptor teardown is called when used in a component (#1190)', t => {
+		const done = t.async();
+
 		function Wrapped () {}
 
 		let torndown = 0;
@@ -183,8 +185,9 @@ export default function() {
 		});
 
 		t.htmlEqual( fixture.innerHTML, 'bar' );
-		ractive.teardown();
-		t.equal( torndown, 1 );
+		ractive.teardown().then( () => {
+			t.equal( torndown, 1 );
+		}).then( done, done );
 	});
 
 


### PR DESCRIPTION
## Description:
If you happen to access a mapped keypath after component teardown, which happens before unrender due to how binding works, then you can accidentally add orphaned deps to the source side of the mapping, which will cause the component and its detached elements to be retained.

This moves viewmodel teardown to after destruct so that if you happen to access mapped paths in unrender or destruct, they won't init new child links after teardown. It also nulls out the _link in the component model during teardown in case it happens to be accessed again after teardown, it won't create a leak.

## Fixes the following issues:
#3131

## Is breaking:
Maybe a little if you require adaptor teardown with the viewmodel to be synchronous for some reason?