### PR TITLE
Calling `ractive.get()` on an attribute set to an expression unwraps the value

### DIFF
--- a/src/view/resolvers/ReferenceExpressionProxy.js
+++ b/src/view/resolvers/ReferenceExpressionProxy.js
@@ -134,7 +134,7 @@ export default class ReferenceExpressionProxy extends Model {
 		if ( !this.dirty ) this.handleChange();
 	}
 
-	get ( shouldCapture ) {
+	get ( shouldCapture, opts ) {
 		if ( this.dirty ) {
 			this.bubble();
 
@@ -155,12 +155,12 @@ export default class ReferenceExpressionProxy extends Model {
 				if ( this.keypathModel ) this.keypathModel.handleChange();
 			}
 
-			this.value = this.model.get( shouldCapture );
+			this.value = this.model.get( shouldCapture, opts );
 			this.dirty = false;
 			this.mark();
 			return this.value;
 		} else {
-			return this.model ? this.model.get( shouldCapture ) : undefined;
+			return this.model ? this.model.get( shouldCapture, opts ) : undefined;
 		}
 	}
 

--- a/tests/browser/plugins/adaptors/basic.js
+++ b/tests/browser/plugins/adaptors/basic.js
@@ -987,4 +987,44 @@ export default function() {
 
 		t.htmlEqual( fixture.innerHTML, 'hello adapted, hello adapted, hello adapted, hello adapted', 'the output should use the wrapped value');
 	});
+
+	test(`Calling "ractive.get()" on an attribute set to an expression should unwrap the value (#3143)`, t => {
+		const value = 'hello';
+
+		const Adaptor = {
+			filter(v) {
+				return v === value;
+			},
+			wrap(ractive, v) {
+				return {
+					get() {
+						return v + ' adapted';
+					},
+					teardown() {},
+				};
+			},
+		};
+
+		const r = new Ractive({
+			adapt: [Adaptor],
+			el: fixture,
+			data: {
+				index: 0,
+				list: [value],
+			},
+			components: {
+				child: Ractive.extend({
+					template: '{{data}}',
+				}),
+			},
+			template: '<child data={{list[index]}} />',
+		});
+		const child = r.findComponent('child');
+
+		t.strictEqual(child.get('data'), value, 'the value should be unwrapped by default');
+		t.strictEqual(child.get('data', { unwrap: true }), value, 'the value should be unwrapped');
+		t.strictEqual(child.get('data', { unwrap: false }), value + ' adapted', 'the value should be wrapped');
+
+		t.htmlEqual(fixture.innerHTML, 'hello adapted', 'the output should use the wrapped value');
+	});
 }


### PR DESCRIPTION
## Description:

This fixes the issue #3143. The issue occurred in class `ReferenceExpressionProxy` in the method `get()` because the options weren't passed to the model.

## Fixes the following issues:

- Issue  #3143

## Is breaking:

Hopefully, nothing.