### PR TITLE
Make sure progressive enhancement works with aliases

### DIFF
--- a/src/view/items/Alias.js
+++ b/src/view/items/Alias.js
@@ -33,9 +33,9 @@ export default class Alias extends ContainerItem {
     this.fragment.bind();
   }
 
-  render(target) {
+  render(target, occupants) {
     this.rendered = true;
-    if (this.fragment) this.fragment.render(target);
+    if (this.fragment) this.fragment.render(target, occupants);
   }
 
   unbind() {

--- a/tests/browser/render/enhance.js
+++ b/tests/browser/render/enhance.js
@@ -611,4 +611,21 @@ export default function() {
     t.ok(host.find('div') === div);
     t.ok(host.find('div').childNodes[0] === text);
   });
+
+  test('enhancement works with aliases', t => {
+    fixture.innerHTML = '<span>Hello!</span>';
+    const span = fixture.childNodes[0];
+
+    const ractive = new Ractive({
+      el: fixture,
+      template: `
+        {{#with 'Hello!' as greet}}
+          <span>{{greet}}</span>
+        {{/with}}`,
+      enhance: true
+    });
+
+    t.htmlEqual(fixture.innerHTML, '<span>Hello!</span>');
+    t.ok(span === ractive.find('span'));
+  });
 }


### PR DESCRIPTION
## Description:

The function `render` of class `Alias` does not take `occupants` as an argument. In order to make progressive enhancement work, it needs to do so. (I hope I'm not missing some bigger picture.)

## Is breaking:

Should not break anything.