### PR TITLE
Fix #3425: Circumvent recursive typescript declarations

### DIFF
--- a/typings/ractive.d.ts
+++ b/typings/ractive.d.ts
@@ -412,7 +412,16 @@ export class ContextHelper {
 	unshift(keypath: string, value: any): ArrayPushPromise;
 }
 
-export type Component = Static<any> | Promise<Static<any>>;
+/**
+ * Interface for something that looks like a Ractive constructor.
+ * This is used in places, where the recursive typing declarations would otherwise cause TypeScript errors.
+ * (see #3425)
+ */
+interface CanComponent {
+    new(opts?: InitOpts): { root: Ractive; };
+}
+export type Component = CanComponent | Promise<CanComponent>;
+
 
 export type ComponentItem = {
 	instance: Ractive<any>;


### PR DESCRIPTION
## Description:
TypeScript doesn't like the recursiveness of the current typings. This is a quickfix that gets rid of some of the recursiveness, by trading in some type safety. Don't know whether you want to accept that or whether you have a better idea for a proper fix.

## Fixes the following issues:
#3425 (most cases)