### PR TITLE
Add support for auto shuffling at the iterative block level

### DIFF
--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -17,6 +17,7 @@ export default class Computation extends Model {
     this.signature = signature;
 
     this.isReadonly = !this.signature.setter;
+    this.isComputed = true;
 
     this.dependencies = [];
 

--- a/src/model/ComputationChild.js
+++ b/src/model/ComputationChild.js
@@ -9,6 +9,7 @@ export default class ComputationChild extends Model {
 
     this.isReadonly = !this.root.ractive.syncComputedChildren;
     this.dirty = true;
+    this.isComputed = true;
   }
 
   get setRoot() {

--- a/src/shared/Context.js
+++ b/src/shared/Context.js
@@ -34,6 +34,8 @@ class ContextData extends Model {
   getKeypath() {
     return '@context.data';
   }
+
+  rebound() {}
 }
 
 export default class Context {

--- a/src/shared/methodCallers.js
+++ b/src/shared/methodCallers.js
@@ -22,9 +22,6 @@ export function marked(x) {
 export function markedAll(x) {
   x.markedAll();
 }
-export function rebound(x) {
-  x.rebound();
-}
 export function render(x) {
   x.render();
 }

--- a/src/shared/methodCallers.js
+++ b/src/shared/methodCallers.js
@@ -22,6 +22,9 @@ export function marked(x) {
 export function markedAll(x) {
   x.markedAll();
 }
+export function rebound(x) {
+  x.rebound();
+}
 export function render(x) {
   x.render();
 }

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -5,6 +5,7 @@ import { getContext, findParentWithContext } from 'shared/getRactiveContext';
 import {
   bind,
   destroyed,
+  rebound,
   shuffled,
   toEscapedString,
   toString,
@@ -222,6 +223,10 @@ export default class Fragment {
 
   rebind(next) {
     this.context = next;
+  }
+
+  rebound() {
+    this.items.forEach(rebound);
   }
 
   render(target, occupants) {

--- a/src/view/Fragment.js
+++ b/src/view/Fragment.js
@@ -5,7 +5,6 @@ import { getContext, findParentWithContext } from 'shared/getRactiveContext';
 import {
   bind,
   destroyed,
-  rebound,
   shuffled,
   toEscapedString,
   toString,
@@ -225,8 +224,12 @@ export default class Fragment {
     this.context = next;
   }
 
-  rebound() {
-    this.items.forEach(rebound);
+  rebound(update) {
+    this.items.forEach(x => x.rebound(update));
+    if (update) {
+      if (this.rootModel) this.rootModel.applyValue(this.context.getKeypath(this.ractive.root));
+      if (this.pathModel) this.pathModel.applyValue(this.context.getKeypath());
+    }
   }
 
   render(target, occupants) {

--- a/src/view/RepeatedFragment.js
+++ b/src/view/RepeatedFragment.js
@@ -17,6 +17,7 @@ import { getContext } from 'shared/getRactiveContext';
 import { keys } from 'utils/object';
 import KeyModel from 'src/model/specials/KeyModel';
 import { splitKeypath } from '../shared/keypaths';
+import resolve from './resolvers/resolve';
 
 const keypathString = /^"(\\"|[^"])+"$/;
 
@@ -60,9 +61,9 @@ export default class RepeatedFragment {
     this.bound = true;
     const value = context.get();
 
-    this.aliases = this.owner.template.z && this.owner.template.z.slice();
+    const aliases = (this.aliases = this.owner.template.z && this.owner.template.z.slice());
 
-    const shuffler = this.aliases && this.aliases.find(a => a.n === 'shuffle');
+    const shuffler = aliases && aliases.find(a => a.n === 'shuffle');
     if (shuffler && shuffler.x && shuffler.x.x) {
       if (shuffler.x.x.s === 'true') this.shuffler = true;
       else if (keypathString.test(shuffler.x.x.s))
@@ -70,6 +71,22 @@ export default class RepeatedFragment {
     }
 
     if (this.shuffler) this.values = shuffleValues(this, this.shuffler);
+
+    if (this.source) this.source.model.unbind(this.source);
+    const source = context.isComputed && aliases && aliases.find(a => a.n === 'source');
+    if (source && source.x && source.x.r) {
+      const model = resolve(this, source.x);
+      this.source = {
+        handleChange() {},
+        rebind(next) {
+          this.model.unregister(this);
+          this.model = next;
+          next.register(this);
+        }
+      };
+      this.source.model = model;
+      model.register(this.source);
+    }
 
     // {{#each array}}...
     if ((this.isArray = isArray(value))) {
@@ -105,7 +122,7 @@ export default class RepeatedFragment {
     if (!this.bubbled) this.bubbled = [];
     this.bubbled.push(index);
 
-    this.owner.bubble();
+    if (!this.rebounding) this.owner.bubble();
   }
 
   createIteration(key, index) {
@@ -174,16 +191,17 @@ export default class RepeatedFragment {
 
   rebind(next) {
     this.context = next;
+    if (this.source) return;
     this.iterations.forEach(fragment => {
       swizzleFragment(this, fragment, fragment.key, fragment.index);
     });
   }
 
-  rebound() {
+  rebound(update) {
     this.context = this.owner.model;
     this.iterations.forEach((f, i) => {
-      f.context = this.context.joinKey(i);
-      f.rebound();
+      f.context = contextFor(this, f, i);
+      f.rebound(update);
     });
   }
 
@@ -236,6 +254,7 @@ export default class RepeatedFragment {
 
   unbind() {
     this.bound = false;
+    if (this.source) this.source.model.unregister(this.source);
     this.iterations.forEach(unbind);
     return this;
   }
@@ -276,6 +295,19 @@ export default class RepeatedFragment {
       let i;
 
       if ((this.isArray = isArray(value))) {
+        // if there's a source to map back to, make sure everything stays bound correctly
+        if (this.source) {
+          this.rebounding = 1;
+          const source = this.source.model.get();
+          this.iterations.forEach((f, c) => {
+            if (c < value.length && f.lastValue !== value[c] && ~(i = source.indexOf(value[c]))) {
+              swizzleFragment(this, f, c, c);
+              f.rebound(true);
+            }
+          });
+          this.rebounding = 0;
+        }
+
         if (wasArray) {
           reset = false;
           if (this.iterations.length > value.length) {
@@ -393,8 +425,9 @@ export default class RepeatedFragment {
     const len = (this.length = this.context.get().length);
     const prev = this.previousIterations;
     const iters = this.iterations;
+    const value = this.context.get();
     const stash = {};
-    let idx, dest, pos, next, anchor;
+    let idx, dest, pos, next, anchor, rebound;
 
     const map = new Array(newIndices.length);
     newIndices.forEach((e, i) => (map[e] = i));
@@ -405,6 +438,7 @@ export default class RepeatedFragment {
     while (idx < len) {
       dest = newIndices[pos];
       next = null;
+      rebound = false;
 
       if (dest === -1) {
         // drop it like it's hot
@@ -422,6 +456,7 @@ export default class RepeatedFragment {
           anchor = (anchor && parentNode && anchor.firstNode()) || nextNode;
 
           if (next) {
+            rebound = this.source && next.lastValue !== value[idx];
             swizzleFragment(this, next, idx, idx);
             if (parentNode) parentNode.insertBefore(next.detach(), anchor);
           } else {
@@ -446,6 +481,7 @@ export default class RepeatedFragment {
             parentNode.insertBefore(docFrag, anchor);
           }
         } else if (pos !== idx || stash[idx]) {
+          rebound = this.source && next.lastValue !== value[idx];
           swizzleFragment(this, next, idx, idx);
           if (stash[idx] && parentNode) parentNode.insertBefore(next.detach(), anchor);
         }
@@ -455,8 +491,8 @@ export default class RepeatedFragment {
       }
 
       if (next && isObjectType(next)) {
-        if (next.shouldRebind) {
-          next.rebound();
+        if (next.shouldRebind || rebound) {
+          next.rebound(rebound);
           next.shouldRebind = 0;
         }
         next.update();
@@ -512,11 +548,12 @@ function nextRendered(start, newIndices, frags) {
 }
 
 function swizzleFragment(section, fragment, key, idx) {
-  const model = section.context ? section.context.joinKey(key) : undefined;
+  const model = section.context ? contextFor(section, fragment, key) : undefined;
 
   fragment.key = key;
   fragment.index = idx;
   fragment.context = model;
+  if (section.source) fragment.lastValue = model && model.get();
 
   if (fragment.idxModel) fragment.idxModel.applyValue(idx);
   if (fragment.keyModel) fragment.keyModel.applyValue(key);
@@ -539,4 +576,15 @@ function shuffleValues(section, shuffler) {
   } else {
     return section.context.get().map(v => shuffler.reduce((a, c) => a && a[c], v));
   }
+}
+
+function contextFor(section, fragment, key) {
+  if (section.source) {
+    let idx;
+    const source = section.source.model.get();
+    if (source.indexOf && ~(idx = source.indexOf(section.context.joinKey(key).get())))
+      return section.source.model.joinKey(idx);
+  }
+
+  return section.context.joinKey(key);
 }

--- a/src/view/items/Alias.js
+++ b/src/view/items/Alias.js
@@ -31,10 +31,10 @@ export default class Alias extends ContainerItem {
     this.fragment.bind();
   }
 
-  rebound() {
+  rebound(update) {
     const aliases = this.fragment.aliases;
     for (const k in aliases) {
-      if (aliases[k].rebound) aliases[k].rebound();
+      if (aliases[k].rebound) aliases[k].rebound(update);
       else {
         aliases[k].unreference();
         aliases[k] = 0;
@@ -43,7 +43,7 @@ export default class Alias extends ContainerItem {
 
     resolveAliases(this.template.z, this.up, aliases);
 
-    if (this.fragment) this.fragment.rebound();
+    if (this.fragment) this.fragment.rebound(update);
   }
 
   render(target, occupants) {

--- a/src/view/items/Alias.js
+++ b/src/view/items/Alias.js
@@ -2,18 +2,16 @@ import Fragment from '../Fragment';
 import { ContainerItem } from './shared/Item';
 import resolve from '../resolvers/resolve';
 
-export function resolveAliases(aliases, fragment) {
-  const resolved = {};
-
+export function resolveAliases(aliases, fragment, dest = {}) {
   for (let i = 0; i < aliases.length; i++) {
-    resolved[aliases[i].n] = resolve(fragment, aliases[i].x);
+    if (!dest[aliases[i].n]) {
+      const m = resolve(fragment, aliases[i].x);
+      dest[aliases[i].n] = m;
+      m.reference();
+    }
   }
 
-  for (const k in resolved) {
-    resolved[k].reference();
-  }
-
-  return resolved;
+  return dest;
 }
 
 export default class Alias extends ContainerItem {
@@ -31,6 +29,21 @@ export default class Alias extends ContainerItem {
 
     this.fragment.aliases = resolveAliases(this.template.z, this.up);
     this.fragment.bind();
+  }
+
+  rebound() {
+    const aliases = this.fragment.aliases;
+    for (const k in aliases) {
+      if (aliases[k].rebound) aliases[k].rebound();
+      else {
+        aliases[k].unreference();
+        aliases[k] = 0;
+      }
+    }
+
+    resolveAliases(this.template.z, this.up, aliases);
+
+    if (this.fragment) this.fragment.rebound();
   }
 
   render(target, occupants) {

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -1,6 +1,13 @@
 import runloop from 'src/global/runloop';
 import { updateAnchors } from 'shared/anchors';
-import { bind, render as callRender, unbind, unrender, update } from 'shared/methodCallers';
+import {
+  bind,
+  rebound,
+  render as callRender,
+  unbind,
+  unrender,
+  update
+} from 'shared/methodCallers';
 import { teardown } from 'src/Ractive/prototype/teardown';
 import getRactiveContext from 'shared/getRactiveContext';
 import { warnIfDebug } from 'utils/log';
@@ -211,6 +218,10 @@ export default class Component extends Item {
   getContext(...assigns) {
     assigns.unshift(this.instance);
     return getRactiveContext.apply(null, assigns);
+  }
+
+  rebound() {
+    this.attributes.forEach(rebound);
   }
 
   render(target, occupants) {

--- a/src/view/items/Component.js
+++ b/src/view/items/Component.js
@@ -1,13 +1,6 @@
 import runloop from 'src/global/runloop';
 import { updateAnchors } from 'shared/anchors';
-import {
-  bind,
-  rebound,
-  render as callRender,
-  unbind,
-  unrender,
-  update
-} from 'shared/methodCallers';
+import { bind, render as callRender, unbind, unrender, update } from 'shared/methodCallers';
 import { teardown } from 'src/Ractive/prototype/teardown';
 import getRactiveContext from 'shared/getRactiveContext';
 import { warnIfDebug } from 'utils/log';
@@ -220,8 +213,8 @@ export default class Component extends Item {
     return getRactiveContext.apply(null, assigns);
   }
 
-  rebound() {
-    this.attributes.forEach(rebound);
+  rebound(update) {
+    this.attributes.forEach(x => x.rebound(update));
   }
 
   render(target, occupants) {

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -6,7 +6,7 @@ import { escapeHtml, voidElementNames } from 'utils/html';
 import { createElement, detachNode, matches, safeAttributeString } from 'utils/dom';
 import runloop from 'src/global/runloop';
 import Context from 'shared/Context';
-import { bind, destroyed, rebound, render, unbind, update } from 'shared/methodCallers';
+import { bind, destroyed, render, unbind, update } from 'shared/methodCallers';
 import { ContainerItem } from './shared/Item';
 import Fragment from '../Fragment';
 import ConditionalAttribute from './element/ConditionalAttribute';
@@ -261,10 +261,10 @@ export default class Element extends ContainerItem {
     }
   }
 
-  rebound() {
-    super.rebound();
-    if (this.attributes) this.attributes.forEach(rebound);
-    if (this.binding) this.binding.rebound();
+  rebound(update) {
+    super.rebound(update);
+    if (this.attributes) this.attributes.forEach(x => x.rebound(update));
+    if (this.binding) this.binding.rebound(update);
   }
 
   render(target, occupants) {

--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -6,7 +6,7 @@ import { escapeHtml, voidElementNames } from 'utils/html';
 import { createElement, detachNode, matches, safeAttributeString } from 'utils/dom';
 import runloop from 'src/global/runloop';
 import Context from 'shared/Context';
-import { bind, destroyed, render, unbind, update } from 'shared/methodCallers';
+import { bind, destroyed, rebound, render, unbind, update } from 'shared/methodCallers';
 import { ContainerItem } from './shared/Item';
 import Fragment from '../Fragment';
 import ConditionalAttribute from './element/ConditionalAttribute';
@@ -259,6 +259,12 @@ export default class Element extends ContainerItem {
       this.binding.bind();
       if (this.rendered) this.binding.render();
     }
+  }
+
+  rebound() {
+    super.rebound();
+    if (this.attributes) this.attributes.forEach(rebound);
+    if (this.binding) this.binding.rebound();
   }
 
   render(target, occupants) {

--- a/src/view/items/Partial.js
+++ b/src/view/items/Partial.js
@@ -113,6 +113,26 @@ assign(proto, {
     this.bubble();
   },
 
+  rebound() {
+    const aliases = this.fragment && this.fragment.aliases;
+    if (aliases) {
+      for (const k in aliases) {
+        if (aliases[k].rebound) aliases[k].rebound();
+        else {
+          aliases[k].unreference();
+          aliases[k] = 0;
+        }
+      }
+      if (this.template.z) {
+        resolveAliases(this.template.z, this.containerFragment || this.up, aliases);
+      }
+    }
+    if (this._attrs) {
+      keys(this._attrs).forEach(k => this._attrs[k].rebound());
+    }
+    MustacheContainer.prototype.rebound.call(this);
+  },
+
   refreshAttrs() {
     keys(this._attrs).forEach(k => {
       this.handle.attributes[k] = this._attrs[k].valueOf();

--- a/src/view/items/Partial.js
+++ b/src/view/items/Partial.js
@@ -113,11 +113,11 @@ assign(proto, {
     this.bubble();
   },
 
-  rebound() {
+  rebound(update) {
     const aliases = this.fragment && this.fragment.aliases;
     if (aliases) {
       for (const k in aliases) {
-        if (aliases[k].rebound) aliases[k].rebound();
+        if (aliases[k].rebound) aliases[k].rebound(update);
         else {
           aliases[k].unreference();
           aliases[k] = 0;
@@ -128,9 +128,9 @@ assign(proto, {
       }
     }
     if (this._attrs) {
-      keys(this._attrs).forEach(k => this._attrs[k].rebound());
+      keys(this._attrs).forEach(k => this._attrs[k].rebound(update));
     }
-    MustacheContainer.prototype.rebound.call(this);
+    MustacheContainer.prototype.rebound.call(this, update);
   },
 
   refreshAttrs() {

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -82,18 +82,24 @@ export default class Section extends MustacheContainer {
     }
   }
 
-  rebound() {
+  rebound(update) {
     if (this.model) {
-      if (this.model.rebound) this.model.rebound();
+      if (this.model.rebound) this.model.rebound(update);
       else {
         super.unbind();
         super.bind();
-        if (this.sectionType === SECTION_WITH || this.sectionType === SECTION_IF_WITH) {
+        if (
+          this.sectionType === SECTION_WITH ||
+          this.sectionType === SECTION_IF_WITH ||
+          this.sectionType === SECTION_EACH
+        ) {
           if (this.fragment) this.fragment.rebind(this.model);
         }
+
+        if (update) this.bubble();
       }
     }
-    if (this.fragment) this.fragment.rebound();
+    if (this.fragment) this.fragment.rebound(update);
   }
 
   render(target, occupants) {

--- a/src/view/items/Section.js
+++ b/src/view/items/Section.js
@@ -82,6 +82,20 @@ export default class Section extends MustacheContainer {
     }
   }
 
+  rebound() {
+    if (this.model) {
+      if (this.model.rebound) this.model.rebound();
+      else {
+        super.unbind();
+        super.bind();
+        if (this.sectionType === SECTION_WITH || this.sectionType === SECTION_IF_WITH) {
+          if (this.fragment) this.fragment.rebind(this.model);
+        }
+      }
+    }
+    if (this.fragment) this.fragment.rebound();
+  }
+
   render(target, occupants) {
     this.rendered = true;
     if (this.fragment) this.fragment.render(target, occupants);

--- a/src/view/items/component/Mapping.js
+++ b/src/view/items/component/Mapping.js
@@ -41,12 +41,12 @@ export default class Mapping extends Item {
     }
   }
 
-  rebound() {
-    if (this.boundFragment) this.boundFragment.rebound();
+  rebound(update) {
+    if (this.boundFragment) this.boundFragment.rebound(update);
     if (this.link) {
       this.model = resolve(this.up, this.template.f[0]);
-      const viewmodel = this.element.instance.viewmodel;
-      viewmodel.joinAll(splitKeypath(this.name)).link(this.model, this.name, { mapping: true });
+      const model = this.element.instance.viewmodel.joinAll(splitKeypath(this.name));
+      model.link(this.model, this.name, { mapping: true });
     }
   }
 

--- a/src/view/items/component/Mapping.js
+++ b/src/view/items/component/Mapping.js
@@ -41,6 +41,15 @@ export default class Mapping extends Item {
     }
   }
 
+  rebound() {
+    if (this.boundFragment) this.boundFragment.rebound();
+    if (this.link) {
+      this.model = resolve(this.up, this.template.f[0]);
+      const viewmodel = this.element.instance.viewmodel;
+      viewmodel.joinAll(splitKeypath(this.name)).link(this.model, this.name, { mapping: true });
+    }
+  }
+
   render() {}
 
   unbind() {

--- a/src/view/items/element/Decorator.js
+++ b/src/view/items/element/Decorator.js
@@ -67,6 +67,11 @@ export default class Decorator {
     if (!safe) this.bubble();
   }
 
+  rebound() {
+    teardownArgsFn(this, this.template);
+    setupArgsFn(this, this.template, this.up, { register: true });
+  }
+
   render() {
     this.shouldDestroy = false;
     if (this.handle) this.unrender();

--- a/src/view/items/element/Decorator.js
+++ b/src/view/items/element/Decorator.js
@@ -67,9 +67,10 @@ export default class Decorator {
     if (!safe) this.bubble();
   }
 
-  rebound() {
+  rebound(update) {
     teardownArgsFn(this, this.template);
     setupArgsFn(this, this.template, this.up, { register: true });
+    if (update) this.bubble();
   }
 
   render() {

--- a/src/view/items/element/binding/Binding.js
+++ b/src/view/items/element/binding/Binding.js
@@ -81,7 +81,9 @@ export default class Binding {
   }
 
   rebound() {
+    if (this.model) this.model.unregisterTwowayBinding(this);
     this.model = this.attribute.interpolator.model;
+    this.model.registerTwowayBinding(this);
   }
 
   render() {

--- a/src/view/items/element/binding/Binding.js
+++ b/src/view/items/element/binding/Binding.js
@@ -80,6 +80,10 @@ export default class Binding {
     }
   }
 
+  rebound() {
+    this.model = this.attribute.interpolator.model;
+  }
+
   render() {
     this.node = this.element.node;
     this.node._ractive.binding = this;

--- a/src/view/items/element/binding/RadioNameBinding.js
+++ b/src/view/items/element/binding/RadioNameBinding.js
@@ -61,6 +61,11 @@ export default class RadioNameBinding extends Binding {
     this.updateName();
   }
 
+  rebound() {
+    super.rebound();
+    this.updateName();
+  }
+
   render() {
     super.render();
 

--- a/src/view/items/element/binding/RadioNameBinding.js
+++ b/src/view/items/element/binding/RadioNameBinding.js
@@ -61,8 +61,8 @@ export default class RadioNameBinding extends Binding {
     this.updateName();
   }
 
-  rebound() {
-    super.rebound();
+  rebound(update) {
+    super.rebound(update);
     this.updateName();
   }
 

--- a/src/view/items/shared/Item.js
+++ b/src/view/items/shared/Item.js
@@ -36,6 +36,10 @@ export default class Item {
     return this.up.findNextNode(this);
   }
 
+  rebound() {
+    if (this.fragment) this.fragment.rebound();
+  }
+
   shuffled() {
     if (this.fragment) this.fragment.shuffled();
   }

--- a/src/view/items/shared/Item.js
+++ b/src/view/items/shared/Item.js
@@ -36,8 +36,8 @@ export default class Item {
     return this.up.findNextNode(this);
   }
 
-  rebound() {
-    if (this.fragment) this.fragment.rebound();
+  rebound(update) {
+    if (this.fragment) this.fragment.rebound(update);
   }
 
   shuffled() {

--- a/src/view/items/shared/Mustache.js
+++ b/src/view/items/shared/Mustache.js
@@ -40,6 +40,8 @@ export default class Mustache extends Item {
   }
 
   rebind(next, previous, safe) {
+    if (this.isStatic) return;
+
     next = rebindMatch(this.template, next, previous, this.up);
     if (next === this.model) return false;
 
@@ -50,6 +52,17 @@ export default class Mustache extends Item {
     this.model = next;
     if (!safe) this.handleChange();
     return true;
+  }
+
+  rebound() {
+    if (this.model) {
+      if (this.model.rebound) this.model.rebound();
+      else {
+        this.model.unregister(this);
+        this.bind();
+      }
+    }
+    if (this.fragment) this.fragment.rebound();
   }
 
   unbind() {

--- a/src/view/items/shared/Mustache.js
+++ b/src/view/items/shared/Mustache.js
@@ -54,15 +54,17 @@ export default class Mustache extends Item {
     return true;
   }
 
-  rebound() {
+  rebound(update) {
     if (this.model) {
-      if (this.model.rebound) this.model.rebound();
+      if (this.model.rebound) this.model.rebound(update);
       else {
         this.model.unregister(this);
         this.bind();
       }
+
+      if (update) this.bubble();
     }
-    if (this.fragment) this.fragment.rebound();
+    if (this.fragment) this.fragment.rebound(update);
   }
 
   unbind() {

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -16,6 +16,7 @@ export default class ExpressionProxy extends Model {
     this.template = template;
 
     this.isReadonly = true;
+    this.isComputed = true;
     this.dirty = true;
 
     this.fn =
@@ -100,8 +101,9 @@ export default class ExpressionProxy extends Model {
     this.bubble(!safe);
   }
 
-  rebound() {
+  rebound(update) {
     this.models = this.template.r.map(ref => resolveReference(this.fragment, ref));
+    if (update) this.bubble(true);
   }
 
   retrieve() {

--- a/src/view/resolvers/ExpressionProxy.js
+++ b/src/view/resolvers/ExpressionProxy.js
@@ -100,6 +100,10 @@ export default class ExpressionProxy extends Model {
     this.bubble(!safe);
   }
 
+  rebound() {
+    this.models = this.template.r.map(ref => resolveReference(this.fragment, ref));
+  }
+
   retrieve() {
     return this.get();
   }

--- a/src/view/resolvers/ReferenceExpressionProxy.js
+++ b/src/view/resolvers/ReferenceExpressionProxy.js
@@ -15,9 +15,26 @@ export default class ReferenceExpressionProxy extends LinkModel {
     this.root = fragment.ractive.viewmodel;
     this.template = template;
     this.rootLink = true;
+    this.template = template;
+    this.fragment = fragment;
+
+    this.rebound();
+  }
+
+  getKeypath() {
+    return this.model ? this.model.getKeypath() : '@undefined';
+  }
+
+  rebound() {
+    const fragment = this.fragment;
+    const template = this.template;
 
     let base = (this.base = resolve(fragment, template));
     let idx;
+
+    if (this.proxy) {
+      teardown(this);
+    }
 
     const proxy = (this.proxy = {
       rebind: (next, previous) => {
@@ -83,18 +100,18 @@ export default class ReferenceExpressionProxy extends LinkModel {
     pathChanged();
   }
 
-  getKeypath() {
-    return this.model ? this.model.getKeypath() : '@undefined';
-  }
-
   teardown() {
-    if (this.base) this.base.unregister(this.proxy);
-    if (this.models) {
-      this.models.forEach(m => {
-        if (m.unregister) m.unregister(this);
-      });
-    }
+    teardown(this);
     super.teardown();
+  }
+}
+
+function teardown(proxy) {
+  if (proxy.base) proxy.base.unregister(proxy.proxy);
+  if (proxy.models) {
+    proxy.models.forEach(m => {
+      if (m.unregister) m.unregister(proxy);
+    });
   }
 }
 

--- a/src/view/resolvers/resolveReference.js
+++ b/src/view/resolvers/resolveReference.js
@@ -101,7 +101,10 @@ export default function resolveReference(fragment, ref) {
       const root = ref[1] === 'r' ? fragment.ractive.root : null;
       let f = fragment;
 
-      while (f && (!f.context || (f.isRoot && f.ractive.component))) {
+      while (
+        f &&
+        (!f.context || (f.isRoot && f.ractive.component && (root || !f.ractive.isolated)))
+      ) {
         f = f.isRoot ? f.componentParent : f.parent;
       }
 

--- a/tests/browser/autoshuffle.js
+++ b/tests/browser/autoshuffle.js
@@ -1,0 +1,517 @@
+import { initModule } from '../helpers/test-config';
+import { test } from 'qunit';
+import { fire } from 'simulant';
+
+export default function() {
+  initModule('autoshuffle');
+
+  test(`iterative sections can be told to always automatically shuffle themselves`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, true shuffle}}<div>{{.}}</div>{{/each}}`,
+      data: {
+        items: [1, 2, 3, 4, 5]
+      }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    r.set('items', [3, 4, 6, 1, 2]);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0', 42);
+    t.equal(r.find('div').innerText, '42');
+  });
+
+  test(`triple and auto shuffle`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, true shuffle}}<div>{{{.}}}</div>{{/each}}`,
+      data: {
+        items: [1, 2, 3, 4, 5]
+      }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    r.set('items', [3, 4, 6, 1, 2]);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0', 42);
+    t.equal(r.find('div').innerText, '42');
+  });
+
+  test(`iterative sections that have a member update when auto shuffling`, t => {
+    let items = [
+      { v: '1', i: 1 },
+      { v: '2', i: 2 },
+      { v: '3', i: 3 },
+      { v: '4', i: 4 },
+      { v: '5', i: 5 }
+    ];
+
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, 'v' shuffle}}<div>{{.i}}</div>{{/each}}`,
+      data: { items }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    items[2].i = '42';
+    items = [items[2], items[3], { v: '6', i: 6 }, items[0], items[1]];
+    r.set('items', items);
+
+    t.equal(r.find('div').innerText, '42');
+    r.set('items.0.i', '3');
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+  });
+
+  test(`attribute bindings work with auto shuffle`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, true shuffle}}<div data-i="{{@index + 1}}" data-v="{{.}}">{{.}}</div>{{/each}}`,
+      data: {
+        items: [1, 2, 3, 4, 5]
+      }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    r.set('items', [3, 4, 6, 1, 2]);
+
+    r.findAll('div').forEach((e, i) => {
+      if (e.innerText !== '6') {
+        t.equal(i + 1, e.getAttribute('data-i'), `${e.innerText} data-i`);
+        t.equal(e.innerText, e.getAttribute('data-v'), `${e.innerText} data-v`);
+        t.equal(e.innerText, e.getAttribute('i'), `${e.innerText} i`);
+      } else {
+        t.equal(e.getAttribute('data-i'), 3);
+        t.equal(6, e.getAttribute('data-v'));
+        t.equal(e.getAttribute('i'), null);
+      }
+    });
+  });
+
+  test(`conditional attributes work with auto shuffle`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, true shuffle}}<div {{#if .}}data-foo="{{\`\${.} \${@index + 1}\`}}"{{/if}}>{{.}}</div>{{/each}}`,
+      data: {
+        items: [1, 2, 3, 4, 5]
+      }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    r.set('items', [3, 4, 6, 1, 2]);
+
+    r.findAll('div').forEach((e, i) => {
+      if (e.innerText !== '6') {
+        t.equal(e.getAttribute('data-foo'), `${e.innerText} ${i + 1}`);
+        t.equal(e.innerText, e.getAttribute('i'));
+      } else {
+        t.equal(e.getAttribute('data-foo'), '6 3');
+        t.equal(e.getAttribute('i'), null);
+      }
+    });
+  });
+
+  test(`binding with auto shuffle`, t => {
+    let items = [
+      { v: '1', i: 1 },
+      { v: '2', i: 2 },
+      { v: '3', i: 3 },
+      { v: '4', i: 4 },
+      { v: '5', i: 5 }
+    ];
+
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, 'i' shuffle}}<input value="{{.v}}" />{{/each}}`,
+      data: { items }
+    });
+
+    r.findAll('input').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    items = [items[2], items[3], { v: '6', i: 6 }, items[0], items[1]];
+    r.set('items', items);
+
+    r.findAll('input').forEach(e => {
+      const ctx = r.getContext(e);
+      if (ctx.get('i') !== 6) {
+        t.equal(e.getAttribute('i'), ctx.get('v'));
+      } else {
+        t.equal(ctx.get('@index'), 2);
+      }
+    });
+
+    const input = r.find('input');
+    r.set('items.0.v', 42);
+    t.equal(input.value, '42');
+    t.equal(input.getAttribute('i'), '3');
+    input.value = '99';
+    fire(input, 'change');
+    t.equal(r.get('items.0.v'), '99');
+  });
+
+  test(`components and mappings and auto shuffle`, t => {
+    const cmp = Ractive.extend({
+      template: '<div>{{.foo}}</div>'
+    });
+
+    let items = [{ foo: 1 }, { foo: 2 }, { foo: 3 }, { foo: 4 }, { foo: 5 }];
+
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, 'foo' as shuffle}}<cmp bind-foo />{{/each}}`,
+      components: { cmp },
+      data: { items }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    items = [items[2], items[3], { foo: '6' }, items[0], items[1]];
+    r.set('items', items);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0.foo', 42);
+    t.equal(r.find('div').innerText, '42');
+  });
+
+  test(`partial with aliases and auto shuffle`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, true shuffle}}{{>foo . as foo}}{{/each}}`,
+      partials: { foo: '<div>{{foo}}</div>' },
+      data: {
+        items: [1, 2, 3, 4, 5]
+      }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+    r.set('items', [3, 4, 6, 1, 2]);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+  });
+
+  test(`partial with context and auto shuffle`, t => {
+    let items = [
+      { foo: { foo: 1 } },
+      { foo: { foo: 2 } },
+      { foo: { foo: 3 } },
+      { foo: { foo: 4 } },
+      { foo: { foo: 5 } }
+    ];
+
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, 'foo.foo' shuffle}}{{>foo .foo}}{{/each}}`,
+      partials: { foo: '<div>{{.foo}}</div>' },
+      data: { items }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    items = [items[2], items[3], { foo: { foo: 6 } }, items[0], items[1]];
+    r.set('items', items);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0.foo.foo', 42);
+    t.equal(r.find('div').innerText, '42');
+  });
+
+  test(`macro and auto shuffle`, t => {
+    let items = [{ foo: 1 }, { foo: 2 }, { foo: 3 }, { foo: 4 }, { foo: 5 }];
+
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, 'foo' shuffle}}<foo bind-foo />{{/each}}`,
+      partials: {
+        foo: Ractive.macro(
+          h => {
+            h.aliasLocal('_foo');
+            h.set('_foo.v', h.attributes.foo);
+            h.setTemplate('<div>{{_foo.v}}</div>');
+
+            return {
+              update(attrs) {
+                h.set('_foo.v', attrs.foo);
+              }
+            };
+          },
+          {
+            attributes: ['foo']
+          }
+        )
+      },
+      data: { items }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    items = [items[2], items[3], { foo: 6 }, items[0], items[1]];
+    r.set('items', items);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0.foo', 42);
+    t.equal(r.find('div').innerText, '42');
+  });
+
+  test(`conditional section and auto shuffle`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, true shuffle}}{{#if true}}<div>{{.}}</div>{{/if}}{{/each}}`,
+      data: {
+        items: [1, 2, 3, 4, 5]
+      }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    r.set('items', [3, 4, 6, 1, 2]);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0', 42);
+    t.equal(r.find('div').innerText, '42');
+  });
+
+  test(`with section and auto shuffle`, t => {
+    let items = [
+      { foo: { foo: 1 } },
+      { foo: { foo: 2 } },
+      { foo: { foo: 3 } },
+      { foo: { foo: 4 } },
+      { foo: { foo: 5 } }
+    ];
+
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, 'foo.foo' shuffle}}{{#with foo}}<div>{{.foo}}</div>{{/with}}{{/each}}`,
+      data: { items }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    items = [items[2], items[3], { foo: { foo: 6 } }, items[0], items[1]];
+    r.set('items', items);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0.foo.foo', 42);
+    t.equal(r.find('div').innerText, '42');
+  });
+
+  test(`alias section and auto shuffle`, t => {
+    let items = [
+      { foo: { foo: 1 } },
+      { foo: { foo: 2 } },
+      { foo: { foo: 3 } },
+      { foo: { foo: 4 } },
+      { foo: { foo: 5 } }
+    ];
+
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, 'foo.foo' shuffle}}{{#with .foo.foo as bar}}<div>{{bar}}</div>{{/with}}{{/each}}`,
+      data: { items }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    items = [items[2], items[3], { foo: { foo: 6 } }, items[0], items[1]];
+    r.set('items', items);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0.foo.foo', 42);
+    t.equal(r.find('div').innerText, '42');
+  });
+
+  test(`alias section and auto shuffle`, t => {
+    let items = [
+      { foo: { foo: [1] } },
+      { foo: { foo: [2] } },
+      { foo: { foo: [3] } },
+      { foo: { foo: [4] } },
+      { foo: { foo: [5] } }
+    ];
+
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, 'foo.foo.0' shuffle}}{{#each .foo.foo}}<div>{{.}}</div>{{/each}}{{/each}}`,
+      data: { items }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    items = [items[2], items[3], { foo: { foo: [6] } }, items[0], items[1]];
+    r.set('items', items);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0.foo.foo', [42]);
+    t.equal(r.find('div').innerText, '42');
+  });
+
+  test(`expression and auto shuffle`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, true shuffle}}<div>{{. + 1}}</div>{{/each}}`,
+      data: {
+        items: [1, 2, 3, 4, 5]
+      }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 2));
+
+    r.set('items', [3, 4, 6, 1, 2]);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '7') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0', 42);
+    t.equal(r.find('div').innerText, '43');
+  });
+
+  test(`expression alias and auto shuffle`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, true shuffle}}{{#with . + 1 as foo}}<div>{{foo}}</div>{{/with}}{{/each}}`,
+      data: {
+        items: [1, 2, 3, 4, 5]
+      }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 2));
+
+    r.set('items', [3, 4, 6, 1, 2]);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '7') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0', 42);
+    t.equal(r.find('div').innerText, '43');
+  });
+
+  test(`reference expression and auto shuffle`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, true shuffle}}<div>{{~/items[@index]}}</div>{{/each}}`,
+      data: {
+        items: [1, 2, 3, 4, 5]
+      }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    r.set('items', [3, 4, 6, 1, 2]);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0', 42);
+    t.equal(r.find('div').innerText, '42');
+  });
+
+  test(`reference expression alias and auto shuffle`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, true shuffle}}{{#with ~/items[@index] as foo}}<div>{{foo}}</div>{{/with}}{{/each}}`,
+      data: {
+        items: [1, 2, 3, 4, 5]
+      }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    r.set('items', [3, 4, 6, 1, 2]);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0', 42);
+    t.equal(r.find('div').innerText, '42');
+  });
+
+  test(`decorator and auto shuffle`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items, true shuffle}}<div as-test="." />{{/each}}`,
+      decorators: {
+        test(node, v) {
+          node.innerText = v;
+          return {
+            teardown() {},
+            update(v) {
+              node.innerText = v;
+            }
+          };
+        }
+      },
+      data: {
+        items: [1, 2, 3, 4, 5]
+      }
+    });
+
+    r.findAll('div').forEach((e, i) => e.setAttribute('i', i + 1));
+
+    r.set('items', [3, 4, 6, 1, 2]);
+
+    r.findAll('div').forEach(e => {
+      if (e.innerText !== '6') t.equal(e.innerText, e.getAttribute('i'));
+      else t.equal(e.getAttribute('i'), null);
+    });
+
+    r.set('items.0', 42);
+    t.equal(r.find('div').innerText, '42');
+  });
+}

--- a/tests/browser/autoshuffle.js
+++ b/tests/browser/autoshuffle.js
@@ -365,7 +365,7 @@ export default function() {
     t.equal(r.find('div').innerText, '42');
   });
 
-  test(`alias section and auto shuffle`, t => {
+  test(`iterative section and auto shuffle`, t => {
     let items = [
       { foo: { foo: [1] } },
       { foo: { foo: [2] } },

--- a/tests/browser/eachSource.js
+++ b/tests/browser/eachSource.js
@@ -1,0 +1,536 @@
+import { initModule } from '../helpers/test-config';
+import { test } from 'qunit';
+import { fire } from 'simulant';
+
+export default function() {
+  initModule('eachSource');
+
+  test(`each can be told to map each iteration back to a source array for computed values`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template:
+        '{{#each items.slice(start, end) as item, items as source}}{{item}}-{{@keypath}}-{{@index}}|{{/each}}',
+      data: {
+        items: [1, 2, 3, 4],
+        start: 0,
+        end: 2
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '1-items.0-0|2-items.1-1|');
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(fixture.innerHTML, '3-items.2-0|4-items.3-1|');
+  });
+
+  test(`each on a non-computed value ignores the source`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: '{{#each items as item, items as source}}{{.}}-{{@keypath}}-{{@index}}|{{/each}}',
+      data: {
+        items: [1, 2, 3, 4]
+      }
+    });
+
+    t.equal(r.fragment.items[0].fragment.context.getKeypath(), 'items');
+    t.ok(!r.fragment.items[0].fragment.source);
+  });
+
+  test(`each with source and nested conditional`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template:
+        '{{#each items.slice(start, end) as item, items as source}}{{#if item == ~/offset + @index}}{{item}}-{{@keypath}}-{{@index}}|{{/if}}{{/each}}',
+      data: {
+        items: [1, 2, 3, 4],
+        start: 0,
+        end: 2,
+        offset: 1
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '1-items.0-0|2-items.1-1|');
+
+    r.set({ start: 2, end: 4, offset: 3 });
+
+    t.htmlEqual(fixture.innerHTML, '3-items.2-0|4-items.3-1|');
+  });
+
+  test(`each with source and nested bindings`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: `{{#each items.slice(start, end), items source}}<input value="{{.v}}" />{{/each}}`,
+      data: {
+        items: [{ v: 1 }, { v: 2 }, { v: 3 }, { v: 4 }],
+        start: 0,
+        end: 2
+      }
+    });
+
+    let inputs = r.findAll('input');
+
+    t.equal(inputs[0].value, '1');
+    t.equal(inputs[1].value, '2');
+
+    inputs[0].value = 42;
+    inputs[1].value = 43;
+
+    fire(inputs[0], 'input');
+    fire(inputs[1], 'input');
+
+    t.equal(r.get('items.0.v'), '42');
+    t.equal(r.get('items.1.v'), '43');
+
+    r.set({ start: 2, end: 4 });
+
+    inputs = r.findAll('input');
+
+    t.equal(inputs[0].value, '3');
+    t.equal(inputs[1].value, '4');
+
+    inputs[0].value = 98;
+    inputs[1].value = 99;
+
+    fire(inputs[0], 'input');
+    fire(inputs[1], 'input');
+
+    t.equal(r.get('items.2.v'), '98');
+    t.equal(r.get('items.3.v'), '99');
+
+    r.set({ start: 0, end: 2 });
+
+    inputs = r.findAll('input');
+
+    t.equal(inputs[0].value, '42');
+    t.equal(inputs[1].value, '43');
+  });
+
+  test(`each with source that is shuffled`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template:
+        '{{#each items.slice(start, end), items source}}{{#each .v as item}}{{item}}-{{@keypath}}-{{@index}}|{{/each}}{{/each}}',
+      data: {
+        items: [{ v: [1, 2] }, { v: [3, 4] }],
+        start: 0,
+        end: 1
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '1-items.0.v.0-0|2-items.0.v.1-1|');
+
+    r.set({ start: 1, end: 2 });
+
+    t.htmlEqual(fixture.innerHTML, '3-items.1.v.0-0|4-items.1.v.1-1|');
+
+    r.unshift('items', { v: [] });
+
+    t.htmlEqual(fixture.innerHTML, '1-items.1.v.0-0|2-items.1.v.1-1|');
+
+    r.unshift('items.1.v', 99);
+
+    t.htmlEqual(fixture.innerHTML, '99-items.1.v.0-0|1-items.1.v.1-1|2-items.1.v.2-2|');
+  });
+
+  test(`source mapped each and attributes`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template:
+        '{{#each items.slice(start, end), items source}}<div class="{{.}}">{{@keypath}}-{{@index}}</div>{{/each}}',
+      data: {
+        items: ['a', 'b', 'c', 'd'],
+        start: 0,
+        end: 2
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '<div class="a">items.0-0</div><div class="b">items.1-1</div>');
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(fixture.innerHTML, '<div class="b">items.1-0</div><div class="c">items.2-1</div>');
+
+    r.set('items.2', 'yep');
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div class="b">items.1-0</div><div class="yep">items.2-1</div>'
+    );
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div class="yep">items.2-0</div><div class="d">items.3-1</div>'
+    );
+  });
+
+  test(`source mapped each and conditional attributes`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template:
+        '{{#each items.slice(start, end), items source}}<div {{`class="${.}"`}}>{{@keypath}}-{{@index}}</div>{{/each}}',
+      data: {
+        items: ['a', 'b', 'c', 'd'],
+        start: 0,
+        end: 2
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '<div class="a">items.0-0</div><div class="b">items.1-1</div>');
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(fixture.innerHTML, '<div class="b">items.1-0</div><div class="c">items.2-1</div>');
+
+    r.set('items.2', 'yep');
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div class="b">items.1-0</div><div class="yep">items.2-1</div>'
+    );
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div class="yep">items.2-0</div><div class="d">items.3-1</div>'
+    );
+  });
+
+  test(`source mapped each and component mapping`, t => {
+    const cmp = Ractive.extend({
+      template: '<div>{{foo}}-{{@keypath}}-{{@rootpath}}-{{yield}}</div>'
+    });
+
+    const r = new Ractive({
+      target: fixture,
+      template:
+        '{{#each items.slice(start, end), items source}}<cmp bind-foo=.>{{@keypath}}-{{@index}}</cmp>{{/each}}',
+      components: { cmp },
+      data: {
+        items: ['a', 'b', 'c', 'd'],
+        start: 0,
+        end: 2
+      }
+    });
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div>a--items.0-items.0-0</div><div>b--items.1-items.1-1</div>'
+    );
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div>b--items.1-items.1-0</div><div>c--items.2-items.2-1</div>'
+    );
+
+    r.set('items.2', 'yep');
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div>b--items.1-items.1-0</div><div>yep--items.2-items.2-1</div>'
+    );
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div>yep--items.2-items.2-0</div><div>d--items.3-items.3-1</div>'
+    );
+  });
+
+  test(`source mapped each and partial`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: '{{#each items.slice(start, end), items source}}{{>foo}}{{/each}}',
+      data: {
+        items: ['a', 'b', 'c', 'd'],
+        start: 0,
+        end: 2
+      },
+      partials: {
+        foo: '<div>{{.}}-{{@keypath}}-{{@index}}</div>'
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '<div>a-items.0-0</div><div>b-items.1-1</div>');
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div><div>c-items.2-1</div>');
+
+    r.set('items.2', 'yep');
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div><div>yep-items.2-1</div>');
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>yep-items.2-0</div><div>d-items.3-1</div>');
+  });
+
+  test(`source mapped each and partial with context`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: '{{#each items.slice(start, end), items source}}{{>foo .v}}{{/each}}',
+      data: {
+        items: [{ v: 'a' }, { v: 'b' }, { v: 'c' }, { v: 'd' }],
+        start: 0,
+        end: 2
+      },
+      partials: {
+        foo: '<div>{{.}}-{{@keypath}}-{{@index}}</div>'
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '<div>a-items.0.v-0</div><div>b-items.1.v-1</div>');
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1.v-0</div><div>c-items.2.v-1</div>');
+
+    r.set('items.2.v', 'yep');
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1.v-0</div><div>yep-items.2.v-1</div>');
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>yep-items.2.v-0</div><div>d-items.3.v-1</div>');
+  });
+
+  test(`source mapped each and partial with alias`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: '{{#each items.slice(start, end), items source}}{{>foo . as foo}}{{/each}}',
+      data: {
+        items: ['a', 'b', 'c', 'd'],
+        start: 0,
+        end: 2
+      },
+      partials: {
+        foo: '<div>{{foo}}-{{@keypath}}-{{@index}}</div>'
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '<div>a-items.0-0</div><div>b-items.1-1</div>');
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div><div>c-items.2-1</div>');
+
+    r.set('items.2', 'yep');
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div><div>yep-items.2-1</div>');
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>yep-items.2-0</div><div>d-items.3-1</div>');
+  });
+
+  test(`source mapped each and macro`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template:
+        '{{#each items.slice(start, end), items source}}<foo bind-a>{{.v}}-{{@keypath}}-{{@index}}</foo>{{/each}}',
+      data: {
+        items: [{ a: 'a', v: 1 }, { a: 'b', v: 2 }, { a: 'c', v: 3 }, { a: 'd', v: 4 }],
+        start: 0,
+        end: 2
+      },
+      partials: {
+        foo: Ractive.macro(
+          h => {
+            h.aliasLocal('_foo');
+            h.setTemplate('<div class="{{_foo.attr}}">{{>content}}</div>');
+            h.set('@local.attr', h.attributes.a);
+            return {
+              update(attrs) {
+                h.set('@local.attr', attrs.a);
+              }
+            };
+          },
+          {
+            attributes: ['a']
+          }
+        )
+      }
+    });
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div class="a">1-items.0-0</div><div class="b">2-items.1-1</div>'
+    );
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div class="b">2-items.1-0</div><div class="c">3-items.2-1</div>'
+    );
+
+    r.set('items.2.a', 'yep');
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div class="b">2-items.1-0</div><div class="yep">3-items.2-1</div>'
+    );
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(
+      fixture.innerHTML,
+      '<div class="yep">3-items.2-0</div><div class="d">4-items.3-1</div>'
+    );
+  });
+
+  test(`source mapped each and with`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template:
+        '{{#each items.slice(start, end), items source}}{{#with .v}}<div>{{.}}-{{@keypath}}-{{@index}}</div>{{/with}}{{/each}}',
+      data: {
+        items: [{ v: 'a' }, { v: 'b' }, { v: 'c' }, { v: 'd' }],
+        start: 0,
+        end: 2
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '<div>a-items.0.v-0</div><div>b-items.1.v-1</div>');
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1.v-0</div><div>c-items.2.v-1</div>');
+
+    r.set('items.2.v', 'yep');
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1.v-0</div><div>yep-items.2.v-1</div>');
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>yep-items.2.v-0</div><div>d-items.3.v-1</div>');
+  });
+
+  test(`source mapped each and alias block`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template:
+        '{{#each items.slice(start, end), items source}}{{#with . as foo}}<div>{{foo}}-{{@keypath}}-{{@index}}</div>{{/with}}{{/each}}',
+      data: {
+        items: ['a', 'b', 'c', 'd'],
+        start: 0,
+        end: 2
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '<div>a-items.0-0</div><div>b-items.1-1</div>');
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div><div>c-items.2-1</div>');
+
+    r.set('items.2', 'yep');
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div><div>yep-items.2-1</div>');
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>yep-items.2-0</div><div>d-items.3-1</div>');
+  });
+
+  test(`source mapped each and alias block`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template:
+        '{{#each items.slice(start, end), items source}}{{#if .length && typeof . === "string"}}<div>{{.}}-{{@keypath}}-{{@index}}</div>{{/if}}{{/each}}',
+      data: {
+        items: ['a', 'b', 'c', 'd'],
+        start: 0,
+        end: 2
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '<div>a-items.0-0</div><div>b-items.1-1</div>');
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div><div>c-items.2-1</div>');
+
+    r.set('items.2', false);
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div>');
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>d-items.3-1</div>');
+  });
+
+  test(`source mapped each and partial with context`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template:
+        '{{#each items.slice(start, end), items source}}<div>{{.[~/key]}}-{{@keypath}}-{{@index}}</div>{{/each}}',
+      data: {
+        items: [{ v: 'a' }, { v: 'b' }, { v: 'c' }, { v: 'd' }],
+        key: 'v',
+        start: 0,
+        end: 2
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '<div>a-items.0-0</div><div>b-items.1-1</div>');
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div><div>c-items.2-1</div>');
+
+    r.set('items.2.v', 'yep');
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div><div>yep-items.2-1</div>');
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>yep-items.2-0</div><div>d-items.3-1</div>');
+  });
+
+  test(`source mapped each and decorator`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: '{{#each items.slice(start, end), items source}}<div as-foo=. />{{/each}}',
+      data: {
+        items: ['a', 'b', 'c', 'd'],
+        start: 0,
+        end: 2
+      },
+      decorators: {
+        foo(node, val) {
+          const ctx = this.getContext(node);
+          node.innerHTML = `${val}-${ctx.get('@keypath')}-${ctx.get('@index')}`;
+          return {
+            teardown() {},
+            update(val) {
+              node.innerHTML = `${val}-${ctx.get('@keypath')}-${ctx.get('@index')}`;
+            }
+          };
+        }
+      }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '<div>a-items.0-0</div><div>b-items.1-1</div>');
+
+    r.set({ start: 1, end: 3 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div><div>c-items.2-1</div>');
+
+    r.set('items.2', 'yep');
+
+    t.htmlEqual(fixture.innerHTML, '<div>b-items.1-0</div><div>yep-items.2-1</div>');
+
+    r.set({ start: 2, end: 4 });
+
+    t.htmlEqual(fixture.innerHTML, '<div>yep-items.2-0</div><div>d-items.3-1</div>');
+  });
+  // reference expression, decorator
+}


### PR DESCRIPTION
## Description:
This adds experimental support for automatic shuffling at the iterative block level, which means that you can tell an `{{#each}}` block that (or how) to shuffle and it will do so even on regular set updates. This opens up the ability to have shuffling in an iterative section that is dealing with a computed value.

```hbs
{{#each items, true as shuffle}}...{{/each}}
{{#each items as item, true as shuffle}}...{{/each}}
{{#each items, 'some.key.path' as shuffle}}...{{/each}}
{{#each items as item, 'some.key.path' as shuffle}}...{{/each}}
<!-- and of course, you can also leave off the 'as' if that's your thing -->
{{#each items item, 'some.key.path' shuffle}}...{{/each}}
```

The alias syntax is used for consistency and parse-abilty, even though it's not necessarily the _most_ ideal way to convey this particular directive. I'm also planning to add the ability to set the iteration context based on a lookup in a source array via

```hbs
{{#each compute(some(items)), items source}}
  the actual context here will be items[indexOf the current iteration in the source]
{{/each}}
```

That will allow, among other things, filtering lists with bindings without having to do the whole `syncComputedChildren` thing.

Regarding the keypath version of the shuffle setting, I chose to use a string rather than a reference to allow future shuffling based on a function.

If I feel particularly frisky, I may also try to get a shuffle transition in here too, but I may punt on that for now, as this is the last set of things that I want to get in before I cut 0.10.

## Fixes the following issues:
#3097 #2947

## Is breaking:
Nope