### PR TITLE
Escape quotes in static attributes - #3311

### DIFF
--- a/src/view/items/Element.js
+++ b/src/view/items/Element.js
@@ -387,7 +387,10 @@ export default class Element extends ContainerItem {
 
     if (this.statics)
       keys(this.statics).forEach(
-        k => k !== 'class' && k !== 'style' && (attrs = ` ${k}="${this.statics[k]}"` + attrs)
+        k =>
+          k !== 'class' &&
+          k !== 'style' &&
+          (attrs = ` ${k}="${safeAttributeString(this.statics[k])}"` + attrs)
       );
 
     // Special case - selected options

--- a/tests/helpers/samples/render.js
+++ b/tests/helpers/samples/render.js
@@ -949,7 +949,12 @@ const renderTests = [
 		name: 'HTML entities in static attributes',
 		template: '<span data-foo="&#x2713;"></span>',
 		result: '<span data-foo="&#x2713;"></span>'
-	},
+  },
+  {
+    name: 'Proper escaping in static attributes (#3311)',
+    template: `<span data-foo='{ "x": 1 }' />`,
+    result: '<span data-foo="{ &quot;x&quot;: 1 }"></span>'
+  },
 	{
 		name: 'HTML entities in dynamic attributes',
 		template: '<span data-foo="{{foo}}"></span>',


### PR DESCRIPTION
This one slipped through the cracks, but there's a test and fix now.

Static attributes were added as a perf enhancement, because _every_ attribute was getting its own fragment, which causes a bunch of extra allocation for something that's just going to end up rendering the same string it already knows.