### PR TITLE
Fix project homepage in banner comment and bower.json

### DIFF
--- a/gobblefile.js
+++ b/gobblefile.js
@@ -18,7 +18,7 @@ const banner = `/*
 	Ractive.js v${version}
 	Build: ${commitHash}
 	Date: ${time}
-	Website: http://ractivejs.org
+	Website: https://ractive.js.org
 	License: MIT
 */`;
 

--- a/manifests/bower.json
+++ b/manifests/bower.json
@@ -2,7 +2,7 @@
   "name": "ractive",
   "description": "Next-generation DOM manipulation",
   "version": "BUILD_PLACEHOLDER_VERSION",
-  "homepage": "http://ractivejs.org",
+  "homepage": "https://ractive.js.org",
   "license": "MIT",
   "main": "ractive.js",
   "keywords": [


### PR DESCRIPTION
## Description:

The currently used URL `http://ractivejs.org` points to a domain parking page. This uses the `.js.org` version.

## Fixes the following issues:

n/a
