### PR TITLE
docs: Fix a few typos

### DIFF
--- a/qunit/qunit.js
+++ b/qunit/qunit.js
@@ -1401,7 +1401,7 @@ QUnit.assert = Assert.prototype = {
 	}
 };
 
-// Provide an alternative to assert.throws(), for enviroments that consider throws a reserved word
+// Provide an alternative to assert.throws(), for environments that consider throws a reserved word
 // Known to us are: Closure Compiler, Narwhal
 (function() {
 	/*jshint sub:true */
@@ -2963,7 +2963,7 @@ QUnit.diff = (function() {
                                 textInsert = textInsert.substring(commonlength);
                                 textDelete = textDelete.substring(commonlength);
                             }
-                            // Factor out any common suffixies.
+                            // Factor out any common suffixes.
                             commonlength = this.diffCommonSuffix(textInsert, textDelete);
                             if (commonlength !== 0) {
                                 diffs[pointer][1] = textInsert.substring(textInsert.length -

--- a/src/Ractive/construct.js
+++ b/src/Ractive/construct.js
@@ -155,7 +155,7 @@ function handleAttributes(ractive) {
     // grab all of the passed attribute names
     const props = attrs.filter(a => a.t === ATTRIBUTE).map(a => a.n);
 
-    // warn about missing requireds
+    // warn about missing requires
     attributes.required.forEach(p => {
       if (!~props.indexOf(p)) {
         warnIfDebug(`Component '${component.name}' requires attribute '${p}' to be provided`);

--- a/src/view/items/Triple.js
+++ b/src/view/items/Triple.js
@@ -104,7 +104,7 @@ export default class Triple extends Mustache {
       if (occupants.length) anchor = occupants[0];
     }
 
-    // attach any remainging nodes to the parent
+    // attach any remaining nodes to the parent
     if (nodes.length) {
       const frag = createDocumentFragment();
       nodes.forEach(n => frag.appendChild(n));

--- a/src/view/items/partial/getPartialTemplate.js
+++ b/src/view/items/partial/getPartialTemplate.js
@@ -7,7 +7,7 @@ import { isArray, isFunction } from 'utils/is';
 import { addFunctions } from 'shared/getFunction';
 
 export default function getPartialTemplate(ractive, name, up) {
-  // If the partial in instance or view heirarchy instances, great
+  // If the partial in instance or view hierarchy instances, great
   let partial = getPartialFromRegistry(ractive, name, up || {});
   if (partial) return partial;
 


### PR DESCRIPTION
There are small typos in:
- qunit/qunit.js
- src/Ractive/construct.js
- src/view/items/Triple.js
- src/view/items/partial/getPartialTemplate.js

Fixes:
- Should read `suffixes` rather than `suffixies`.
- Should read `requires` rather than `requireds`.
- Should read `remaining` rather than `remainging`.
- Should read `hierarchy` rather than `heirarchy`.
- Should read `environments` rather than `enviroments`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md