### PR TITLE
Custom event plugin init args support

### DIFF
--- a/src/parse/converters/element/readAttribute.js
+++ b/src/parse/converters/element/readAttribute.js
@@ -8,7 +8,7 @@ import flattenExpression from 'parse/utils/flattenExpression';
 import refineExpression from 'parse/utils/refineExpression';
 import { isString } from 'utils/is';
 
-const attributeNamePattern = /^[^\s"'>\/=]+/;
+const attributeNamePattern = /^[^\s"'>\/=(]+/;
 const onPattern = /^on/;
 const eventPattern = /^on-([a-zA-Z\*\.$_]((?:[a-zA-Z\*\.$_0-9\-]|\\-)+))$/;
 const reservedEventNames = /^(?:change|reset|teardown|update|construct|config|init|render|complete|unrender|detach|insert|destruct|attachchild|detachchild)$/;
@@ -234,6 +234,11 @@ export function readAttributeOrDirective ( parser ) {
 	else if ( match = eventPattern.exec( attribute.n ) ) {
 		attribute.n = splitEvent( match[1] );
 		attribute.t = EVENT;
+
+		if ( parser.matchString( '(' ) ) {
+			attribute.a = flattenExpression({ t: ARRAY_LITERAL, m: readExpressionList( parser ) });
+			if ( !parser.matchString( ')' ) ) parser.error( `Expected closing ')'`);
+		}
 
 		parser.inEvent = true;
 

--- a/src/view/items/element/ElementEvents.js
+++ b/src/view/items/element/ElementEvents.js
@@ -55,11 +55,12 @@ class DOMEvent {
 }
 
 class CustomEvent {
-	constructor ( eventPlugin, owner, name ) {
+	constructor ( eventPlugin, owner, name, args ) {
 		this.eventPlugin = eventPlugin;
 		this.owner = owner;
 		this.name = name;
 		this.handler = null;
+		this.args = args;
 	}
 
 	bind () {}
@@ -68,14 +69,14 @@ class CustomEvent {
 		runloop.scheduleTask( () => {
 			const node = this.owner.node;
 
-			this.handler = this.eventPlugin.call( this.owner.ractive, node, ( event = {} ) => {
+			this.handler = this.eventPlugin.apply( this.owner.ractive, [ node, ( event = {} ) => {
 				if ( event.original ) event.event = event.original;
 				else event.original = event.event;
 
 				event.name = this.name;
 				event.node = event.node || node;
 				return directive.fire( event );
-			});
+			} ].concat( this.args || [] ) );
 		});
 	}
 


### PR DESCRIPTION
## Description:
This adds init param support for event plugins - because outside of having a bunch of variations on an event, there's no way to tell the plugin how to behave since the only thing you can pass to the event is what it should do when it fires. This means you can't easily do things like tell a swipe event the threshold distance or bounding coordinate range for firing the event, specify which keys a key event should respond to, tell an event it should never bubble, or specify a custom delay on a hover event for a popover.

Granted some of those aren't too onerous as inputs to a factory method to create event plugins, but the more complex scenarios (swipe events) are where it starts to become painful because for things like a menu pull out, where you only want a small chunk of pixels on the side to be a valid start point for the swipe, and you may also want the plugin to update a keypath with the current relative distance before the event reaches the firing threshold for distance, you start to build up a good handful of variations on the same event installed with different cumbersome names in the instance/component.

As it stands now, this is a net ~18 line change, so it's not particularly heavy, but it also doesn't support things like updating params after the event initializes. It's strictly a one-pass resolution at init, where the args are gathered to pass on to the event plugin. It wouldn't be terribly hard to extend support for arg updates, including a teardown/recreate cycle for plugins that don't supply an update function, but it seems a bit overkill at the moment and can be added without _really_ breaking changes later on.

### Syntax?

The syntax added to the template is a not-particularly-pretty-but-to-the-point `on-event(args,go,here)="@.stillTheAction, called.onFire()"`, where the parens and arg list are entirely optional. If the arg list _is_ preset, they are collected into an array and applied to the custom event constructor after the fire param e.g. `function customEvent(node, fire, args, go, here) { ... }`.

Other considered syntax was `on-event[args,here]="fired"` and `on-event{args,go:'here'}="fired"`, where the former is an array and the latter an object. Of course, whitespace is allowed in there at any point, but editors may or may not get very confused by that. On the plus side, for those emacs users out there, you can always just `C-M-S-t M-S-x sgml-attrs-with-spaces<ret> C-x re-highlight<ret>` 😆

If the parser sees an args list on an event, it collects an array expression into the attribute's new `a` member, which if present, will cause the `EventDirective` VDOM node to evaluate the expression and pass the resulting array on to the plugin.

### Barrier to merge

If there are no objections, I'll probably go ahead and merge this in a day or three because it's fairly light and allows me to handle some of the more complex events that I'm working on right now a bit more gracefully.

## Fixes the following issues:
A few of my own numerous issues 😀, though I suspect anyone wanting to write/use more advanced composite events, like a double tap or swipe events or use many different key events would appreciate this as well.

## Is breaking:
Nope.