### PR TITLE
All the computed changes - WIP - RFC

### DIFF
--- a/src/Ractive/config/config.js
+++ b/src/Ractive/config/config.js
@@ -22,6 +22,7 @@ const custom = {
 	computed: config,
 	css: cssConfigurator,
 	data: dataConfigurator,
+	helpers: config,
 	template: templateConfigurator
 };
 

--- a/src/Ractive/config/config.js
+++ b/src/Ractive/config/config.js
@@ -11,8 +11,15 @@ import RactiveProto from '../prototype';
 import { hasOwn, keys } from 'utils/object';
 import { isFunction } from 'utils/is';
 
+const config = {
+	extend: ( Parent, proto, options, Child ) => configure( 'extend', Parent, proto, options, Child ),
+	init: ( Parent, ractive, options ) => configure( 'init', Parent, ractive, options ),
+	reset: ractive => order.filter( c => c.reset && c.reset( ractive ) ).map( c => c.name )
+};
+
 const custom = {
 	adapt: adaptConfigurator,
+	computed: config,
 	css: cssConfigurator,
 	data: dataConfigurator,
 	template: templateConfigurator
@@ -32,12 +39,6 @@ const order = [].concat(
 	custom.template,
 	custom.css
 );
-
-const config = {
-	extend: ( Parent, proto, options, Child ) => configure( 'extend', Parent, proto, options, Child ),
-	init: ( Parent, ractive, options ) => configure( 'init', Parent, ractive, options ),
-	reset: ractive => order.filter( c => c.reset && c.reset( ractive ) ).map( c => c.name )
-};
 
 function configure ( method, Parent, target, options, Child ) {
 	deprecate( options );

--- a/src/Ractive/config/defaults.js
+++ b/src/Ractive/config/defaults.js
@@ -1,3 +1,5 @@
+import { create } from 'utils/object';
+
 export default {
 	// render placement:
 	el:                     void 0,
@@ -21,8 +23,8 @@ export default {
 	contextLines:           0,
 
 	// data & binding:
-	data:                   {},
-	computed:               {},
+	data:                   create( null ),
+	computed:               create( null ),
 	syncComputedChildren:   false,
 	resolveInstanceMembers: true,
 	warnAboutAmbiguity:     false,

--- a/src/Ractive/config/defaults.js
+++ b/src/Ractive/config/defaults.js
@@ -24,6 +24,7 @@ export default {
 
 	// data & binding:
 	data:                   create( null ),
+	helpers:                create( null ),
 	computed:               create( null ),
 	syncComputedChildren:   false,
 	resolveInstanceMembers: true,

--- a/src/Ractive/config/registries.js
+++ b/src/Ractive/config/registries.js
@@ -7,13 +7,15 @@ const registryNames = [
 	'decorators',
 	'easing',
 	'events',
+	'helpers',
 	'interpolators',
 	'partials',
 	'transitions'
 ];
 
 const registriesOnDefaults = [
-	'computed'
+	'computed',
+	'helpers'
 ];
 
 class Registry {

--- a/src/Ractive/config/runtime-parser.js
+++ b/src/Ractive/config/runtime-parser.js
@@ -1,4 +1,4 @@
-import { fromExpression, fromComputationString } from 'parse/utils/createFunction';
+import { fromExpression } from 'parse/utils/createFunction';
 import { doc } from 'config/environment';
 import { fatal } from 'utils/log';
 import { addFunctions } from 'shared/getFunction';
@@ -24,7 +24,6 @@ const TEMPLATE_INSTRUCTIONS = `Either preparse or use a ractive runtime source t
 
 const COMPUTATION_INSTRUCTIONS = `Either include a version of Ractive that can parse or convert your computation strings to functions.`;
 
-
 function throwNoParse ( method, error, instructions ) {
 	if ( !method ) {
 		fatal( `Missing Ractive.parse - cannot parse ${error}. ${instructions}` );
@@ -37,8 +36,11 @@ export function createFunction ( body, length ) {
 }
 
 export function createFunctionFromString ( str, bindTo ) {
-	throwNoParse( fromComputationString, 'compution string "${str}"', COMPUTATION_INSTRUCTIONS );
-	return fromComputationString( str, bindTo );
+	throwNoParse( parse, 'compution string "${str}"', COMPUTATION_INSTRUCTIONS );
+	const tpl = parse( str, { expression: true } );
+	return function () {
+		return tpl.e.apply( bindTo, tpl.r.map( r => bindTo.get( r ) ) );
+	};
 }
 
 const parser = {

--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -8,9 +8,9 @@ import Hook from 'src/events/Hook';
 import subscribe from './helpers/subscribe';
 import Ractive from '../Ractive';
 import { ATTRIBUTE, INTERPOLATOR } from 'config/types';
-import { assign, create, hasOwn, keys } from 'utils/object';
-import { isString, isFunction } from 'utils/is';
-import { splitKeypath } from 'shared/keypaths';
+import { assign, create, hasOwn } from 'utils/object';
+import { isString } from 'utils/is';
+import { compute } from 'src/Ractive/prototype/compute';
 
 const constructHook = new Hook( 'construct' );
 
@@ -76,16 +76,9 @@ export default function construct ( ractive, options ) {
 
 	ractive.viewmodel = viewmodel;
 
-	const computed = ractive.computed;
-	keys( computed ).forEach( k => {
-		if ( isString( computed[k] ) || isFunction( computed[k] ) ) computed[k] = { get: computed[k] };
-
-		if ( splitKeypath( k ).length === 1 ) {
-			viewmodel.compute( k, computed[k] );
-		} else {
-			computed[k].pattern = new RegExp( '^' + k.replace( /\*\*/g, '(.+)' ).replace( /\*/g, '((?:\\.|[^\\.])+)' ) + '$' );
-		}
-	});
+	for ( const k in ractive.computed ) {
+		compute.call( ractive, k, ractive.computed[k] );
+	}
 }
 
 function getAdaptors ( ractive, protoAdapt, options ) {

--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -25,6 +25,11 @@ const registryNames = [
 	'transitions'
 ];
 
+const protoRegistries = [
+	'computed',
+	'helpers'
+];
+
 let uid = 0;
 
 export default function construct ( ractive, options ) {
@@ -51,7 +56,11 @@ export default function construct ( ractive, options ) {
 		ractive[ name ] = assign( create( ractive.constructor[ name ] || null ), options[ name ] );
 	}
 
-	const computed = ractive.computed = assign( create( ractive.constructor.prototype.computed ), options.computed );
+	i = protoRegistries.length;
+	while ( i-- ) {
+		const name = protoRegistries[ i ];
+		ractive[ name ] = assign( create( ractive.constructor.prototype[ name ] ), options[ name ] );
+	}
 
 	if ( ractive._attributePartial ) {
 		ractive.partials['extra-attributes'] = ractive._attributePartial;
@@ -67,6 +76,7 @@ export default function construct ( ractive, options ) {
 
 	ractive.viewmodel = viewmodel;
 
+	const computed = ractive.computed;
 	keys( computed ).forEach( k => {
 		if ( isString( computed[k] ) || isFunction( computed[k] ) ) computed[k] = { get: computed[k] };
 

--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -12,13 +12,13 @@ const configHook = new Hook( 'config' );
 const initHook = new HookQueue( 'init' );
 
 export default function initialise ( ractive, userOptions, options ) {
-	keys( ractive.viewmodel.computations ).forEach( key => {
-		const computation = ractive.viewmodel.computations[ key ];
-
-		if ( hasOwn( ractive.viewmodel.value, key ) ) {
-			computation.set( ractive.viewmodel.value[ key ] );
-		}
-	});
+	// initialize settable computeds
+	const computed = ractive.viewmodel.computed;
+	if ( computed ) {
+		keys( computed ).forEach( k => {
+			if ( !computed[k].isReadonly && k in ractive.viewmodel.value ) computed[k].set( ractive.viewmodel.value[k] );
+		});
+	}
 
 	// init config from Parent and options
 	config.init( ractive.constructor, ractive, userOptions );

--- a/src/Ractive/initialise.js
+++ b/src/Ractive/initialise.js
@@ -6,7 +6,6 @@ import Hook from 'src/events/Hook';
 import HookQueue from 'src/events/HookQueue';
 import Ractive from '../Ractive';
 import subscribe from './helpers/subscribe';
-import { hasOwn, keys } from 'utils/object';
 
 const configHook = new Hook( 'config' );
 const initHook = new HookQueue( 'init' );
@@ -15,9 +14,11 @@ export default function initialise ( ractive, userOptions, options ) {
 	// initialize settable computeds
 	const computed = ractive.viewmodel.computed;
 	if ( computed ) {
-		keys( computed ).forEach( k => {
-			if ( !computed[k].isReadonly && k in ractive.viewmodel.value ) computed[k].set( ractive.viewmodel.value[k] );
-		});
+		for ( const k in computed ) {
+			if ( k in ractive.viewmodel.value && computed[k] && !computed[k].isReadonly ) {
+				computed[k].set( ractive.viewmodel.value[k] );
+			}
+		}
 	}
 
 	// init config from Parent and options

--- a/src/Ractive/prototype.js
+++ b/src/Ractive/prototype.js
@@ -1,6 +1,7 @@
 import add from './prototype/add';
 import animate from './prototype/animate';
 import attachChild from './prototype/attachChild';
+import compute from './prototype/compute';
 import detach from './prototype/detach';
 import detachChild from './prototype/detachChild';
 import find from './prototype/find';
@@ -50,6 +51,7 @@ const proto = {
 	add,
 	animate,
 	attachChild,
+	compute,
 	detach,
 	detachChild,
 	find,

--- a/src/Ractive/prototype/compute.js
+++ b/src/Ractive/prototype/compute.js
@@ -1,0 +1,39 @@
+import { splitKeypath } from 'shared/keypaths';
+import { isString, isFunction } from 'utils/is';
+import runloop from 'src/global/runloop';
+import { fireShuffleTasks } from 'src/model/ModelBase';
+
+export function compute ( path, computed ) {
+	this.computed[ path ] = computed;
+	if ( isString( computed ) || isFunction( computed ) ) computed = this.computed[ path ] = { get: computed };
+
+	const keys = splitKeypath( path );
+	if ( !~path.indexOf( '*' ) ) {
+		const last = keys.pop();
+		return this.viewmodel.joinAll( keys ).compute( last, computed );
+	} else {
+		computed.pattern = new RegExp( '^' + path.replace( /\*\*/g, '(.+)' ).replace( /\*/g, '((?:\\.|[^\\.])+)' ) + '$' );
+	}
+}
+
+export default function Ractive$compute ( path, computed ) {
+	const comp = compute.call( this, path, computed );
+	const promise = runloop.start();
+
+	if ( comp ) {
+		const keys = splitKeypath( path );
+		if ( keys.length === 1 && !comp.isReadonly ) {
+			comp.set( this.viewmodel.value[ keys[0] ] );
+		}
+
+		const first = keys.reduce( ( a, c ) => a && a.childByKey[c], this.viewmodel );
+		if ( first ) {
+			first.rebind( comp, first, false );
+			fireShuffleTasks();
+		}
+	}
+
+	runloop.end();
+
+	return promise;
+}

--- a/src/Ractive/prototype/compute.js
+++ b/src/Ractive/prototype/compute.js
@@ -29,6 +29,7 @@ export default function Ractive$compute ( path, computed ) {
 		const first = keys.reduce( ( a, c ) => a && a.childByKey[c], this.viewmodel );
 		if ( first ) {
 			first.rebind( comp, first, false );
+			if ( first.parent ) delete first.parent.childByKey[ first.key ];
 			fireShuffleTasks();
 		}
 	}

--- a/src/Ractive/prototype/compute.js
+++ b/src/Ractive/prototype/compute.js
@@ -12,13 +12,13 @@ export function compute ( path, computed ) {
 		const last = keys.pop();
 		return this.viewmodel.joinAll( keys ).compute( last, computed );
 	} else {
-		computed.pattern = new RegExp( '^' + path.replace( /\*\*/g, '(.+)' ).replace( /\*/g, '((?:\\.|[^\\.])+)' ) + '$' );
+		computed.pattern = new RegExp( '^' + keys.map( k => k.replace( /\*\*/g, '(.+)' ).replace( /\*/g, '((?:\\.|[^\\.])+)' ) ).join( '\\.' ) + '$' );
 	}
 }
 
 export default function Ractive$compute ( path, computed ) {
-	const comp = compute.call( this, path, computed );
 	const promise = runloop.start();
+	const comp = compute.call( this, path, computed );
 
 	if ( comp ) {
 		const keys = splitKeypath( path );

--- a/src/Ractive/prototype/compute.js
+++ b/src/Ractive/prototype/compute.js
@@ -12,7 +12,7 @@ export function compute ( path, computed ) {
 		const last = keys.pop();
 		return this.viewmodel.joinAll( keys ).compute( last, computed );
 	} else {
-		computed.pattern = new RegExp( '^' + keys.map( k => k.replace( /\*\*/g, '(.+)' ).replace( /\*/g, '((?:\\.|[^\\.])+)' ) ).join( '\\.' ) + '$' );
+		computed.pattern = new RegExp( '^' + keys.map( k => k.replace( /\*\*/g, '(.+)' ).replace( /\*/g, '((?:\\\\.|[^\\.])+)' ) ).join( '\\.' ) + '$' );
 	}
 }
 

--- a/src/extend/_extend.js
+++ b/src/extend/_extend.js
@@ -103,9 +103,8 @@ function extendOne ( Parent, options = {}, Target ) {
 
 	dataConfigurator.extend( Parent, proto, options, Child );
 
-	if ( options.computed ) {
-		proto.computed = assign( create( Parent.prototype.computed ), options.computed );
-	}
+	proto.computed = assign( create( Parent.prototype.computed ), options.computed );
+	proto.helpers = assign( create( Parent.prototype.helpers ), options.helpers );
 
 	return Child;
 }

--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -3,25 +3,19 @@
 
 import { capture, startCapturing, stopCapturing } from 'src/global/capture';
 import { warnIfDebug } from 'utils/log';
-import Model from './Model';
-import { maybeBind } from './ModelBase';
+import Model, { shared } from './Model';
+import { maybeBind, noVirtual } from './ModelBase';
 import ComputationChild from './ComputationChild';
 import { hasConsole } from 'config/environment';
 import { isEqual } from 'utils/is';
 
 export default class Computation extends Model {
-	constructor ( viewmodel, signature, key ) {
-		super( null, null );
+	constructor ( parent, signature, key ) {
+		super( parent, key );
 
-		this.root = this.parent = viewmodel;
 		this.signature = signature;
 
-		this.key = key; // not actually used, but helps with debugging
-		this.isExpression = key && key[0] === '@';
-
 		this.isReadonly = !this.signature.setter;
-
-		this.context = viewmodel.computationContext;
 
 		this.dependencies = [];
 
@@ -61,12 +55,16 @@ export default class Computation extends Model {
 		);
 	}
 
+	getContext () {
+		return this.parent.isRoot ? this.root.ractive : this.parent.get( false, noVirtual );
+	}
+
 	getValue () {
 		startCapturing();
 		let result;
 
 		try {
-			result = this.signature.getter.call( this.context );
+			result = this.signature.getter.call( this.root.ractive, this.getContext() );
 		} catch ( err ) {
 			warnIfDebug( `Failed to compute ${this.getKeypath()}: ${err.message || err}` );
 
@@ -128,7 +126,7 @@ export default class Computation extends Model {
 		while ( i-- ) {
 			if ( this.dependencies[i] ) this.dependencies[i].unregister( this );
 		}
-		if ( this.root.computations[this.key] === this ) delete this.root.computations[this.key];
+		if ( this.parent.computed[this.key] === this ) delete this.parent.computed[this.key];
 		super.teardown();
 	}
 }
@@ -137,3 +135,5 @@ const prototype = Computation.prototype;
 const child = ComputationChild.prototype;
 prototype.handleChange = child.handleChange;
 prototype.joinKey = child.joinKey;
+
+shared.Computation = Computation;

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -7,7 +7,7 @@ import { isArray, isEqual, isNumeric, isObjectLike } from 'utils/is';
 import { handleChange, mark, markForce, marked, teardown } from 'shared/methodCallers';
 import Ticker from 'shared/Ticker';
 import getPrefixer from './helpers/getPrefixer';
-import { escapeKey, unescapeKey } from 'shared/keypaths';
+import { unescapeKey } from 'shared/keypaths';
 import { warnIfDebug } from 'utils/log';
 import { hasOwn, keys } from 'utils/object';
 
@@ -160,7 +160,16 @@ export default class Model extends ModelBase {
 	}
 
 	compute ( key, computed ) {
-		return ( this.computed || ( this.computed = {} ) )[ escapeKey( key ) ] = new shared.Computation( this, getComputationSignature( this.root.ractive, key, computed ), key );
+		const registry = this.computed || ( this.computed = {} );
+
+		if ( registry[key] ) {
+			registry[key].signature = getComputationSignature( this.root.ractive, key, computed );
+			registry[key].mark();
+		} else {
+			registry[key] = new shared.Computation( this, getComputationSignature( this.root.ractive, key, computed ), key );
+		}
+
+		return registry[key];
 	}
 
 	createBranch ( key ) {

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -4,10 +4,11 @@ import { escapeKey, unescapeKey } from 'shared/keypaths';
 import { addToArray, removeFromArray } from 'utils/array';
 import { isArray, isObject, isFunction } from 'utils/is';
 import bind from 'utils/bind';
-import { hasOwn, keys as objectKeys } from 'utils/object';
+import { create, hasOwn, keys as objectKeys } from 'utils/object';
 
 const shuffleTasks = { early: [], mark: [] };
 const registerQueue = { early: [], mark: [] };
+export const noVirtual = { virtual: false };
 
 export default class ModelBase {
 	constructor ( parent ) {
@@ -20,7 +21,6 @@ export default class ModelBase {
 		this.keyModels = {};
 
 		this.bindings = [];
-		this.patternObservers = [];
 
 		if ( parent ) {
 			this.parent = parent;
@@ -97,15 +97,20 @@ export default class ModelBase {
 			return [];
 		}
 
+		const computed = this.computed;
+		if ( computed ) {
+			children.push.apply( children, objectKeys( computed ).map( k => this.joinKey( k ) ) );
+		}
+
 		return children;
 	}
 
 	getVirtual ( shouldCapture ) {
 		const value = this.get( shouldCapture, { virtual: false } );
 		if ( isObject( value ) ) {
-			const result = isArray( value ) ? [] : {};
+			const result = isArray( value ) ? [] : create( null );
 
-			const keys = objectKeys( value );
+			let keys = objectKeys( value );
 			let i = keys.length;
 			while ( i-- ) {
 				const child = this.childByKey[ keys[i] ];
@@ -122,6 +127,14 @@ export default class ModelBase {
 				}
 			}
 
+			if ( this.computed ) {
+				keys = objectKeys( this.computed );
+				i = keys.length;
+				while ( i-- ) {
+					result[ keys[i] ] = this.computed[ keys[i] ].get();
+				}
+			}
+
 			return result;
 		} else return value;
 	}
@@ -129,7 +142,7 @@ export default class ModelBase {
 	has ( key ) {
 		if ( this._link ) return this._link.has( key );
 
-		const value = this.get();
+		const value = this.get( false, noVirtual );
 		if ( !value ) return false;
 
 		key = unescapeKey( key );
@@ -141,6 +154,14 @@ export default class ModelBase {
 			if ( hasOwn( constructor.prototype, key ) ) return true;
 			constructor = constructor.constructor;
 		}
+
+		let computed = this.computed;
+		if ( computed && key in this.computed ) return true;
+
+		computed = this.root.ractive.computed;
+		objectKeys( computed ).forEach( k => {
+			if ( computed[k].pattern && computed[k].pattern.test( this.getKeypath() ) ) return true;
+		});
 
 		return false;
 	}
@@ -159,7 +180,7 @@ export default class ModelBase {
 		let parent = this.parent;
 		const path = startPath || [ this.key ];
 		while ( parent ) {
-			if ( parent.patternObservers.length ) parent.patternObservers.forEach( o => o.notify( path.slice() ) );
+			if ( parent.patterns ) parent.patterns.forEach( o => o.notify( path.slice() ) );
 			path.unshift( parent.key );
 			parent.links.forEach( l => l.notifiedUpstream( path, this.root ) );
 			parent.deps.forEach( d => d.handleChange( path ) );
@@ -213,7 +234,7 @@ export default class ModelBase {
 	}
 
 	registerPatternObserver ( observer ) {
-		this.patternObservers.push( observer );
+		( this.patterns || ( this.patterns = [] ) ).push( observer );
 		this.register( observer );
 	}
 
@@ -234,7 +255,7 @@ export default class ModelBase {
 	}
 
 	unregisterPatternObserver ( observer ) {
-		removeFromArray( this.patternObservers, observer );
+		removeFromArray( this.patterns, observer );
 		this.unregister( observer );
 	}
 

--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -4,7 +4,7 @@ import { escapeKey, unescapeKey } from 'shared/keypaths';
 import { addToArray, removeFromArray } from 'utils/array';
 import { isArray, isObject, isFunction } from 'utils/is';
 import bind from 'utils/bind';
-import { create, hasOwn, keys as objectKeys } from 'utils/object';
+import { create, keys as objectKeys } from 'utils/object';
 
 const shuffleTasks = { early: [], mark: [] };
 const registerQueue = { early: [], mark: [] };
@@ -94,7 +94,7 @@ export default class ModelBase {
 		}
 
 		else if ( value != null ) {
-			return [];
+			children = [];
 		}
 
 		const computed = this.computed;
@@ -146,22 +146,17 @@ export default class ModelBase {
 		if ( !value ) return false;
 
 		key = unescapeKey( key );
-		if ( hasOwn( value, key ) ) return true;
-
-		// We climb up the constructor chain to find if one of them contains the key
-		let constructor = value.constructor;
-		while ( constructor !== Function && constructor !== Array && constructor !== Object ) {
-			if ( hasOwn( constructor.prototype, key ) ) return true;
-			constructor = constructor.constructor;
-		}
+		if ( ( isFunction( value ) || isObject( value ) ) && key in value ) return true;
 
 		let computed = this.computed;
 		if ( computed && key in this.computed ) return true;
 
-		computed = this.root.ractive.computed;
-		objectKeys( computed ).forEach( k => {
-			if ( computed[k].pattern && computed[k].pattern.test( this.getKeypath() ) ) return true;
-		});
+		computed = this.root.ractive && this.root.ractive.computed;
+		if ( computed ) {
+			objectKeys( computed ).forEach( k => {
+				if ( computed[k].pattern && computed[k].pattern.test( this.getKeypath() ) ) return true;
+			});
+		}
 
 		return false;
 	}

--- a/src/model/RootModel.js
+++ b/src/model/RootModel.js
@@ -2,7 +2,7 @@ import { capture } from 'src/global/capture';
 import Model from './Model';
 import { handleChange, mark } from 'shared/methodCallers';
 import RactiveModel from './specials/RactiveModel';
-import SharedModel, { GlobalModel } from './specials/SharedModel';
+import SharedModel, { GlobalModel, SharedModel as SharedBase } from './specials/SharedModel';
 import { splitKeypath, unescapeKey } from 'shared/keypaths';
 import resolveReference from 'src/view/resolvers/resolveReference';
 import noop from 'utils/noop';
@@ -11,7 +11,8 @@ const specialModels = {
 	'@this'( root ) { return root.getRactiveModel(); },
 	'@global'() { return GlobalModel; },
 	'@shared'() { return SharedModel; },
-	'@style'( root ) { return root.getRactiveModel().joinKey( 'cssData' ); }
+	'@style'( root ) { return root.getRactiveModel().joinKey( 'cssData' ); },
+	'@helpers'(root) { return root.getHelpers(); }
 };
 specialModels['@'] = specialModels['@this'];
 
@@ -56,6 +57,11 @@ export default class RootModel extends Model {
 		} else {
 			return this.value;
 		}
+	}
+
+	getHelpers() {
+		if ( !this.helpers ) this.helpers = new SharedBase( this.ractive.helpers, 'helpers' );
+		return this.helpers;
 	}
 
 	getKeypath () {

--- a/src/parse/converters/expressions/primary/readReference.js
+++ b/src/parse/converters/expressions/primary/readReference.js
@@ -9,7 +9,7 @@ const globals = /^(?:Array|console|Date|RegExp|decodeURIComponent|decodeURI|enco
 const keywords = /^(?:break|case|catch|continue|debugger|default|delete|do|else|finally|for|function|if|in|instanceof|new|return|switch|throw|try|typeof|var|void|while|with)$/;
 
 const prefixPattern = /^(?:\@\.|\@|~\/|(?:\^\^\/(?:\^\^\/)*(?:\.\.\/)*)|(?:\.\.\/)+|\.\/(?:\.\.\/)*|\.)/;
-const specials = /^(key|index|keypath|rootpath|this|global|shared|context|event|node|local|style)/;
+const specials = /^(key|index|keypath|rootpath|this|global|shared|context|event|node|local|style|helpers)/;
 
 export default function readReference ( parser ) {
 	let prefix, name, global, reference, lastDotIndex;

--- a/src/parse/utils/createFunction.js
+++ b/src/parse/utils/createFunction.js
@@ -1,5 +1,3 @@
-const pattern = /\$\{([^\}]+)\}/g;
-
 export function fromExpression ( body, length = 0 ) {
 	const args = new Array( length );
 
@@ -13,17 +11,4 @@ export function fromExpression ( body, length = 0 ) {
 	// With this workaround, we get a little more compact:
 	//     function (_0){return _0*2}
 	return new Function( [], `return function (${args.join(',')}){return(${body});};` )();
-}
-
-export function fromComputationString ( str, bindTo ) {
-	let hasThis;
-
-	let functionBody = 'return (' + str.replace( pattern, ( match, keypath ) => {
-		hasThis = true;
-		return `__ractive.get("${keypath}")`;
-	}) + ');';
-
-	if ( hasThis ) functionBody = `var __ractive = this; ${functionBody}`;
-	const fn = new Function( functionBody );
-	return hasThis ? fn.bind( bindTo ) : fn;
 }

--- a/src/view/resolvers/resolveReference.js
+++ b/src/view/resolvers/resolveReference.js
@@ -110,10 +110,21 @@ export default function resolveReference ( fragment, ref ) {
 			return fragment.ractive.constructor._cssModel.joinAll( keys );
 		}
 
+		// @helpers instance model
+		else if ( base === '@helpers' ) {
+			return fragment.ractive.viewmodel.getHelpers().joinAll( keys );
+		}
+
 		// nope
 		else {
 			throw new Error( `Invalid special reference '${base}'` );
 		}
+	}
+
+	// helpers
+	if ( base && !keys.length ) {
+		const helpers = fragment.ractive.viewmodel.getHelpers();
+		if ( helpers.has( base ) ) return helpers.joinKey( base );
 	}
 
 	const context = fragment.findContext();

--- a/tests/browser/computations.js
+++ b/tests/browser/computations.js
@@ -38,7 +38,7 @@ export default function() {
 				number: 10
 			},
 			computed: {
-				answer: '${foo.bar.qux} * ${number}'
+				answer: 'foo.bar.qux * number'
 			}
 		});
 
@@ -63,7 +63,7 @@ export default function() {
 				height: 10
 			},
 			computed: {
-				area: '${width} * ${height}'
+				area: 'width * height'
 			}
 		});
 
@@ -86,7 +86,7 @@ export default function() {
 			},
 			computed: {
 				full: {
-					get: '${first} + " " + ${last}',
+					get: 'first + " " + last',
 					set ( fullname ) {
 						const parts = fullname.split( ' ' );
 
@@ -115,7 +115,7 @@ export default function() {
 		const Box = Ractive.extend({
 			template: '<div style="width: {{width}}px; height: {{height}}px;">{{area}}px squared</div>',
 			computed: {
-				area: '${width} * ${height}'
+				area: 'width * height'
 			}
 		});
 
@@ -140,7 +140,7 @@ export default function() {
 		const Box = Ractive.extend({
 			template: '<div style="width: {{width}}px; height: {{height}}px;">{{area}}px squared</div>',
 			computed: {
-				area: '${width} * ${height}'
+				area: 'width * height'
 			}
 		});
 
@@ -166,8 +166,8 @@ export default function() {
 			template: '{{number}} - {{squared}} - {{cubed}}',
 			data: { number: 5 },
 			computed: {
-				squared: '${number} * ${number}',
-				cubed: '${squared} * ${number}'
+				squared: 'number * number',
+				cubed: 'squared * number'
 			}
 		});
 
@@ -209,7 +209,7 @@ export default function() {
 			el: fixture,
 			template: '{{uppercaseBar}}',
 			computed: {
-				uppercaseBar: '${foo}.bar.toUpperCase()'
+				uppercaseBar: 'foo.bar.toUpperCase()'
 			}
 		});
 
@@ -316,7 +316,7 @@ export default function() {
 					component: Ractive.extend({
 						debug: true,
 						computed: {
-							foo: '${bar}'
+							foo: 'bar'
 						}
 					})
 				}
@@ -366,7 +366,7 @@ export default function() {
 		const Component = Ractive.extend({
 			template: '{{FOO}} {{BAR}}',
 			computed: {
-				FOO: '${foo}.toUpperCase()',
+				FOO: 'foo.toUpperCase()',
 				BAR () {
 					return this.get( 'bar' ).toUpperCase();
 				}
@@ -486,8 +486,8 @@ export default function() {
 				count: 1
 			},
 			computed: {
-				foo: '${bar} + 1',
-				bar: '${count} + 1'
+				foo: 'bar + 1',
+				bar: 'count + 1'
 			}
 		});
 
@@ -513,7 +513,7 @@ export default function() {
 		const Component = Base.extend({
 			template: '{{foo}}',
 			computed: {
-				foo: '${base} + 1'
+				foo: 'base + 1'
 			}
 		});
 
@@ -609,7 +609,7 @@ export default function() {
 				items: [ 1, 2, 3 ]
 			},
 			computed: {
-				count: '${items}.length'
+				count: 'items.length'
 			}
 		});
 
@@ -1058,7 +1058,7 @@ export default function() {
 	test( `computations with dotted names can be accessed (#2807)`, t => {
 		const r = new Ractive({
 			computed: {
-				'foo\\.bar': '${baz} + 1'
+				'foo\\.bar': 'baz + 1'
 			},
 			data: { baz: 1 }
 		});

--- a/tests/browser/computations.js
+++ b/tests/browser/computations.js
@@ -1058,7 +1058,7 @@ export default function() {
 	test( `computations with dotted names can be accessed (#2807)`, t => {
 		const r = new Ractive({
 			computed: {
-				'foo.bar': '${baz} + 1'
+				'foo\\.bar': '${baz} + 1'
 			},
 			data: { baz: 1 }
 		});
@@ -1229,5 +1229,23 @@ export default function() {
 
 		t.equal( arr.length, 2 );
 		t.htmlEqual( fixture.innerHTML, '13' );
+	});
+
+	test( `computeds can contain wildcards for keypath matching fun`, t => {
+		let count = 0;
+
+		new Ractive({
+			target: fixture,
+			template: '{{#each list}}{{.wat}}{{/each}}',
+			computed: {
+				'list.*.wat' ( item ) { count++; return item; }
+			},
+			data: {
+				list: [ 1, 2, 3 ]
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, '123' );
+		t.equal( count, 3 );
 	});
 }

--- a/tests/browser/helpers.js
+++ b/tests/browser/helpers.js
@@ -1,0 +1,85 @@
+import { initModule } from '../helpers/test-config';
+import { test } from 'qunit';
+
+export default function() {
+	initModule( 'helpers.js' );
+
+	test( `helpers are available for use in templates`, t => {
+		new Ractive({
+			target: fixture,
+			template: '{{upper(foo)}}',
+			data: { foo: 'bar' },
+			helpers: {
+				upper ( v ) { return v.toUpperCase(); }
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'BAR' );
+	});
+
+	test( `helpers are inherited`, t => {
+		const cmp1 = Ractive.extend({
+			helpers: {
+				upper ( v ) { return v.toUpperCase(); }
+			}
+		});
+
+		const cmp2 = cmp1.extend({
+			helpers: {}
+		});
+
+		new cmp2({
+			target: fixture,
+			template: '{{upper(foo)}}',
+			data: { foo: 'bar' },
+			helpers: {}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'BAR' );
+	});
+
+	test( `helpers can be overridden down the inheritance line`, t => {
+		const cmp = Ractive.extend({
+			helpers: {
+				fmt ( v ) { return v.toUpperCase(); }
+			}
+		});
+
+		new cmp({
+			target: fixture,
+			template: '{{fmt(foo)}}',
+			data: { foo: 'bar' },
+			helpers: {
+				fmt ( v ) { return v.split( '' ).join( ' ' ); }
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'b a r' );
+	});
+
+	test( `helpers can be accessed via @helpers for api retrieval and update`, t => {
+		const cmp = Ractive.extend({
+			helpers: {
+				fmt1 ( v ) { return v.toUpperCase(); }
+			}
+		});
+		const r = new cmp({
+			target: fixture,
+			template: `{{fmt1(foo) + ' ' + fmt2(foo)}}`,
+			data: { foo: 'bar' },
+			helpers: {
+				fmt2 ( v ) { return v.split( '' ).join( ' ' ); }
+			}
+		});
+
+		t.equal( r.get( '@helpers.fmt1' )( 'asdf' ), 'ASDF' );
+		t.htmlEqual( fixture.innerHTML, 'BAR b a r' );
+
+		cmp.prototype.helpers.fmt1 = function ( v ) { return v.split( '' ).join( ' ' ).toUpperCase(); };
+		r.update( '@helpers.fmt1' );
+		t.htmlEqual( fixture.innerHTML, 'B A R b a r' );
+
+		r.set( '@helpers.fmt1', v => '_' + v );
+		t.htmlEqual( fixture.innerHTML, '_bar b a r' );
+	});
+}

--- a/tests/browser/init/config.js
+++ b/tests/browser/init/config.js
@@ -15,6 +15,7 @@ export default function() {
 			'staticDelimiters',
 			'staticTripleDelimiters',
 			'csp',
+			'helpers',
 			'interpolate',
 			'preserveWhitespace',
 			'sanitize',
@@ -56,6 +57,7 @@ export default function() {
 			'delegate',
 			'delimiters',
 			'el',
+			'helpers',
 			'interpolate',
 			'isolated',
 			'lazy',
@@ -88,6 +90,7 @@ export default function() {
 		];
 
 		const expectedPrototypeRegistries = [
+			'helpers',
 			'computed'
 		];
 

--- a/tests/browser/init/initialisation/data.js
+++ b/tests/browser/init/initialisation/data.js
@@ -124,7 +124,7 @@ export default function() {
 		const ractive = new Ractive({
 			data: { foo: 'bar' },
 			computed: {
-				bizz: '${foo} + "ftw"'
+				bizz: 'foo + "ftw"'
 			},
 			onconfig () {
 				t.equal( this.get( 'foo' ), 'bar' );

--- a/tests/browser/methods/compute.js
+++ b/tests/browser/methods/compute.js
@@ -1,0 +1,24 @@
+import { initModule } from '../../helpers/test-config';
+import { test } from 'qunit';
+
+export default function() {
+	initModule( 'methods/compute.js' );
+
+	test( `computations can be added on the fly using compute`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: '{{comp}}',
+			data: { foo: 'bar' }
+		});
+
+		t.htmlEqual( fixture.innerHTML, '' );
+
+		r.compute( 'comp', () => r.get( 'foo' ) );
+
+		t.htmlEqual( fixture.innerHTML, 'bar' );
+
+		r.set( 'foo', 'baz' );
+
+		t.htmlEqual( fixture.innerHTML, 'baz' );
+	});
+}

--- a/tests/browser/methods/compute.js
+++ b/tests/browser/methods/compute.js
@@ -21,4 +21,24 @@ export default function() {
 
 		t.htmlEqual( fixture.innerHTML, 'baz' );
 	});
+
+	test( `redefining computations on the fly`, t => {
+		const r = new Ractive({
+			target: fixture,
+			template: '{{comp}}',
+			data: {
+				foo: 'hel',
+				bar: 'lo'
+			},
+			computed: {
+				comp: 'foo + bar'
+			}
+		});
+
+		t.htmlEqual( fixture.innerHTML, 'hello' );
+
+		r.compute( 'comp', 'bar + foo' );
+
+		t.htmlEqual( fixture.innerHTML, 'lohel' );
+	});
 }

--- a/tests/browser/methods/compute.js
+++ b/tests/browser/methods/compute.js
@@ -20,6 +20,7 @@ export default function() {
 		r.set( 'foo', 'baz' );
 
 		t.htmlEqual( fixture.innerHTML, 'baz' );
+		t.equal( r.get( 'comp' ), 'baz' );
 	});
 
 	test( `redefining computations on the fly`, t => {

--- a/tests/browser/methods/observe.js
+++ b/tests/browser/methods/observe.js
@@ -831,7 +831,7 @@ export default function() {
 		const ractive = new Ractive({
 			data: { num: 21 },
 			computed: {
-				doubled: '${num}*2'
+				doubled: 'num*2'
 			}
 		});
 
@@ -939,7 +939,7 @@ export default function() {
 			el: fixture,
 			template: `{{ foo + 2 }}`,
 			data: { foo: 1 },
-			computed: { bar: '${foo} + 1'},
+			computed: { bar: 'foo + 1'},
 			oninit () {
 				this.observe( '*', ( n, o, k ) => {
 					t.ok( k[0] !== '@' );
@@ -1911,7 +1911,7 @@ export default function() {
 				foo: ''
 			},
 			computed: {
-				expr: '${foo}'
+				expr: 'foo'
 			}
 		});
 	});


### PR DESCRIPTION
## Description:

This addresses a handful of requests involving computeds starting from at least two years back. It also introduces a number of breaking changes, so it should probably land in a version greater than 0.9.

This PR is not complete. There are a number of open questions, mostly related to nested computations that need to be answered before the test suite can be filled out around all of these changes.

### Helpers

As outlined in a number of issues, many devs simply don't like having functions in their data. I personally find it liberating to be able to call functions that I throw in there and pass around, but I can see where it would be unpleasant for some. To address that, this introduces another registry that starts with `Ractive.defaults.helpers` and is inherited by subsequent extensions and instances. This registry can technically contain anything, but it's meant to hold helper functions, like `upper(str)` and `format(date, 'YYYY/mm/dd')`. The helpers registry is added into the resolution process after prefixed references and before context traversal, so if you have a reference with a single unprefixed key, it will resolve in the helpers registry before looking through data and contexts.

This is only breaking if you happen to have a `helpers` key on one of your components, but otherwise, you can only break stuff by adding to the `helpers` intentionally.

### Nested computations

This feature adds the ability to have computed members at an arbitrary keypath depth - not just at the root. It does so by breaking the current behavior of computed paths e.g. that `foo.bar` as a computed is available as `foo\.bar` in the model and makes it available as the nested `bar` key on the `foo` object - if that object exists.

As it stands currently, the computed registry is only checked the first time a keypath is requested. If there's a match, subsequent requests will turn up the computed and if not, they'll turn up the plain model that maps to the actual data, which may not exists. I think there should probably be a knob to adjust that behavior a bit, like a computed that only applies if there's no underlying value and a computed that _always_ shadows the underlying value.

Building on nested keypaths, this also introduces wildcard computeds, which are similar to pattern observers but with fewer limitations. A single `*` in a computed path will match _one_ key and a `**` will match multiple keys, so `foo.*.bar` will match `foo.1.bar` not `foo.1.baz.bar` and `foo.**.bar` will match `foo.1.bar` and `foo.1.baz.bar`. Multiple wildcards can be used in a single path, including `**.bar` to make `bar` available on _any_ path. __Note__ that matching wildcards is not _terribly_ expensive, but it's also not as cheap as just matching underlying data directly. If you have more than a handful of these, it's going to start having some performance overhead.

Nested computations receive their parent value as the first argument to their getter, followed by their keypath and any wildcard matches. I _think_ it would be useful to give them a context object somewhere in there too, but I'm not sure where or how. I leave that as an open question.

Also open is the question of how to call the setter for a nested computation. Should it be the same signature as the getter, but with the target value first? Should setting a nested value also invalidate the parent model, as that's likely what would be mutated?

### Runtime addition of computeds

You can already add to the `computed` registry of a Ractive instance, but any existing references to the same keypath as the new computed won't use it until they are re-rendered. This adds a new method `compute` to the Ractive prototype that allows you to add a new computed at runtime and have any existing models that match the keypath transfer their deps to the new computed.

The answers to the questions for nested computations will also heavily affect how runtime computations behave. For instance, should there be a flag for wildcard computations that override existing models that match the path with a new computed instance at those paths?

### Stringy computed syntax

The current string syntax for computeds looks something like a string template, but it's definitely not the same thing. Instead the interpolation points in the computed string are turned into `__ractive.get('...')` and a `var __ractive = this;` is added at the beginning. That string is then set as the body of a `new Function`.

This PR drops the manual conversion of the computed string and instead leverages Ractive's expression parser directly. This means that references no longer need to be wrapped in interpolation tags `${ ... }`. A function is still created at runtime.

### Other stuff

As of 0.7, models would walk their constructor chain up to `Object`, `Function`, or `Array` looking for prototype property matches for child keys. This is problematic for the fairly common pattern of using `Object.create(null)` as the root of a prototype hierarchy, where there is no constructor. `Object.getPrototypeOf` is also sufficiently unsupported that it's not really a practical solution, so it's much simpler to just ad an `in` check and let the root prototypes contribute whatever they will too. This is breaking.

## Try it out

A build of this branch is available on npm as `@evs-chris/ractive@1.0.0-wild-compute-001` and https://cdn.jsdelivr.net/npm/@evs-chris/ractive@1.0.0-wild-compute-001/ractive.js.

## Fixes the following issues:

#3120, #2748, #1583

## Is breaking:
Yep.

`computed`s with a `.` require escaping if they're supposed to have a `.` in the keypath. This is more consistent with the rest of the data anyway.

_All_ prototype properties are considered when checking to see if a model contains a value. This means that scoped refs are _much_ more important if you do things like `{{#each items}}{{length}}{{/each}}` where some items have a `length` and some don't. For those that don't, the `length` of the array will be returned because the parent context `items` _does_ have a _length_.

The string version of `computed` syntax changes to match regular old mustache expressions e.g. rather than `${width} * ${height}` you would write `width * height` for an `area` computed. This also opens up template string use in computeds e.g. ```'`the area is ${width * height}`'```. Notice the template string nested in a regular single quoted string. Ractive already supports template strings internally by having the parser transpile them, so the variable references are turned into ractive refs.