### PR TITLE
Computed properties are unwrapped by ractive.get() in children components

### DIFF
--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -53,7 +53,7 @@ export default class Computation extends Model {
 		}
 
 		// if capturing, this value needs to be unwrapped because it's for external use
-		return maybeBind( this, shouldCapture && this.wrapper && !(opts && opts.unwrap === false) ? this.wrapperValue : this.value );
+		return maybeBind( this, ( ( opts && 'unwrap' in opts ) ? opts.unwrap !== false : shouldCapture ) && this.wrapper ? this.wrapperValue : this.value, !opts || opts.shouldBind !== false );
 	}
 
 	getValue () {

--- a/src/model/ComputationChild.js
+++ b/src/model/ComputationChild.js
@@ -44,7 +44,7 @@ export default class ComputationChild extends Model {
 			this.adapt();
 		}
 
-		return shouldCapture && this.wrapper && !(opts && opts.unwrap === false) ? this.wrapperValue : this.value;
+		return ( ( opts && 'unwrap' in opts ) ? opts.unwrap !== false : shouldCapture ) && this.wrapper ? this.wrapperValue : this.value;
 	}
 
 	handleChange () {

--- a/src/model/LinkModel.js
+++ b/src/model/LinkModel.js
@@ -67,7 +67,7 @@ export default class LinkModel extends ModelBase {
 			capture( this );
 
 			// may need to tell the target to unwrap
-			opts.unwrap = true;
+			opts.unwrap = 'unwrap' in opts ? opts.unwrap : true;
 		}
 
 		const bind = 'shouldBind' in opts ? opts.shouldBind : true;

--- a/tests/browser/plugins/adaptors/basic.js
+++ b/tests/browser/plugins/adaptors/basic.js
@@ -956,22 +956,35 @@ export default function() {
 		const r = new Ractive({
 			adapt: [ Adaptor ],
 			target: fixture,
-			template: '{{scalar}}, {{#each list}}{{.}}{{/each}}',
+			components: {
+				c: Ractive.extend({
+					template: '{{data}}',
+				}),
+			},
+			template: '{{scalar}}, {{#each list}}{{.}}{{/each}}, <c data={{scalar}} />, <c data={{list.0}} />',
 			computed: {
 				scalar() { return value; },
 				list() { return [value]; },
 			}
 		});
 
+		const children = r.findAllComponents('c');
+
 		t.strictEqual(r.get('scalar'), value, 'the computation should be unwrapped by default');
 		t.strictEqual(r.get('list.0'), value, 'the computation children should be unwrapped by default');
+		t.strictEqual(children[0].get('data'), value, 'the linked computation should be unwrapped by default');
+		t.strictEqual(children[1].get('data'), value, 'the linked computation children should be unwrapped by default');
 
 		t.strictEqual(r.get('scalar', {unwrap: false}), 'hello adapted', 'the computation should be wrapped');
 		t.strictEqual(r.get('list.0', {unwrap: false}), 'hello adapted', 'the computation children should be wrapped');
+		t.strictEqual(children[0].get('data', {unwrap: false}), 'hello adapted', 'the linked computation should be wrapped');
+		t.strictEqual(children[1].get('data', {unwrap: false}), 'hello adapted', 'the linked computation children should be wrapped');
 
 		t.strictEqual(r.get('scalar', {unwrap: true}), 'hello', 'the computation should be unwrapped');
 		t.strictEqual(r.get('list.0', {unwrap: true}), 'hello', 'the computation children should be unwrapped');
+		t.strictEqual(children[0].get('data', {unwrap: true}), 'hello', 'the linked computation should be unwrapped');
+		t.strictEqual(children[1].get('data', {unwrap: true}), 'hello', 'the linked computation children should be unwrapped');
 
-		t.htmlEqual( fixture.innerHTML, 'hello adapted, hello adapted', 'the output should use the wrapped value');
+		t.htmlEqual( fixture.innerHTML, 'hello adapted, hello adapted, hello adapted, hello adapted', 'the output should use the wrapped value');
 	});
 }


### PR DESCRIPTION
Hello,

This pull request fixes the issue #3137 and corrects a logic error added in pull-request #3138.

