### PR TITLE
Children of computation should be unwrapped by `ractive.get()`

### DIFF
--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -40,7 +40,7 @@ export default class Computation extends Model {
 		if ( this.signature.setter ) return this;
 	}
 
-	get ( shouldCapture ) {
+	get ( shouldCapture, opts ) {
 		if ( shouldCapture ) capture( this );
 
 		if ( this.dirty ) {
@@ -53,7 +53,7 @@ export default class Computation extends Model {
 		}
 
 		// if capturing, this value needs to be unwrapped because it's for external use
-		return maybeBind( this, shouldCapture && this.wrapper ? this.wrapperValue : this.value );
+		return maybeBind( this, shouldCapture && this.wrapper && !(opts && opts.unwrap === false) ? this.wrapperValue : this.value );
 	}
 
 	getValue () {

--- a/src/model/ComputationChild.js
+++ b/src/model/ComputationChild.js
@@ -33,7 +33,7 @@ export default class ComputationChild extends Model {
 		}
 	}
 
-	get ( shouldCapture ) {
+	get ( shouldCapture, opts ) {
 		if ( shouldCapture ) capture( this );
 
 		if ( this.dirty ) {
@@ -44,7 +44,7 @@ export default class ComputationChild extends Model {
 			this.adapt();
 		}
 
-		return this.value;
+		return shouldCapture && this.wrapper && !(opts && opts.unwrap === false) ? this.wrapperValue : this.value;
 	}
 
 	handleChange () {


### PR DESCRIPTION
Hello,

This pull request fixes the issue #3137.

## Description:

- The value of computed properties is now correctly unwrapped
- The `unwrap` option is no more ignored for computed property. I don't know why it was ignored before, I guess it was a error.

## Fixes the following issues:

- Issue #3137.

## Is breaking:

I hope it doesn't be breaks anything :crossed_fingers: 
