### PR TITLE
Shallow copy value when handling data bound to named checkboxes (fix #3293)

### DIFF
--- a/src/view/items/element/binding/CheckboxNameBinding.js
+++ b/src/view/items/element/binding/CheckboxNameBinding.js
@@ -68,7 +68,7 @@ export default class CheckboxNameBinding extends Binding {
 
   handleChange() {
     this.isChecked = this.element.node.checked;
-    this.group.value = this.model.get();
+    this.group.value = this.model.get().slice();
     const value = this.element.getAttribute('value');
     if (this.isChecked && !this.arrayContains(this.group.value, value)) {
       this.group.value.push(value);

--- a/tests/browser/twoway.js
+++ b/tests/browser/twoway.js
@@ -1711,4 +1711,23 @@ export default function() {
     inputs = r.findAll('input');
     t.ok(inputs[0].checked && !inputs[1].checked);
   });
+  
+  test('Old and new values should be set correctly with named checkbox bindings (#3293)', t => {
+    const ractive = new Ractive({
+      el: fixture,
+      template: `
+        <input type="checkbox" id="red" name="{{colors}}" value="red" />
+        <input type="checkbox" id="green" name="{{colors}}" value="green" /> `,
+      data: { colors: ['green'] }
+    });
+
+    ractive.observe('colors', function(newValue, oldValue) {
+      t.deepEqual(newValue, ['green', 'red'], 'new value should be correct');
+      t.deepEqual(oldValue, ['green'], 'old value should be correct');
+    }, {
+      init: false
+    });
+    
+    fire(ractive.find('#red'), 'click');
+  });
 }


### PR DESCRIPTION
## Description:
Before : ractive get named checkboxes value by reference.
After : ractive get a shallow copy of named checkboxes value.

Test is included.

## Fixes the following issues:
#3293

## Is breaking:
No