### PR TITLE
Additional getComponentConstructor() condition

### DIFF
--- a/src/view/items/component/getComponentConstructor.js
+++ b/src/view/items/component/getComponentConstructor.js
@@ -2,7 +2,7 @@ import { noRegistryFunctionReturn } from 'config/errors';
 import { warnIfDebug } from 'utils/log';
 import { findInstance } from 'shared/registry';
 import { hasOwn } from 'utils/object';
-import { isString } from 'utils/is';
+import { isString, isFunction } from 'utils/is';
 
 // finds the component constructor in the registry or view hierarchy registries
 export default function getComponentConstructor ( ractive, name ) {
@@ -13,7 +13,7 @@ export default function getComponentConstructor ( ractive, name ) {
 		Component = instance.components[ name ];
 
 		// if not from Ractive.extend or a Promise, it's a function that should return a constructor
-		if ( Component && !Component.isInstance && !Component.then && typeof Component === 'function' ) {
+		if ( Component && !Component.isInstance && !Component.then && isFunction(Component) ) {
 			// function option, execute and store for reset
 			const fn = Component.bind( instance );
 			fn.isOwner = hasOwn( instance.components, name );

--- a/src/view/items/component/getComponentConstructor.js
+++ b/src/view/items/component/getComponentConstructor.js
@@ -12,8 +12,8 @@ export default function getComponentConstructor ( ractive, name ) {
 	if ( instance ) {
 		Component = instance.components[ name ];
 
-		// if not from Ractive.extend or a Promise, it's a function that shold return a constructor
-		if ( Component && !Component.isInstance && !Component.then ) {
+		// if not from Ractive.extend or a Promise, it's a function that should return a constructor
+		if ( Component && !Component.isInstance && !Component.then && typeof Component === 'function' ) {
 			// function option, execute and store for reset
 			const fn = Component.bind( instance );
 			fn.isOwner = hasOwn( instance.components, name );


### PR DESCRIPTION
## Description:

I've accidentally come across such error:
> TypeError: Component.bind is not a function

I don't know how it actually happened but seems this condition is not cover all cases:

```
// if not from Ractive.extend or a Promise, it's a function that should return a constructor
if ( Component && !Component.isInstance && !Component.then ) {
...
}
```
I think the logic here is not insufficient and we also need to check Component variable type, because if it's not an instance or promise it doesn't mean that it's a function.

## Fixes the following issues:
error above
## Is breaking:
nope