### PR TITLE
Fix enhance & append conflict check

### DIFF
--- a/src/Ractive/config/config.js
+++ b/src/Ractive/config/config.js
@@ -67,7 +67,7 @@ function configure(method, Parent, target, options, Child) {
   }
 
   // disallow combination of `append` and `enhance`
-  if (options.append && options.enhance) {
+  if (target.append && target.enhance) {
     throw new Error('Cannot use append and enhance at the same time');
   }
 

--- a/src/Ractive/config/defaults.js
+++ b/src/Ractive/config/defaults.js
@@ -5,6 +5,7 @@ export default {
   el: void 0,
   append: false,
   delegate: true,
+  enhance: false,
 
   // template:
   template: null,


### PR DESCRIPTION
## Description:

**Preface:** We should not use `enhance: true` and `append: true` at the same time, so Ractive checks for this case and throws an error if we misbehave.

However, if we use `Ractive.defaults.enhance = true;` and create a Ractive instance with `append: true`, Ractive fails to throw an error.

That's because [here](https://github.com/ractivejs/ractive/blob/ff430f552d23ab9ea2ce256e9408de3e9c47921c/src/Ractive/config/config.js#L70)

```js
// disallow combination of `append` and `enhance`
if (options.append && options.enhance) {
  throw new Error('Cannot use append and enhance at the same time');
}
```
we're using the `options` object to check for the conflicting case. I guess we should use `target` instead of `options` to do this.

## Is breaking:

It *was* breaking the `Cannot use append and enhance at the same time` test in `enhance.js` because `options.enhance` was not getting copied into `target`. And that's because the `defaults` object does not include `enhance`. That's why I added that in 4bdefbd.