### PR TITLE
make sure we are in a browser before registerElement check  - #3369

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -4,7 +4,7 @@ import { isString, isNumber } from 'utils/is';
 
 let createElement, matches, div, methodNames, unprefixed, prefixed, i, j, makeFunction;
 
-const customStr = 'registerElement' in doc;
+const customStr = isClient && 'registerElement' in doc;
 function wrap(is) {
   return customStr ? is : { is };
 }


### PR DESCRIPTION
## Description:
Adding isClient check before `registerElement ` check to avoid issue while require Ractive in Node env.

## Fixes the following issues:
#3369

## Is breaking:
Hopefully not
