### PR TITLE
Proposal for plugin extension point - RFC - #3178

### DIFF
--- a/src/Ractive.js
+++ b/src/Ractive.js
@@ -15,6 +15,7 @@ import macro from './extend/_macro';
 import parse from './parse/_parse';
 import getContext, { getNodeInfo } from './Ractive/static/getContext';
 import isInstance from './Ractive/static/isInstance';
+import use from './Ractive/static/use';
 import construct from './Ractive/construct';
 import initialise from './Ractive/initialise';
 import { getCSS } from './global/css';
@@ -84,6 +85,7 @@ defineProperties( Ractive, {
 	splitKeypath:     { value: splitKeypath },
 	// sharedSet and styleSet are in _extend because circular refs
 	unescapeKey:      { value: unescapeKey },
+	use:              { value: use },
 
 	// support
 	enhance:          { writable: true, value: false },

--- a/src/Ractive/prototype.js
+++ b/src/Ractive/prototype.js
@@ -43,6 +43,7 @@ import unrender from './prototype/unrender';
 import unshift from './prototype/unshift';
 import update from './prototype/update';
 import updateModel from './prototype/updateModel';
+import use from './prototype/use';
 
 import { defineProperty } from 'utils/object';
 
@@ -94,7 +95,8 @@ const proto = {
 	unrender,
 	unshift,
 	update,
-	updateModel
+	updateModel,
+	use
 };
 
 defineProperty( proto, 'target', {

--- a/src/Ractive/prototype/use.js
+++ b/src/Ractive/prototype/use.js
@@ -1,0 +1,10 @@
+export default function use ( ...plugins ) {
+	plugins.forEach( p => {
+		p({
+			proto: this,
+			Ractive: this.constructor.Ractive,
+			instance: this
+		});
+	});
+	return this;
+}

--- a/src/Ractive/static/use.js
+++ b/src/Ractive/static/use.js
@@ -1,0 +1,10 @@
+export default function use ( ...plugins ) {
+	plugins.forEach( p => {
+		p({
+			proto: this.prototype,
+			Ractive: this.Ractive,
+			instance: this
+		});
+	});
+	return this;
+}

--- a/src/extend/_extend.js
+++ b/src/extend/_extend.js
@@ -8,6 +8,7 @@ import styleSet from '../Ractive/static/styleSet';
 import styleGet from '../Ractive/static/styleGet';
 import sharedSet from '../Ractive/static/sharedSet';
 import sharedGet from '../Ractive/static/sharedGet';
+import use from '../Ractive/static/use';
 import { assign, create, defineProperties, toPairs } from 'utils/object';
 import { isArray, isFunction } from 'utils/is';
 
@@ -64,6 +65,7 @@ function extendOne ( Parent, options = {}, Target ) {
 		extend: { value: extend, writable: true, configurable: true },
 		extendWith: { value: extendWith, writable: true, configurable: true },
 		extensions: { value: [] },
+		use: { value: use },
 
 		isInstance: { value: isInstance },
 

--- a/tests/browser/use.js
+++ b/tests/browser/use.js
@@ -1,0 +1,48 @@
+import { initModule } from '../helpers/test-config';
+import { test } from 'qunit';
+
+export default function() {
+	initModule( 'use.js' );
+
+	test( `Ractive.use gets access to appropriate args`, t => {
+		Ractive.use(({ Ractive, proto, instance }) => {
+			t.ok( Ractive === Ractive );
+			t.ok( proto === Ractive.defaults );
+			t.ok( instance === Ractive );
+		});
+	});
+
+	test( `ractive.use gets access to appropriate args`, t => {
+		const r = new Ractive();
+		r.use(({ Ractive, proto, instance }) => {
+			t.ok( Ractive === Ractive );
+			t.ok( proto === r );
+			t.ok( instance === r );
+		});
+	});
+
+	test( `Component.use gets access to appropriate args`, t => {
+		const cmp = Ractive.extend({
+			decorators: { tmp() {} }
+		});
+
+		cmp.use(({ Ractive, proto, instance }) => {
+			t.ok( Ractive === Ractive );
+			t.ok( proto === cmp.prototype );
+			t.ok( instance === cmp );
+			t.ok( 'tmp' in instance.decorators );
+			proto.foo = 42;
+		});
+
+		const r = new cmp();
+		r.use(({ Ractive, proto, instance }) => {
+			t.ok( Ractive === Ractive );
+			t.ok( proto === r );
+			t.ok( instance === r );
+			t.ok( 'tmp' in instance.decorators );
+			t.equal( r.foo, 42 );
+			proto.foo = 99;
+			t.equal( cmp.prototype.foo, 42 );
+		});
+	});
+}


### PR DESCRIPTION
## Description:
This is my take on the `use` API from #3178. It's super simple and has the following characteristics:

1. The plugin author and user are responsible for config, similar to express middleware e.g. `use(myPlugin(config))` rather than Ractive trying to be the middleman for config.
2. Ractive/Components and instances have their own separate handling so that you can target either with the same plugin without any special casing. The object passed to the plugin currently contains a `target` property, which is the place where any extra methods or properties should go (the prototype or instance), and a `registry` property, which is where any decorators, components, etc should be registered (the constructor or the instance). So you can `target.newMethod = function() {}` and `register.decorators.foo = function(node) {...}`.
3. Multiple plugins can be registered in one go, because in my experience, `Component.use(fade, aceEditor, tabs, table)` is a bit more ergonomic than individual `use`s, though there are some benefits to having explicitly listed individual components.
4. At some point in the future, the object passed in to the plugin function could supply additional info, like whether or not this is server environment. This would also give us a good place to move some of the core APIs, like the transition and adaptor helpers, into core modules that are optional. The only things that use those are plugins, so that may even make a source module build tree-shake-able in the right build env when ractive is part of the bundle.
5. The target of `use` is returned from the function, cause I like the ability to chain methods.

### TODO

* [ ] Tests. I've played with it a bit, and everything looks good. If this looks good, I'll fill out the test suite.

## Fixes the following issues:
#3178

## Is breaking:
No.