### PR TITLE
Add another unit-test for #3380

### DIFF
--- a/src/model/Computation.js
+++ b/src/model/Computation.js
@@ -39,7 +39,7 @@ export default class Computation extends Model {
   get(shouldCapture, opts) {
     if (shouldCapture) capture(this);
 
-    if (this.dirty || this.dependencies.find(d => d.dirty)) {
+    if (this.dirty) {
       const old = this.value;
       this.value = this.getValue();
       // this may cause a view somewhere to update, so it must be in a runloop

--- a/src/model/ComputationChild.js
+++ b/src/model/ComputationChild.js
@@ -41,12 +41,13 @@ export default class ComputationChild extends Model {
     if (shouldCapture) capture(this);
 
     if (this.dirty) {
-      this.dirty = false;
       const parentValue = this.parent.get();
       this.value = parentValue ? parentValue[this.key] : undefined;
       if (this.wrapper) this.newWrapperValue = this.value;
       this.adapt();
     }
+
+    this.dirty = false;
 
     return (opts && 'unwrap' in opts ? opts.unwrap !== false : shouldCapture) && this.wrapper
       ? this.wrapperValue
@@ -54,7 +55,11 @@ export default class ComputationChild extends Model {
   }
 
   handleChange() {
-    if (this.dirty) return;
+    if (this.dirty) {
+      this.deps.forEach(handleChange);
+      return;
+    }
+
     this.dirty = true;
 
     if (this.boundValue) this.boundValue = null;

--- a/tests/browser/computations.js
+++ b/tests/browser/computations.js
@@ -1447,4 +1447,19 @@ export default function() {
     r.set('data.name', 'Joe');
     t.equal(r.get('state.isValid'), true);
   });
+
+  test(`computed properties depending on computed properties update template correctly - #3380`, t => {
+    const r = new Ractive({
+      target: fixture,
+      template: '{{#if !state.isValid}}no{{else}}yes{{/if}}',
+      computed: {
+        'state.isNameValid': `typeof data.name === 'string' && data.name.length > 0`,
+        'state.isValid': `state.isNameValid`
+      }
+    });
+
+    t.equal(r.toHtml(), 'no');
+    r.set('data.name', 'Joe');
+    t.equal(r.toHtml(), 'yes');
+  });
 }

--- a/tests/helpers/samples/render.js
+++ b/tests/helpers/samples/render.js
@@ -841,7 +841,7 @@ const renderTests = [
 	},
 	{
 		name: 'Reference expression with sub-expression',
-		template: '{{ foo[ "ba" + letter ].prop}}',
+		template: '{{foo[ "ba" + letter ].prop}}',
 		data: { foo: { bar: { prop: 'one' }, baz: { prop: 'two' } }, letter: 'r' },
 		result: 'one',
 		new_data: { foo: { bar: { prop: 'one' }, baz: { prop: 'two' } }, letter: 'z' },


### PR DESCRIPTION
Add a second unit-test for #3380, that checks whether the template is properly re-rendered, when a computed property changes that depends another computed property.

This is currently failing (see [issue #3380](https://github.com/ractivejs/ractive/issues/3380#issuecomment-850838221) for a short layman's diagnosis by me)