### PR TITLE
Fix observing escaped keypaths (#3319)

### DIFF
--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -82,7 +82,7 @@ export default class ModelBase {
         children.push(this.joinKey(i));
       });
     } else if (isObject(value) || isFunction(value)) {
-      children = objectKeys(value).map(key => this.joinKey(key));
+      children = objectKeys(value).map(key => this.joinKey(escapeKey(key)));
     } else if (value != null) {
       children = [];
     }

--- a/tests/browser/methods/observe.js
+++ b/tests/browser/methods/observe.js
@@ -621,6 +621,26 @@ export default function() {
     ractive.set('gup.foo.bar', { baz: 2 });
   });
 
+  test('An observed wildcard can be an escaped string (#3319)', t => {
+    t.expect(4);
+
+    const ractive = new Ractive({
+      el: fixture,
+      template: 'blah',
+      data: { gup: { 'foo.bar': { baz: 1 } } }
+    });
+
+    let expected = 1;
+
+    ractive.observe('gup.*.baz', (n, o, keypath) => {
+      t.deepEqual(n, expected);
+      t.equal(keypath, 'gup.foo\\.bar.baz');
+    });
+
+    expected = 2;
+    ractive.set('gup.foo\\.bar', { baz: 2 });
+  });
+
   test('Pattern observers fire when ractive.update() is called without parameters', t => {
     t.expect(2);
 


### PR DESCRIPTION
## Description:
Escapes the child's key (some.key -> some\\.key) in ModelBase's joinKey() and adds a test case for it.

## Fixes the following issues:
#3319

## Is breaking:
Should not be