### PR TITLE
Manage partials’ expressions in CSP mode

### DIFF
--- a/src/Ractive/config/registries.js
+++ b/src/Ractive/config/registries.js
@@ -1,4 +1,5 @@
 import { assign, create, keys } from 'utils/object';
+import { addFunctions } from 'shared/getFunction';
 
 const registryNames = [
   'adaptors',
@@ -40,6 +41,12 @@ class Registry {
     assign(registry, option);
 
     target[name] = registry;
+
+    if (name === 'partials' && target[name]) {
+      keys(target[name]).forEach(key => {
+        addFunctions(target[name][key]);
+      });
+    }
   }
 
   reset(ractive) {

--- a/src/parse/_parse.js
+++ b/src/parse/_parse.js
@@ -124,8 +124,10 @@ const StandardParser = Parser.extend({
   },
 
   postProcess(result, options) {
+    const [parserResult] = result;
+
     if (options.expression) {
-      const expr = flattenExpression(result[0]);
+      const expr = flattenExpression(parserResult);
       expr.e = fromExpression(expr.s, expr.r.length);
       return expr;
     } else {
@@ -139,7 +141,7 @@ const StandardParser = Parser.extend({
       }
 
       cleanup(
-        result[0].t,
+        parserResult.t,
         this.stripComments,
         this.preserveWhitespace,
         !this.preserveWhitespace,
@@ -149,11 +151,14 @@ const StandardParser = Parser.extend({
 
       if (this.csp !== false) {
         const expr = {};
-        insertExpressions(result[0].t, expr);
-        if (keys(expr).length) result[0].e = expr;
+
+        insertExpressions(parserResult.t, expr);
+        insertExpressions(parserResult.p || {}, expr);
+
+        if (keys(expr).length) parserResult.e = expr;
       }
 
-      return result[0];
+      return parserResult;
     }
   },
 

--- a/tests/browser/partials.js
+++ b/tests/browser/partials.js
@@ -1239,4 +1239,45 @@ export default function() {
     t.equal(run, 2);
     t.htmlEqual(fixture.innerHTML, '1');
   });
+
+  // #3285
+  test(`extending a component with pre-parsed partials should keep any expressions that was converted to function due to CSP #3285`, t => {
+    const a = Ractive.parse(`{{1 + 2}}`, { csp: true });
+
+    // after Ractive.extend, 1+2 should still return 5, rather than being re-evaluated to 3
+    a.e['1+2'] = function() {
+      return ['5'];
+    };
+
+    const MyComponent = {
+      partials: { a }
+    };
+
+    const MyWrapper = Ractive.extend(MyComponent, {
+      target: fixture,
+      template: '{{>a}}'
+    });
+
+    new MyWrapper();
+
+    t.htmlEqual(fixture.innerHTML, '5');
+  });
+
+  // #3285
+  test(`pre-parsed partial expressions are converted and executed as a function in CSP #3285`, t => {
+    const a = Ractive.parse(`{{1 + 2}}`, { csp: true });
+
+    // after Ractive.extend, 1+2 should still return 5, rather than being re-evaluated to 3
+    a.e['1+2'] = function() {
+      return ['5'];
+    };
+
+    new Ractive({
+      target: fixture,
+      template: '{{>a}}',
+      partials: { a }
+    });
+
+    t.htmlEqual(fixture.innerHTML, '5');
+  });
 }

--- a/tests/helpers/samples/parse.js
+++ b/tests/helpers/samples/parse.js
@@ -911,6 +911,25 @@ const parseTests = [
 			}
 		}
 	},
+	// #3285
+	{
+		name: 'template with partial – csp: true #3285',
+		template: '{{#partial a}}{{x + 1}}<a {{#if x + 2}}data-id={{x + 3}}{{/if}} slide-in="x+4" on-click="proxy" on-focus="method(x + 5)">{{foo.bar[x + 6].baz}}</a>{{/partial}}',
+		options: { csp: true },
+		parsed: {
+			v:4,t:[],p:{a:[{t:2,x:{r:['x'],s:'_0+1'}},{t:7,e:'a',m:[{t:4,f:[{n:'data-id',f:[{t:2,x:{r:['x'],s:'_0+3'}}],t:13}],n:50,x:{r:['x'],s:'_0+2'}},{v:'t1',n:'slide',f:{s:'[_0+4]',r:['x']},t:72},{n:['click'],f:'proxy',t:70},{n:['focus'],f:{r:['method','x'],s:'[_0(_1+5)]'},t:70}],f:[{t:2,rx:{r:'foo.bar',m:[{r:['x'],s:'_0+6'},'baz']}}]}]},
+			// these are intentially made strings for testing purposes
+			// actual template has javascript function objects
+			e:{
+				'_0+1':'function (_0){return(_0+1);}',
+				'_0+3':'function (_0){return(_0+3);}',
+				'_0+2':'function (_0){return(_0+2);}',
+				'[_0+4]':'function (_0){return([_0+4]);}',
+				'[_0(_1+5)]':'function (_0,_1){return([_0(_1+5)]);}',
+				'_0+6':'function (_0){return(_0+6);}'
+			}
+		}
+	},
 	// #2325
 	{
 		name: 'expression with numeric refinement #2325',


### PR DESCRIPTION
## Description:
- Add partials’ expressions to parsed object.
- Add partials’ expressions functions to the `getFunctions` pool.

## Additional notes
- We tried to create a custom registry for partials based `src/Ractive/config/custom/template.js` but encountered issues and maybe it wasn’t worth it since the patch is very small.
- We only patched configure registry function. Should we add it elsewhere?

## Fixes the following issues:
Fixes #3285

## Is breaking:
No