The previous pull request (#3138) was incomplete: it only resolved the problem when `ractive.get()` was called on a child of a computed property defined in the current component.

## Description

The incorrect behavior described in issue #3137 still existed when a child of a computed property was passed to a child component.

Here is an example where the problem still occurred ([Playground](https://ractive.js.org/playground/?env=docs#N4IgFiBcoE5SBTAJgcwSANCAzlA2uAC6EAO2kA9BQMZIB2AVtgHTUA2A9gK5IBmbAQxgJWHALYUBDAQA8KbAJYAjbBQCOXOgsIUATMwAszAIzrN25mIV1mTEAF0AvlkLwABG4A8iugGs3wmwAvAA6OIQAnmwI2GAICIRhbmDCvKFEpORUtIws7Nx8gsKiElKy8sqqGlo6+kam1RbU2NhJFAB8IXQenkgKAG5uCkjpjYkg7Z4Uff2d3V4zQyNhYwC0vAoyhFzCYZPTA+2YOPAAigCqNcyEMYQAFAAGAMJgCmxIwt0cvG7U4iRcQgCQgKDjdWLcd5uJQINyaADuMAEJBIyDc8Li3WE2xgdDRSgiAQE1BB-REaHuAEoHhg3HdCJS3EF2m5gF0QoQ-nRsIQ3BstjtYUE3EgONQuGIEHRCMwKQBRaKS6UAIQiAEkkHcAORrfk4hBaykAbnZnLBPLc-QEbC4QrcWribE4WpNdFNXItAEEkMjCBwYEzWaaORs2DcA3dLW5GcAAgkdt1BkFk5brbajW5nMHCIjkXSiSSBghaYMY9mOdiE0G3YlaxyKXSY3GcYm3ABqe1uAQ+kg3JAuzMYcu1m5CUXw7p3JuOYeOV0cjkzmtz9k1j28gPCvHwtwAJWJpIQdzZNY53d9kDceDc3t9-rc9iHp5ubEvesFT4XZrEJDBUsI5DVl+HLUJe+6FmSzAIFsUqaiewEjggP6CDcl5asAwA+kCjiOFqs6Up+tZZs+NzIcCCBoRhADECDEmAbiKDyOGeNQIrAgIQQYcwOFuB0GEULR1BgDhWqESB-yAsgl7wXWhCMVSrLNlWeBWjaCD2BmxFfkui7GquHIyjyMAKCScoaNadwwMwGx0EgTz-H+0ratQhqygk2pYQIholmmxb2oQcQMdYvhon8P6AsCoLgmAkJINCsIIkiKLIIa87EMwRkmYQZlcBZfKbPqzDWHiMAABIACoALIADK0g6CBOhwXY9n2on+YF3CkICbgQlwUJcNgsIBbCubJXFqm2qlXSOHpbp0BcVxchsKDMAIgIcDyQi8sKhAwOmICOEAA)):

```js
QUnit.test(`Children of computation should be unwrapped when returned by ractive.get()`, (t) => {
	const fixture = document.getElementById('qunit-fixture');
	const value = 'hello';

	const Adaptor = {
		filter ( v ) { return v === value; },
		wrap ( ractive, v ) {
			return {
				get () { return v + ' adapted'; },
				teardown () { }
			};
		}
	};

	const r = new Ractive({
		adapt: [ Adaptor ],
		el: fixture,
		components: {
			c: Ractive.extend({
				template: '{{data}}'
			}),
		},
		template: '{{#each list}}<c data={{.}} />{{/each}}',
		computed: {
			list() { return [value]; },
		}
	});

	t.strictEqual(r.findComponent('c').get('data'), value, 'the linked computation should be unwrapped');
	t.strictEqual( fixture.innerHTML, 'hello adapted', 'the output should use the wrapped value');
});
```

In this case, an instance of `LinkModel` was created. The `LinkModel` called the method  `ComputationChild.get()` the parameters `shouldCapture` set to `false` and `opts` set to `{unwrap: true}`. 

This resulted in the value not being unwrapped because of a logic error I introduced in `ComputationChild.get()` in my previous pull-request.

This pull request corrects the logic error and adds a unit test to be sure `ractive.get()` has the same behavior regardless of whether it is called from a root component or from a child component.

## Fixes the following issues:

- Issue #3137 
- Corrects a logic error added in pull-request #3138