### PR TITLE
Fix @import css transformation (fixes #3254)

### DIFF
--- a/tests/browser/render/css.js
+++ b/tests/browser/render/css.js
@@ -359,6 +359,60 @@ export default function() {
     t.equal(getHexColor(ractive.find('p')), hexCodes.blue);
   });
 
+  test('@import does not corrupt scoped CSS (#3254) - 1', t => {
+    const Widget = Ractive.extend({
+      template: '<p>red</p>',
+      css: '@import(http://example.com/style.css); p { color: red; }'
+    });
+
+    const ractive = new Ractive({
+      el: fixture,
+      template: '<p>black</p><Widget/>',
+      components: { Widget }
+    });
+
+    const paragraphs = ractive.findAll('p');
+
+    t.equal(getHexColor(paragraphs[0]), hexCodes.black);
+    t.equal(getHexColor(paragraphs[1]), hexCodes.red);
+  });
+
+  test('@import does not corrupt scoped CSS (#3254) - 2', t => {
+    const Widget = Ractive.extend({
+      template: '<p>red</p>',
+      css: "@import('http://example.com/style.css'); p { color: red; }"
+    });
+
+    const ractive = new Ractive({
+      el: fixture,
+      template: '<p>black</p><Widget/>',
+      components: { Widget }
+    });
+
+    const paragraphs = ractive.findAll('p');
+
+    t.equal(getHexColor(paragraphs[0]), hexCodes.black);
+    t.equal(getHexColor(paragraphs[1]), hexCodes.red);
+  });
+
+  test('@import does not corrupt scoped CSS (#3254) - 3', t => {
+    const Widget = Ractive.extend({
+      template: '<p>red</p>',
+      css: 'p { color: blue; } @import(http://example.com/style.css); p { color: red; }'
+    });
+
+    const ractive = new Ractive({
+      el: fixture,
+      template: '<p>black</p><Widget/>',
+      components: { Widget }
+    });
+
+    const paragraphs = ractive.findAll('p');
+
+    t.equal(getHexColor(paragraphs[0]), hexCodes.black);
+    t.equal(getHexColor(paragraphs[1]), hexCodes.red);
+  });
+
   test(`components should output css scoping ids with toHTML (#2709)`, t => {
     const cmp = new (Ractive.extend({
       template: '<div />',


### PR DESCRIPTION
## Description:
`@import` statement doesn't end with `}` so a selector directly following it wouldn't be transformed. I added a special character at the end to mark the beginning of the following selector. The special character gets removed at the end of transformation. 

## Fixes the following issues:
#3254 

## Is breaking:
No.